### PR TITLE
Make start scripts in examples Windows-friendly

### DIFF
--- a/en/api/configuration-dev.md
+++ b/en/api/configuration-dev.md
@@ -56,7 +56,8 @@ Then in your `package.json`:
   "scripts": {
     "dev": "node server.js",
     "build": "nuxt build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "cross-env NODE_ENV=production node server.js"
   }
 }
 ```
+Note: You'll need to run `npm install --save-dev cross-env` for the above example to work. If you're *not* developing on Windows you can leave cross-env out of your `start` script and set `NODE_ENV` directly.

--- a/en/examples/auth-routes.md
+++ b/en/examples/auth-routes.md
@@ -76,10 +76,11 @@ And we update our `package.json` scripts:
 "scripts": {
   "dev": "node server.js",
   "build": "nuxt build",
-  "start": "NODE_ENV=production node server.js"
+  "start": "cross-env NODE_ENV=production node server.js"
 }
 // ...
 ```
+Note: You'll need to run `npm install --save-dev cross-env` for the above example to work. If you're *not* developing on Windows you can leave cross-env out of your `start` script and set `NODE_ENV` directly.
 
 ## Using the store
 

--- a/ru/examples/auth-routes.md
+++ b/ru/examples/auth-routes.md
@@ -76,10 +76,11 @@ And we update our `package.json` scripts:
 "scripts": {
   "dev": "node server.js",
   "build": "nuxt build",
-  "start": "NODE_ENV=production node server.js"
+  "start": "cross-env NODE_ENV=production node server.js"
 }
 // ...
 ```
+Note: You'll need to run `npm install --save-dev cross-env` for the above example to work. If you're *not* developing on Windows you can leave cross-env out of your `start` script and set `NODE_ENV` directly.
 
 ## Using the store
 


### PR DESCRIPTION
I wasn't sure what protocol to follow regarding translations.. I didn't add anything to the cn translation pages since they'd already been translated. I changed one file in the ru translation but the other file(api/configuration-dev.md) seemed to be missing there? Just let me know if I need to adjust my PR.