### PR TITLE
Reflect "Fix broken link on nuxt-render-route page" #66 to Japanese translation

### DIFF
--- a/jp/api/nuxt-render-route.md
+++ b/jp/api/nuxt-render-route.md
@@ -16,7 +16,7 @@ description: 特定のルートをレンダリングします。その際にコ�
 
 > 特定のルートをレンダリングします。その際にコンテキストを渡すことができます。
 
-このメソッドはほとんどの場合 [nuxt.renderAndGetWindow](/api/nuxt-render-and-get-window) とともに [テストする目的](guide/development-tools#エンドツーエンドテスト) で使われます。
+このメソッドはほとんどの場合 [nuxt.renderAndGetWindow](/api/nuxt-render-and-get-window) とともに [テストする目的](/guide/development-tools#エンドツーエンドテスト) で使われます。
 
 <p class="Alert Alert--info">`nuxt.renderRoute` はプロダクションモード（dev: false）ではビルド処理の後に実行すると良いでしょう。</p>
 


### PR DESCRIPTION
I have reflected "Fix broken link on nuxt-render-route page" #66 to Japanese translation.