### PR TITLE
Update Testing Documentation

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -64,15 +64,14 @@ We add our test file `test/index.test.js`:
 
 ```js
 import test from 'ava'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
-// We keep the nuxt and server instance
-// So we can close them at the end of the test
+// We keep a reference to nuxt so we can close
+// the server at the end of the test
 let nuxt = null
-let server = null
 
-// Init Nuxt.js and create a server listening on localhost:4000
+// Init Nuxt.js and start listening on localhost:4000
 test.before('Init Nuxt.js', async t => {
   const rootDir = resolve(__dirname, '..')
   let config = {}
@@ -80,9 +79,8 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // project folder
   config.dev = false // production build
   nuxt = new Nuxt(config)
-  await nuxt.build()
-  server = new nuxt.Server(nuxt)
-  server.listen(4000, 'localhost')
+  await new Builder(nuxt).build()
+  nuxt.listen(4000, 'localhost')
 })
 
 // Example of testing only generated html
@@ -102,9 +100,8 @@ test('Route / exits and render HTML with CSS applied', async t => {
   t.is(window.getComputedStyle(element).color, 'red')
 })
 
-// Close server and ask nuxt to stop listening to file changes
-test.after('Closing server and nuxt.js', t => {
-  server.close()
+// Close the nuxt server
+test.after('Closing server', t => {
   nuxt.close()
 })
 ```

--- a/es/guide/development-tools.md
+++ b/es/guide/development-tools.md
@@ -64,13 +64,12 @@ We add our test file `test/index.test.js`:
 
 ```js
 import test from 'ava'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
 // We keep the nuxt and server instance
 // So we can close them at the end of the test
 let nuxt = null
-let server = null
 
 // Init Nuxt.js and create a server listening on localhost:4000
 test.before('Init Nuxt.js', async t => {
@@ -80,9 +79,8 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // project folder
   config.dev = false // production build
   nuxt = new Nuxt(config)
-  await nuxt.build()
-  server = new nuxt.Server(nuxt)
-  server.listen(4000, 'localhost')
+  await new Builder(nuxt).build()
+  nuxt.listen(4000, 'localhost')
 })
 
 // Example of testing only generated html
@@ -104,7 +102,6 @@ test('Route / exits and render HTML with CSS applied', async t => {
 
 // Close server and ask nuxt to stop listening to file changes
 test.after('Closing server and nuxt.js', t => {
-  server.close()
   nuxt.close()
 })
 ```

--- a/fr/guide/development-tools.md
+++ b/fr/guide/development-tools.md
@@ -64,13 +64,12 @@ Nous ajoutons notre fichier de test `test/index.test.js`:
 
 ```js
 import test from 'ava'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
 // We keep the nuxt and server instance
 // So we can close them at the end of the test
 let nuxt = null
-let server = null
 
 // Init Nuxt.js and create a server listening on localhost:4000
 test.before('Init Nuxt.js', async t => {
@@ -80,9 +79,8 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // project folder
   config.dev = false // production build
   nuxt = new Nuxt(config)
-  await nuxt.build()
-  server = new nuxt.Server(nuxt)
-  server.listen(4000, 'localhost')
+  await new Builder(nuxt).build()
+  nuxt.listen(4000, 'localhost')
 })
 
 // Example of testing only generated html
@@ -104,7 +102,6 @@ test('Route / exits and render HTML with CSS applied', async t => {
 
 // Close server and ask nuxt to stop listening to file changes
 test.after('Closing server and nuxt.js', t => {
-  server.close()
   nuxt.close()
 })
 ```

--- a/ja/guide/development-tools.md
+++ b/ja/guide/development-tools.md
@@ -67,13 +67,12 @@ export default {
 
 ```js
 import test from 'ava'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
 // nuxt と server インスタンスを保持します
 // そうすればテスト終了時にそれらをクローズできます
 let nuxt = null
-let server = null
 
 // Nuxt.js を初期化し localhost:4000 でリスニングするサーバーを作成します
 test.before('Init Nuxt.js', async t => {
@@ -83,9 +82,8 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // project folder
   config.dev = false // production build
   nuxt = new Nuxt(config)
-  await nuxt.build()
-  server = new nuxt.Server(nuxt)
-  server.listen(4000, 'localhost')
+  await new Builder(nuxt).build()
+  nuxt.listen(4000, 'localhost')
 })
 
 // 生成された HTML のみをテストする例
@@ -107,7 +105,6 @@ test('Route / exits and render HTML with CSS applied', async t => {
 
 // サーバーを閉じて nuxt にファイル更新のリスニングを中止させる
 test.after('Closing server and nuxt.js', t => {
-  server.close()
   nuxt.close()
 })
 ```

--- a/ko/guide/development-tools.md
+++ b/ko/guide/development-tools.md
@@ -66,13 +66,12 @@ export default {
 
 ```js
 import test from 'ava'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
 // nuxt 와 server 인스턴스를 여기에 확보해둡니다.
 // 그러면 테스트가 종료되었을 때 이것들을 close할 수 있습니다.
 let nuxt = null
-let server = null
 
 // Nuxt.js 를 초기화하고 localhost:4000 에서 리스닝하는 서버를 작성합니다.
 test.before('Init Nuxt.js', async t => {
@@ -82,9 +81,8 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // project folder
   config.dev = false // production build
   nuxt = new Nuxt(config)
-  await nuxt.build()
-  server = new nuxt.Server(nuxt)
-  server.listen(4000, 'localhost')
+  await new Builder(nuxt).build()
+  nuxt.listen(4000, 'localhost')
 })
 
 // 생성된 HTML 만을 테스트하는 예제
@@ -106,7 +104,6 @@ test('Route / exits and render HTML with CSS applied', async t => {
 
 // 서버를 닫고 nuxt 에 파일갱신 리스닝을 중지시킨다
 test.after('Closing server and nuxt.js', t => {
-  server.close()
   nuxt.close()
 })
 ```

--- a/ru/guide/unit-testing.md
+++ b/ru/guide/unit-testing.md
@@ -54,13 +54,12 @@ export default {
 
 ```js
 import test from 'ava'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
 // Сохраним экземпляры nuxt и server.
 // Мы сможем сбросить их в конце теста.
 let nuxt = null
-let server = null
 
 // Инициализируем Nuxt.js и создадим сервер по адресу localhost:4000
 test.before('Init Nuxt.js', async t => {
@@ -70,9 +69,8 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // папка проекта
   config.dev = false // финальная сборка
   nuxt = new Nuxt(config)
-  await nuxt.build()
-  server = new nuxt.Server(nuxt)
-  server.listen(4000, 'localhost')
+  await new Builder(nuxt).build()
+  nuxt.listen(4000, 'localhost')
 })
 
 // Пример генерации html-кода только для этого теста
@@ -94,7 +92,6 @@ test('Route / exits and render HTML with CSS applied', async t => {
 
 // Остановить сервер и попросить nuxt не отслеживать изменения файлов
 test.after('Closing server and nuxt.js', t => {
-  server.close()
   nuxt.close()
 })
 ```

--- a/zh/guide/development-tools.md
+++ b/zh/guide/development-tools.md
@@ -67,13 +67,12 @@ export default {
 
 ```js
 import test from 'ava'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
 // 我们用两个变量保留 nuxt 和 server 实例的引用
 // 这样可以在单元测试结束之后关掉它们
 let nuxt = null
-let server = null
 
 // 初始化 Nuxt.js 并创建一个监听 localhost:4000 的服务器
 test.before('Init Nuxt.js', async t => {
@@ -83,9 +82,8 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // 项目目录
   config.dev = false // 生产构建模式
   nuxt = new Nuxt(config)
-  await nuxt.build()
-  server = new nuxt.Server(nuxt)
-  server.listen(4000, 'localhost')
+  await new Builder(nuxt).build()
+  nuxt.listen(4000, 'localhost')
 })
 
 // 测试生成的html
@@ -107,7 +105,6 @@ test('路由 / 有效且渲染的HTML有特定的CSS样式', async t => {
 
 // 关掉服务器和Nuxt实例，停止文件监听。
 test.after('Closing server and nuxt.js', t => {
-  server.close()
   nuxt.close()
 })
 ```


### PR DESCRIPTION
Hey,

this updates the end-to-end testing doc with the current Nuxt API. 

I also updated the comments in the code, but only for the english version as I don't speak any of the other languages. So I would need help there.

I noticed that in the Russian guide the docs are in `unit-testing.md` instead of `development-tools` resulting in a 404 [here](https://ru.nuxtjs.org/guide/development-tools/). This is certainly not unit testing is it? I can't read Russian though, so I don't know what it says in that file. So again, help needed!