### PR TITLE
[Doc EN]: `guide/assets.md`

### DIFF
--- a/en/guide/assets.md
+++ b/en/guide/assets.md
@@ -7,7 +7,7 @@ description: Nuxt uses vue-loader, file-loader and url-loader for webpack by def
 
 ## webpacked
 
-By default, [vue-loader](http://vue-loader.vuejs.org/en/) automatically processes your style and template files with `css-loader` and the Vue template compiler. In this compilation process, all asset URL such as `<img src="...">`, `background: url(...)` and CSS `@import` are resolved as module dependencies.
+By default, [vue-loader](http://vue-loader.vuejs.org/en/) automatically processes your style and template files with css-loader and the Vue template compiler. In this compilation process, all asset URL such as `<img src="...">`, `background: url(...)` and CSS `@import` are resolved as module dependencies.
 
 For example, we have this file tree:
 
@@ -20,7 +20,8 @@ For example, we have this file tree:
 
 In your CSS, if you use `url('~/assets/image.png')`, it will be translated into `require('~/assets/image.png')`.
 
-Or if in your `pages/index.vue`, you use:
+Or if in your `pages/index.vue` you use:
+
 ```html
 <template>
   <img src="~/assets/image.png">
@@ -36,6 +37,7 @@ createElement('img', { attrs: { src: require('~/assets/image.png') }})
 Because `.png` is not a JavaScript file, Nuxt.js configures webpack to use [file-loader](https://github.com/webpack/file-loader) and [url-loader](https://github.com/webpack/url-loader) to handle them for you.
 
 The benefits of them are:
+
 - file-loader lets you designate where to copy and place the asset file, and how to name it using version hashes for better caching.
 - url-loader allows you to conditionally inline a file as base-64 data URL if they are smaller than a given threshold. This can reduce a number of HTTP requests for trivial files. If the file is larger than the threshold, it automatically falls back to file-loader.
 
@@ -55,7 +57,7 @@ Actually, Nuxt.js default assets loaders configuration is:
     test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
     loader: 'url-loader',
     query: {
-      limit: 1000, // 1 KO
+      limit: 1000, // 1kB
       name: 'fonts/[name].[hash:7].[ext]'
     }
   }
@@ -73,6 +75,7 @@ When launching our application with `nuxt`, our template in `pages/index.vue`:
 ```
 
 Will be generated into:
+
 ```html
 <img src="/_nuxt/img/image.0c61159.png">
 ```
@@ -92,7 +95,7 @@ From your code you can then reference those files with `/` URL:
 ```html
 <!-- Static image from static directory -->
 <img src="/my-image.png"/>
-~
+
 <!-- webpacked image from assets directory -->
 <img src="~/assets/my-image-2.png"/>
 ```

--- a/en/guide/assets.md
+++ b/en/guide/assets.md
@@ -7,7 +7,7 @@ description: Nuxt uses vue-loader, file-loader and url-loader for webpack by def
 
 ## webpacked
 
-By default, [vue-loader](http://vue-loader.vuejs.org/en/) automatically processes your style and template files with css-loader and the Vue template compiler. In this compilation process, all asset URL such as `<img src="...">`, `background: url(...)` and CSS `@import` are resolved as module dependencies.
+By default, [vue-loader](http://vue-loader.vuejs.org/en/) automatically processes your style and template files with css-loader and the Vue template compiler. In this compilation process, all asset URLs such as `<img src="...">`, `background: url(...)` and CSS `@import` are resolved as module dependencies.
 
 For example, we have this file tree:
 
@@ -86,7 +86,7 @@ If you want to update these loaders or disable them, please use [build.extend](/
 
 If you don't want to use webpacked Assets from the `assets` directory, you can create and use the `static` directory in your project root directory.
 
-These files will be automatically serve by Nuxt and accessible in your project root URL.
+These files will be automatically serve by Nuxt and accessible in your project root URLs.
 
 This option is helpful for files like `robots.txt`, `sitemap.xml` or `CNAME` (for like GitHub Pages).
 

--- a/en/guide/assets.md
+++ b/en/guide/assets.md
@@ -86,11 +86,11 @@ If you want to update these loaders or disable them, please use [build.extend](/
 
 If you don't want to use webpacked Assets from the `assets` directory, you can create and use the `static` directory in your project root directory.
 
-These files will be automatically serve by Nuxt and accessible in your project root URLs.
+These files will be automatically serve by Nuxt and accessible in your project root URL.
 
 This option is helpful for files like `robots.txt`, `sitemap.xml` or `CNAME` (for like GitHub Pages).
 
-From your code you can then reference those files with `/` URL:
+From your code you can then reference those files with `/` URLs:
 
 ```html
 <!-- Static image from static directory -->

--- a/en/guide/assets.md
+++ b/en/guide/assets.md
@@ -1,13 +1,13 @@
 ---
 title: Assets
-description: Nuxt uses vue-loader, file-loader and url-loader for Webpack by default for strong assets serving, but you can also use Static directory for static assets.
+description: Nuxt uses vue-loader, file-loader and url-loader for webpack by default for strong assets serving, but you can also use Static directory for static assets.
 ---
 
-> Nuxt uses vue-loader, file-loader and url-loader for Webpack by default for strong assets serving, but you can also use Static directory for static assets.
+> Nuxt uses vue-loader, file-loader and url-loader for webpack by default for strong assets serving, but you can also use Static directory for static assets.
 
-## Webpacked
+## webpacked
 
-By default, [vue-loader](http://vue-loader.vuejs.org/en/) automatically processes your style and template files with `css-loader` and the Vue template compiler. In this compilation process, all asset URLs such as `<img src="...">`, `background: url(...)` and CSS `@import` are resolved as module dependencies.
+By default, [vue-loader](http://vue-loader.vuejs.org/en/) automatically processes your style and template files with `css-loader` and the Vue template compiler. In this compilation process, all asset URL such as `<img src="...">`, `background: url(...)` and CSS `@import` are resolved as module dependencies.
 
 For example, we have this file tree:
 
@@ -18,9 +18,9 @@ For example, we have this file tree:
 ----| index.vue
 ```
 
-In my CSS, if I use `url('~/assets/image.png')`, it will be translated into `require('~/assets/image.png')`.
+In your CSS, if you use `url('~/assets/image.png')`, it will be translated into `require('~/assets/image.png')`.
 
-Or if in my `pages/index.vue`, I use:
+Or if in your `pages/index.vue`, you use:
 ```html
 <template>
   <img src="~/assets/image.png">
@@ -33,11 +33,11 @@ It will be compiled into:
 createElement('img', { attrs: { src: require('~/assets/image.png') }})
 ```
 
-Because `.png` is not a JavaScript file, nuxt.js configures Webpack to use [file-loader](https://github.com/webpack/file-loader) and [url-loader](https://github.com/webpack/url-loader) to handle them for you.
+Because `.png` is not a JavaScript file, Nuxt.js configures webpack to use [file-loader](https://github.com/webpack/file-loader) and [url-loader](https://github.com/webpack/url-loader) to handle them for you.
 
 The benefits of them are:
-- `file-loader` lets you designate where to copy and place the asset file, and how to name it using version hashes for better caching.
-- `url-loader` allows you to conditionally inline a file as base-64 data URL if they are smaller than a given threshold. This can reduce a number of HTTP requests for trivial files. If the file is larger than the threshold, it automatically falls back to `file-loader`.
+- file-loader lets you designate where to copy and place the asset file, and how to name it using version hashes for better caching.
+- url-loader allows you to conditionally inline a file as base-64 data URL if they are smaller than a given threshold. This can reduce a number of HTTP requests for trivial files. If the file is larger than the threshold, it automatically falls back to file-loader.
 
 Actually, Nuxt.js default assets loaders configuration is:
 
@@ -81,18 +81,18 @@ If you want to update these loaders or disable them, please use [build.extend](/
 
 ## Static
 
-If you don't want to use Webpacked Assets from the `assets` directory, you can create and use the `static` directory in your project root directory.
+If you don't want to use webpacked Assets from the `assets` directory, you can create and use the `static` directory in your project root directory.
 
 These files will be automatically serve by Nuxt and accessible in your project root URL.
 
 This option is helpful for files like `robots.txt`, `sitemap.xml` or `CNAME` (for like GitHub Pages).
 
-From your code you can then reference those files with `/` URLs:
+From your code you can then reference those files with `/` URL:
 
 ```html
 <!-- Static image from static directory -->
 <img src="/my-image.png"/>
 ~
-<!-- Webpacked image from assets directory -->
+<!-- webpacked image from assets directory -->
 <img src="~/assets/my-image-2.png"/>
 ```


### PR DESCRIPTION
In our French translation/review we have changed some consistent things, so we suggest you do the same in the original documentation.

More details in comments.

Do not hesitate to set back the original behavior for some changes if you think they do not make sense.