### PR TITLE
Provides more information to avoid nuxt/nuxt.js#1003

### DIFF
--- a/en/api/configuration-css.md
+++ b/en/api/configuration-css.md
@@ -7,6 +7,12 @@ description: Nuxt.js lets you define the CSS files/modules/libraries you want to
 
 > Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every pages).
 
+Before usage make sure that you have installed ```node-sass``` and ```sass-loader``` packages. If you didn't 
+
+```sh
+npm install --save-dev node-sass sass-loader
+```
+
 - Type: `Array`
  - Items: `String` or `Object`
 

--- a/en/api/configuration-css.md
+++ b/en/api/configuration-css.md
@@ -7,7 +7,7 @@ description: Nuxt.js lets you define the CSS files/modules/libraries you want to
 
 > Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every pages).
 
-Before usage make sure that you have installed ```node-sass``` and ```sass-loader``` packages. If you didn't 
+In case you want to use ```sass``` make sure that you have installed ```node-sass``` and ```sass-loader``` packages. If you didn't  just
 
 ```sh
 npm install --save-dev node-sass sass-loader


### PR DESCRIPTION

Hello there :)
Loading css files from current directory requires ```node-sass``` and ```sass-loader``` but it's not stated in the documentation. Same issue here also: nuxt/nuxt.js#1003

Hope it helps
