### PR TITLE
Reflect the update of #68 to Japanese translation

### DIFF
--- a/en/faq/github-pages.md
+++ b/en/faq/github-pages.md
@@ -16,6 +16,8 @@ npm run generate
 It will create a `dist` folder with everything inside ready to be deployed on GitHub Pages hosting.
 Branch `gh-pages` for project repository OR branch `master` for user or organization site
 
+<p class="Alert Alert--nuxt-green"><b>INFO:</b> If you use a custom domain for your GitHub Pages and put `CNAME` file, it is recommended that CNAME file is put in the `static` directory. [More documentation](/guide/assets#static) about it.</p>
+
 ## Command line deployment
 
 You can also use [push-dir package](https://github.com/L33T-KR3W/push-dir):
@@ -42,5 +44,3 @@ Then generate and deploy your static application:
 npm run generate
 npm run deploy
 ```
-
-<p class="Alert Alert--nuxt-green"><b>INFO:</b> If you use a custom domain for your GitHub Pages and put `CNAME` file, it is recommended that CNAME file is put in the `static` directory. [More documentation](/guide/assets#static) about it.</p>

--- a/jp/faq/github-pages.md
+++ b/jp/faq/github-pages.md
@@ -30,6 +30,10 @@ npm run generate
 
 プロジェクトリポジトリならば `gh-pages` ブランチ、ユーザーまたは組織サイトならば `master` ブランチを指定してください。
 
+<!-- <p class="Alert Alert--nuxt-green"><b>INFO:</b> If you use a custom domain for your GitHub Pages and put `CNAME` file, it is recommended that CNAME file is put in the `static` directory. [More documentation](/guide/assets#static) about it.</p> -->
+
+<p class="Alert Alert--nuxt-green"><b>情報:</b> もし GitHub Pages で独自ドメインを使い `CNAME` ファイルを置くのであれば、`CNAME` ファイルは `static` ディレクトリに置くことが推奨されています。詳細は [こちら](/guide/assets#webpack-で扱わない静的ファイル) を参照してください。</p>
+
 <!-- ## Command line deployment -->
 
 ## コマンドラインでデプロイする

--- a/jp/faq/github-pages.md
+++ b/jp/faq/github-pages.md
@@ -32,7 +32,7 @@ npm run generate
 
 <!-- <p class="Alert Alert--nuxt-green"><b>INFO:</b> If you use a custom domain for your GitHub Pages and put `CNAME` file, it is recommended that CNAME file is put in the `static` directory. [More documentation](/guide/assets#static) about it.</p> -->
 
-<p class="Alert Alert--nuxt-green"><b>情報:</b> もし GitHub Pages で独自ドメインを使い `CNAME` ファイルを置くのであれば、`CNAME` ファイルは `static` ディレクトリに置くことが推奨されています。詳細は [こちら](/guide/assets#webpack-で扱わない静的ファイル) を参照してください。</p>
+<p class="Alert Alert--nuxt-green"><b>情報:</b> GitHub Pages で独自ドメインを使うために `CNAME` ファイルを置くのであれば、`CNAME` ファイルは `static` ディレクトリに置くとよいでしょう。詳細は [こちら](/guide/assets#webpack-で扱わない静的ファイル) を参照してください。</p>
 
 <!-- ## Command line deployment -->
 

--- a/jp/guide/assets.md
+++ b/jp/guide/assets.md
@@ -128,9 +128,9 @@ Webpack で扱う対象となる `assets` ディレクトリを使いたくな�
 
 これらのファイルは自動的に Nuxt.js により配信され、またプロジェクトのルート URL からアクセス可能になります。
 
-<!-- This option is helpful for files like `robots.txt` or `sitemap.xml`. -->
+<!-- This option is helpful for files like `robots.txt`, `sitemap.xml` or `CNAME` (for like GitHub Pages). -->
 
-このオプションは `robots.txt` や `sitemap.xml` などのファイルの扱いに役立ちます。
+このオプションは `robots.txt` や `sitemap.xml`、`CNAME`（GitHub Pages などで使う）などのファイルの扱いに役立ちます。
 
 <!-- From your code you can then reference those files with `/` URLs: -->
 


### PR DESCRIPTION
I have moved the documentation about CNAME file out of command line deployment because CNAME file has little relevance with command.

Then I have reflect the update of #68 to Japanese translation.
