### PR TITLE
Update configuration-generate.md

### DIFF
--- a/en/api/configuration-generate.md
+++ b/en/api/configuration-generate.md
@@ -82,7 +82,7 @@ Great, but what if we have **dynamic params**?
 
 `nuxt.config.js`
 ```js
-import axios from 'axios'
+const axios = require('axios')
 
 module.exports = {
   generate: {
@@ -104,7 +104,7 @@ module.exports = {
 
 `nuxt.config.js`
 ```js
-import axios from 'axios'
+const axios = require('axios')
 
 module.exports = {
   generate: {


### PR DESCRIPTION
as described here: https://github.com/nuxt/docs/issues/42 by Atinux.
"You cannot use the import method in nuxt.config.js since it's node.js and it does not support import yet."