### PR TITLE
Docs: process.browser changes

### DIFF
--- a/en/faq/window-document-undefined.md
+++ b/en/faq/window-document-undefined.md
@@ -6,11 +6,11 @@ description: Window or Document undefined with Nuxt.js?
 # Window or Document undefined?
 
 This is due to the server-side rendering.
-If you need to specify that you want to import a resource only on the client-side, you need to use the `process.BROWSER_BUILD` variable.
+If you need to specify that you want to import a resource only on the client-side, you need to use the `process.browser` variable.
 
 For example, in your .vue file:
 ```js
-if (process.BROWSER_BUILD) {
+if (process.browser) {
   require('external_library')
 }
 ```


### PR DESCRIPTION
`process.BROWSER_BUILD` has been deprecated in favor of `process.browser`. The docs don't say so yet, hence this PR.