### PR TITLE
Fix browser-specific property

### DIFF
--- a/en/faq/window-document-undefined.md
+++ b/en/faq/window-document-undefined.md
@@ -6,11 +6,11 @@ description: Window or Document undefined with Nuxt.js?
 # Window or Document undefined?
 
 This is due to the server-side rendering.
-If you need to specify that you want to import a resource only on the client-side, you need to use the `process.BROWSER_BUILD` variable.
+If you need to specify that you want to import a resource only on the client-side, you need to use the `process.browser` variable.
 
 For example, in your .vue file:
 ```js
-if (process.BROWSER_BUILD) {
+if (process.browser) {
   require('external_library')
 }
 ```


### PR DESCRIPTION
BROWSER_BUILD was renamed to browser in RC3: https://github.com/nuxt/nuxt.js/releases/tag/1.0.0-rc3