### PR TITLE
Translate linkExactActiveClass of configuration-router into Japanese

### DIFF
--- a/ja/api/configuration-router.md
+++ b/ja/api/configuration-router.md
@@ -66,6 +66,25 @@ module.exports = {
 
 > このオプションは [vue-router の Router コンストラクタ](https://router.vuejs.org/en/api/options.html) に直接付与されます。
 
+## linkExactActiveClass
+
+- タイプ `文字列`
+- デフォルト: `'nuxt-link-exact-active'`
+
+[`<nuxt-link>`](/api/components-nuxt-link) のデフォルトの active class をグローバルに設定します。
+
+例 (`nuxt.config.js`):
+
+```js
+module.exports = {
+  router: {
+    linkExactActiveClass: 'exact-active-link'
+  }
+}
+```
+
+> このオプションは [vue-router Router constructor](https://router.vuejs.org/en/api/options.html) に直接付与さられます.
+
 ## scrollBehavior
 
 - タイプ: `関数`


### PR DESCRIPTION
original is https://github.com/nuxt/docs/blob/master/en/api/configuration-router.md

```
## linkExactActiveClass

- Type: `String`
- Default: `'nuxt-link-exact-active'`

Globally configure [`<nuxt-link>`](/api/components-nuxt-link) default exact active class.

Example (`nuxt.config.js`):
\`\`\`js
module.exports = {
  router: {
    linkExactActiveClass: 'exact-active-link'
  }
}
\`\`\`

> This option is given directly to the [vue-router Router constructor](https://router.vuejs.org/en/api/options.html).
```

cc:/ @inouetakuya 