### PR TITLE
Small grammar and typo fixes on en/guide/development-tools page

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -104,7 +104,7 @@ We can now launch our tests:
 npm test
 ```
 
-Actually, jsdom has some limitations because of it does not use any browser behind but it will cover most of our tests. If you want to use a browser to test your application, you might want to check [Nightwatch.js](http://nightwatchjs.org).
+jsdom has some limitations because it does not use a browser. However, it will cover most of our tests. If you want to use a browser to test your application, you might want to check out [Nightwatch.js](http://nightwatchjs.org).
 
 ## ESLint
 


### PR DESCRIPTION
I made a few small grammar and typo changes to the 'jsdom limitations' section just above the ESLint section. 