### PR TITLE
Up to date api for vuex store

### DIFF
--- a/en/guide/vuex-store.md
+++ b/en/guide/vuex-store.md
@@ -24,20 +24,18 @@ To activate the store with the classic mode, we create the `store/index.js` file
 
 ```js
 import Vuex from 'vuex'
+import mutations from './mutations'
 
-const store = () => new Vuex.Store({
+const createStore = () => {
+  return new Vuex.Store({
+    state: {
+      counter: 0
+    },
+    mutations
+  })
+}
 
-  state: {
-    counter: 0
-  },
-  mutations: {
-    increment (state) {
-      state.counter++
-    }
-  }
-})
-
-export default store
+export default createStore
 ```
 
 > We don't need to install `vuex` since it's shipped with nuxt.js

--- a/en/guide/vuex-store.md
+++ b/en/guide/vuex-store.md
@@ -24,14 +24,17 @@ To activate the store with the classic mode, we create the `store/index.js` file
 
 ```js
 import Vuex from 'vuex'
-import mutations from './mutations'
 
 const createStore = () => {
   return new Vuex.Store({
     state: {
       counter: 0
     },
-    mutations
+    mutations: {
+      increment (state) {
+        state.counter++
+      }
+    }
   })
 }
 


### PR DESCRIPTION
See https://nuxtjs.org/examples/vuex-store for a working example

Using the example in https://nuxtjs.org/guide/vuex-store I got this error:

> [nuxt] store/index.js should export a method which returns a Vuex instance.