### PR TITLE
Add watchers doc to Japanese translation

### DIFF
--- a/cn/api/configuration-watchers.md
+++ b/cn/api/configuration-watchers.md
@@ -19,7 +19,6 @@ description: watchers 属性可用来覆盖 Nuxt.js 默认的 watchers 配置。
 
 ## webpack
 
-
 - 类型： `Object`
 - 默认值：
 

--- a/en/api/configuration-watchers.md
+++ b/en/api/configuration-watchers.md
@@ -19,7 +19,6 @@ To learn more about chokidar options, see the [chokidar API](https://github.com/
 
 ## webpack
 
-
 - Type: `Object`
 - Default:
 

--- a/jp/api/configuration-css.md
+++ b/jp/api/configuration-css.md
@@ -31,5 +31,3 @@ module.exports = {
   ]
 }
 ```
-
-<p class="Alert">**プロダクションでは**、すべての CSS はミニファイされ `styles.css` というファイルに抽出されます。そしてページの `<head>` タグ内に `style.css` を読み込む link タグが追加されます。</p>

--- a/jp/api/configuration-watchers.md
+++ b/jp/api/configuration-watchers.md
@@ -1,0 +1,35 @@
+---
+title: "API: The watchers Property"
+description: The watchers property lets you overwrite watchers configuration.
+---
+
+# The watchers Property
+
+- Type: `Object`
+- Default: `{}`
+
+> The watchers property lets you overwrite watchers configuration in your nuxt.config.js.
+
+## chokidar
+
+- Type: `Object`
+- Default: `{}`
+
+To learn more about chokidar options, see the [chokidar API](https://github.com/paulmillr/chokidar#api).
+
+## webpack
+
+
+- Type: `Object`
+- Default:
+
+```js
+watchers: {
+  webpack: {
+    aggregateTimeout: 300,
+    poll: 1000
+  }
+}
+```
+
+To learn more about webpack watchoptions, see the [webpack documentation](https://webpack.js.org/configuration/watch/#watchoptions).

--- a/jp/api/configuration-watchers.md
+++ b/jp/api/configuration-watchers.md
@@ -1,27 +1,26 @@
 ---
-title: "API: The watchers Property"
-description: The watchers property lets you overwrite watchers configuration.
+title: "API: watchers プロパティ"
+description: watchers プロパティで監視設定を上書きできます。
 ---
 
-# The watchers Property
+# watchers プロパティ
 
-- Type: `Object`
-- Default: `{}`
+- タイプ: `オブジェクト`
+- デフォルト: `{}`
 
-> The watchers property lets you overwrite watchers configuration in your nuxt.config.js.
+> nuxt.config.js 内の watchers プロパティで監視設定を上書きできます。
 
 ## chokidar
 
-- Type: `Object`
-- Default: `{}`
+- タイプ: `オブジェクト`
+- デフォルト: `{}`
 
-To learn more about chokidar options, see the [chokidar API](https://github.com/paulmillr/chokidar#api).
+chokidar オプションについてより深く理解するには [chokidar API](https://github.com/paulmillr/chokidar#api) を参照してください。
 
 ## webpack
 
-
-- Type: `Object`
-- Default:
+- タイプ: `Object`
+- デフォルト:
 
 ```js
 watchers: {
@@ -32,4 +31,4 @@ watchers: {
 }
 ```
 
-To learn more about webpack watchoptions, see the [webpack documentation](https://webpack.js.org/configuration/watch/#watchoptions).
+webpack の監視オプションについてより深く理解するには [webpack のドキュメント](https://webpack.js.org/configuration/watch/#watchoptions) を参照してください。

--- a/jp/api/menu.json
+++ b/jp/api/menu.json
@@ -91,7 +91,15 @@
         ]
       },
       { "name": "srcDir", "to": "/configuration-srcdir" },
-      { "name": "transition", "to": "/configuration-transition" }
+      { "name": "transition", "to": "/configuration-transition" },
+      {
+        "name": "watchers",
+        "to": "/configuration-watchers",
+        "contents": [
+          { "name": "chokidar", "to": "#chokidar" },
+          { "name": "webpack", "to": "#webpack" }
+        ]
+      }
     ]
   },
   {

--- a/ko/api/configuration-watchers.md
+++ b/ko/api/configuration-watchers.md
@@ -15,7 +15,6 @@ description: watchers 프로퍼티는 watchers 설정을 덮어씌웁니다
 - 타입: `Object`
 - 기본값: `{}`
 
-
 chokidar 옵션에 대해 더 알고싶으시면 [chokidar API](https://github.com/paulmillr/chokidar#api) 문서를 확인 바랍니다.
 
 ## webpack


### PR DESCRIPTION
I have reflected "add watchers doc · nuxt/docs@640e03a" to Japanese translation.