### PR TITLE
It is requied at least `node >= 7.6.0` to start the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Developing
 
-:warning: You must at least use `node >= 7` to start the server.
+:warning: You must at least use `node >= 7.6.0` (supports async/await) to start the server.
 
 Start a dev server on `localhost:4000`
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Nuxt.js documentation files",
   "engines": {
-    "node": ">=7"
+    "node": ">=7.6.0"
   },
   "scripts": {
     "dev": "nodemon --watch *.js --exec 'node api.js'",


### PR DESCRIPTION
It is requied at least `node >= 7.6.0` to start the server because supporting async/await is needed.

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V7.md#7.6.0

> update V8 to 5.5 (Michaël Zasso) #11029

(V8 5.5 supports async/await)

ref. [Node 7.6 Brings Default Async/Await Support](https://www.infoq.com/news/2017/02/node-76-async-await)

### Log

#### (1) Node 7.5.0 -> failed

```
$ node -v
v7.5.0

$ npm run dev

> nuxt-docs@1.0.0 dev /Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs
> nodemon --watch *.js --exec 'node api.js'

[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: api.js
[nodemon] starting `node api.js gh-hook.js`
/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/api.js:37
async function getReleases () {
      ^^^^^^^^
SyntaxError: Unexpected token function
    at Object.exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:543:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:418:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:533:3
[nodemon] app crashed - waiting for file changes before starting...
```

#### (2) Node 7.6.0 -> succeeded

```
$ node -v
v7.6.0

$ npm run dev

> nuxt-docs@1.0.0 dev /Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs
> nodemon --watch *.js --exec 'node api.js'

[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: api.js
[nodemon] starting `node api.js gh-hook.js`
Building files...
Building menu...
Building languages...
Fetching releases...
Watch files changes...
Server listening on localhost:4000
```
