### PR TITLE
Disable Eslint for the Google Analytics snippet

### DIFF
--- a/en/faq/google-analytics.md
+++ b/en/faq/google-analytics.md
@@ -8,6 +8,7 @@ description: How to use Google Analytics?
 To use [Google Analytics](https://analytics.google.com/analytics/web/) with your nuxt.js application, we recommend to create a file `plugins/ga.js`:
 
 ```js
+/* eslint-disable */
 import router from '~router'
 /*
 ** Only run on client-side and only in production mode


### PR DESCRIPTION
When using this snippet from the FAQ, I came across linting errors.

The best way for me to resolve this was to add `/* eslint-disable */` at the beginning; it makes no sense rewrite the GA part to match our linting config, and since we use .gitignore as the source for files to ignore in the `package.json` *lint* script we can't create an .eslintignore file.