### PR TITLE
Revert "Reflect the update of Japanese translation repository name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Chinese translation is maintained by AOTU Labs from China, Shenzhen.
 
 Japanese translation is maintained by INOUE Takuya.
 
-* Translation Repo — [/inouetakuya/jp.docs.nuxtjs](https://github.com/inouetakuya/jp.docs.nuxtjs)
+* Translation Repo — [/inouetakuya/ja.docs.nuxtjs](https://github.com/inouetakuya/ja.docs.nuxtjs)
 * Primary maintainer - [INOUE Takuya](http://blog.inouetakuya.info/)
 * Primary translator - [INOUE Takuya](https://github.com/inouetakuya)
 


### PR DESCRIPTION
Revert nuxt/docs#67 

This revert is related to the issue: [Why are some translation directory names using Country Code instead of Language Code ? · Issue #92 · nuxt/docs](https://github.com/nuxt/docs/issues/92)
