### PR TITLE
Create context.md

### DIFF
--- a/en/api/context.md
+++ b/en/api/context.md
@@ -1,0 +1,25 @@
+---
+title: "API: The Context"
+description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`. 
+---
+
+## Context
+
+List of all the available keys in `context`:
+
+| Key | Type | Available | Description |
+|-----|------|--------------|-------------|
+| `app` | Root Vue Instance | Client & Server | The root vue instance that includes all your plugins. For example, when using `axios`, you can get access to $axios through the `context.app.$axios`
+| `isClient` | Boolean | Client & Server | Boolean to let you know if you're actually renderer from the client-side |
+| `isServer` | Boolean | Client & Server | Boolean to let you know if you're actually renderer from the server-side |
+| `isStatic` | Boolean | Client & Server | Boolean to let you know if you're actually inside a generated app (via `nuxt generate`) |
+| `isDev` | Boolean | Client & Server | Boolean to let you know if you're in dev mode, can be useful for caching some data in production |
+| `route` | [vue-router route](https://router.vuejs.org/en/api/route-object.html) | Client & Server | `vue-router` route instance. |
+| `store` | [vuex store](http://vuex.vuejs.org/en/api.html#vuexstore-instance-properties) | Client & Server | `Vuex.Store` instance. **Available only if the [vuex store](/guide/vuex-store) is set.** |
+| `env` | Object | Client & Server | Environment variables set in `nuxt.config.js`, see [env api](/api/configuration-env)  |
+| `params` | Object | Client & Server | Alias of route.params |
+| `query` | Object | Client & Server | Alias of route.query |
+| `req` | [http.Request](https://nodejs.org/api/http.html#http_class_http_incomingmessage) | Server | Request from the node.js server. If nuxt is used as a middleware, the req object might be different depending of the framework you're using. *Not available via `nuxt generate`*. |
+| `res` | [http.Response](https://nodejs.org/api/http.html#http_class_http_serverresponse) | Server | Response from the node.js server. If nuxt is used as a middleware, the res object might be different depending of the framework you're using. *Not available via `nuxt generate`*. |
+| `redirect` | Function | Client & Server | Use this method to redirect the user to another route, the status code is used on the server-side, default to 302. `redirect([status,] path [, query])` |
+| `error` | Function | Client & Server | Use this method to show the error page: `error(params)`. The `params` should have the fields `statusCode` and `message`. |

--- a/en/api/menu.json
+++ b/en/api/menu.json
@@ -130,6 +130,7 @@
     "title": "Internals",
     "links": [
       { "name": "Intro", "to": "/internals" },
+      { "name": "Context", "to": "/internals-context" },
       { "name": "Nuxt", "to": "/internals-nuxt" },
       { "name": "Renderer", "to": "/internals-renderer" },
       { "name": "Module Container", "to": "/internals-module-container" },


### PR DESCRIPTION
The context is a crucial piece to understanding and working with nuxt. It's been my experiencing that it was hard to get to the documentation page describing the context as it does not have it's own page and available within the asyncData page.

Also added `app` as one of the objects available in the `context`