### PR TITLE
Add documentation to have ava transpile imported files

### DIFF
--- a/cn/guide/development-tools.md
+++ b/cn/guide/development-tools.md
@@ -23,6 +23,16 @@ __package.json__
 // ...
 "scripts": {
   "test": "ava",
+   "ava": {
+     "require": [
+       "babel-register"
+     ]
+   },
+   "babel": {
+     "presets": [
+       "es2015"
+     ]
+   }  
 }
 // ...
 ```

--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -14,11 +14,21 @@ First, we need to add ava and jsdom as development dependencies:
 npm install --save-dev ava jsdom
 ```
 
-And add a test script to our `package.json`:
+And add a test script to our `package.json` and configure ava to compile files that we import into our tests.
 
 ```javascript
 "scripts": {
   "test": "ava",
+   "ava": {
+     "require": [
+       "babel-register"
+     ]
+   },
+   "babel": {
+     "presets": [
+       "es2015"
+     ]
+   }
 }
 ```
 


### PR DESCRIPTION
Adds documentation to ava end to end tests to transpile imported files with babel.  

https://github.com/avajs/ava/blob/master/docs/recipes/babelrc.md

Note: This still does not have recommendation on how to transpile .vue files that are imported outside of nuxt page tests
