### PR TITLE
Add note that async nuxtServerInit must be promise

### DIFF
--- a/en/guide/vuex-store.md
+++ b/en/guide/vuex-store.md
@@ -187,3 +187,5 @@ actions: {
 > If you are using the _Modules_ mode of the Vuex store, only the primary module (in `store/index.js`) will receive this action. You'll need to chain your module actions from there.
 
 The context is given to `nuxtServerInit` as the 2nd argument, it is the same as the `data` or `fetch` method except that `context.redirect()` and `context.error()` are omitted.
+
+> Note: Asynchronous `nuxtServerInit` actions must return a Promise to allow the `nuxt` server to wait on them.


### PR DESCRIPTION
I had some debugging pain a couple of days ago using `nuxtServerInit` with a callback-style async action.   Eventually I realized that it must return a Promise for anything async so that the nuxt server can wait on it properly.  A quick note in the docs should help others avoid that same mistake.

Feel free to change the wording & formatting to fit your preferred style!