### PR TITLE
[Doc EN]: `guide/async-data.md`

### DIFF
--- a/en/guide/async-data.md
+++ b/en/guide/async-data.md
@@ -110,4 +110,4 @@ export default {
 }
 ```
 
-To customize the error page, take a look at the [Guide Views `layouts`](/guide/views#layouts).
+To customize the error page, take a look at the [Guide Views layouts](/guide/views#layouts).

--- a/en/guide/async-data.md
+++ b/en/guide/async-data.md
@@ -110,4 +110,4 @@ export default {
 }
 ```
 
-To customize the error page, take a look at the [VIEWS layouts section](/guide/views#layouts).
+To customize the error page, take a look at the [Guide Views `layouts`](/guide/views#layouts).

--- a/en/guide/async-data.md
+++ b/en/guide/async-data.md
@@ -8,10 +8,7 @@ Nuxt.js adds an `asyncData` method to let you handle async operations before set
 
 ## The asyncData Method
 
-Sometimes you just want to fetch data and pre-render it on the server-side without using a store.
-`asyncData` is called every time before loading the component (**only for pages components**).
-It can be called server-side or before navigating to the corresponding route.
-This method receives [the context](/api/context) as the first argument, you can use it to fetch some data and nuxt.js will merge it with the component data.
+Sometimes you just want to fetch data and pre-render it on the server-side without using a store. `asyncData` is called every time before loading the component (**only for pages components**). It can be called server-side or before navigating to the corresponding route. This method receives [the context](/api/context) as the first argument, you can use it to fetch some data and Nuxt.js will merge it with the component data.
 
 <div class="Alert Alert--orange">You do **NOT** have access of the component instance through `this` inside `asyncData` because it is called **before initiating** the component.</div>
 
@@ -22,6 +19,7 @@ Nuxt.js offers you different ways to use `asyncData`. Choose the one you're the 
 3. Define a callback as second argument. It has to be called like this: `callback(err, data)`
 
 ### Returning a Promise
+
 ```js
 export default {
   asyncData ({ params }) {
@@ -34,6 +32,7 @@ export default {
 ```
 
 ### Using async/await
+
 ```js
 export default {
   async asyncData ({ params }) {
@@ -44,6 +43,7 @@ export default {
 ```
 
 ### Using a callback
+
 ```js
 export default {
   asyncData ({ params }, callback) {
@@ -68,9 +68,9 @@ You can display the data inside your template like you're used to doing:
 
 ## The Context
 
-To see the list of available keys in `context`, take a look at the [API Pages data](/api).
+To see the list of available keys in `context`, take a look at the [API Essential `context`](/api/context).
 
-### Accessing dynamic route data 
+### Accessing dynamic route data
 
 You can use the context object injected into the `asyncData` property to access dynamic route data. For example, dynamic route params can be accessed using the name of the file or folder that configured it. So if you define a file named `_slug.vue`, you can acccess it via `context.params.slug`.
 
@@ -79,6 +79,7 @@ You can use the context object injected into the `asyncData` property to access 
 Nuxt.js adds the `error(params)` method in the `context`, you can call it to display the error page. `params.statusCode` will be also used to render the proper status code form the server-side.
 
 Example with a `Promise`:
+
 ```js
 export default {
   asyncData ({ params, error }) {
@@ -93,7 +94,8 @@ export default {
 }
 ```
 
-If you're using the `callback` argument, you can call it directly with the error and nuxt.js will call the `error` method for you:
+If you're using the `callback` argument, you can call it directly with the error and Nuxt.js will call the `error` method for you:
+
 ```js
 export default {
   asyncData ({ params }, callback) {


### PR DESCRIPTION
In our French translation/review we have changed some consistent things, so we suggest you do the same in the original documentation.

More details in comments.

Do not hesitate to set back the original behavior for some changes if you think they do not make sense.