### PR TITLE
Updated readme with dev info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@
 
 :warning: You must at least use `node >= 7.6.0` (supports async/await) to start the server.
 
+:warning: You must also have the main [nuxt.js](https://github.com/nuxt/nuxt.js) website repo up and running on localhost to be able to run the docs...
+
 Start a dev server on `localhost:4000`
 
 ```bash
 npm install
 npm run dev
 ```
+
+Then access the docs via the website running on `http://localhost:3000`
 
 ## On Translations
 


### PR DESCRIPTION
Updated the readme to state that the main nuxt.js website report must also be running on localhost:3000 for the docs to be accessed. re #184