### PR TITLE
Add the documentation about CNAME file for GitHub Pages

### DIFF
--- a/en/faq/github-pages.md
+++ b/en/faq/github-pages.md
@@ -42,3 +42,5 @@ Then generate and deploy your static application:
 npm run generate
 npm run deploy
 ```
+
+<p class="Alert Alert--nuxt-green"><b>INFO:</b> If you use a custom domain for your GitHub Pages and put `CNAME` file, it is recommended that CNAME file is put in the `static` directory. [More documentation](/guide/assets#static) about it.</p>

--- a/en/guide/assets.md
+++ b/en/guide/assets.md
@@ -85,7 +85,7 @@ If you don't want to use Webpacked Assets from the `assets` directory, you can c
 
 These files will be automatically serve by Nuxt and accessible in your project root URL.
 
-This option is helpful for files like `robots.txt` or `sitemap.xml`.
+This option is helpful for files like `robots.txt`, `sitemap.xml` or `CNAME` (for like GitHub Pages).
 
 From your code you can then reference those files with `/` URLs:
 


### PR DESCRIPTION
I saw the question about handling the CNAME file for GitHub Pages yesterday in Japanese Vue.js community. I think it is useful to add the documentation about it.
