### PR TITLE
Fix FAQ regarding google analytics

### DIFF
--- a/en/faq/google-analytics.md
+++ b/en/faq/google-analytics.md
@@ -25,6 +25,9 @@ if (process.env.NODE_ENV === 'production') {
   ** Set the current page
   */
   ga('create', 'UA-XXXXXXXX-X', 'auto')
+}
+
+export default ({ app: { router }, store }) => {
   /*
   ** Every time the route changes (fired on initialization too)
   */

--- a/ja/faq/google-analytics.md
+++ b/ja/faq/google-analytics.md
@@ -25,6 +25,9 @@ if (process.env.NODE_ENV === 'production') {
   ** 現在のページをセット
   */
   ga('create', 'UA-XXXXXXXX-X', 'auto')
+}
+
+export default ({ app: { router }, store }) => {
   /*
   ** ルートが変更されるたびに毎回実行（初期化も実行される）
   */

--- a/ko/faq/google-analytics.md
+++ b/ko/faq/google-analytics.md
@@ -56,8 +56,11 @@ if (process.env.NODE_ENV === 'production') {
   ** 현재 페이지를 설정
   */
   ga('create', 'UA-XXXXXXXX-X', 'auto')
+}
+
+export default ({ app: { router }, store }) => {
   /*
-  ** 라우트가 변경될 때마다 실행(초기화도 실행됨)
+  ** 라우트가 변경될 때마다 실행 (초기 설정 시에도 실행됨)
   */
   router.afterEach((to, from) => {
     /*
@@ -66,7 +69,6 @@ if (process.env.NODE_ENV === 'production') {
     ga('set', 'page', to.fullPath)
     ga('send', 'pageview')
   })
-}
 ```
 
 > `UA-XXXXXXXX-X` 를 Google 애널리틱스 트랙킹 아이디로 변경해 주세요.

--- a/zh/faq/google-analytics.md
+++ b/zh/faq/google-analytics.md
@@ -23,6 +23,9 @@ if (process.BROWSER_BUILD && process.env.NODE_ENV === 'production') {
   ** 当前页的访问统计
   */
   ga('create', 'UA-XXXXXXXX-X', 'auto')
+}
+
+export default ({ app: { router }, store }) => {
   /*
   ** 每次路由变更时进行pv统计
   */


### PR DESCRIPTION
As @pi0 [pointed out](https://github.com/nuxt/nuxt.js/issues/792#issuecomment-304327304), importing `router` from `~router` does not work. However, that's what [the official documentation](https://nuxtjs.org/faq/google-analytics) suggests.

This can lead many users(me 10 mins ago, for example) to confusion. So I fixed this.

I can confirm that Korean & English version's comments make sense as I'm Korean. However, I don't speak Japaneses and Chinese so I just copied the comments which were originally there. Also, for the same reason, I didn't make this change in, for example, russian docs as there weren't this page at all in the first place.