### PR TITLE
[Docs FR]: French version ready for starting online life.

### DIFF
--- a/fr/api/components-nuxt-child.md
+++ b/fr/api/components-nuxt-child.md
@@ -3,11 +3,11 @@ title: "API: The <nuxt-child> Component"
 description: Display the current page
 ---
 
-# The &lt;nuxt-child&gt; Component
+# The &lt;nuxt-child&gt; Component (En)
 
 > This component is used for displaying the children components in a [nested route](/guide/routing#nested-routes).
 
-Example:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Example:</p>
 
 ```bash
 -| pages/
@@ -21,12 +21,12 @@ This file tree will generate these routes:
 [
   {
     path: '/parent',
-    component: '~pages/parent.vue',
+    component: '~/pages/parent.vue',
     name: 'parent',
     children: [
       {
         path: 'child',
-        component: '~pages/parent/child.vue',
+        component: '~/pages/parent/child.vue',
         name: 'parent-child'
       }
     ]
@@ -34,7 +34,7 @@ This file tree will generate these routes:
 ]
 ```
 
-To display the `child.vue` component, I have to insert `<nuxt-child/>` inside `pages/parent.vue`:
+To display the `child.vue` component, we have to insert `<nuxt-child/>` inside `pages/parent.vue`:
 
 ```html
 <template>

--- a/fr/api/components-nuxt-link.md
+++ b/fr/api/components-nuxt-link.md
@@ -3,11 +3,11 @@ title: "API: The <nuxt-link> Component"
 description: Link the pages between them with nuxt-link.
 ---
 
-# The &lt;nuxt-link&gt; Component
+# The &lt;nuxt-link&gt; Component (En)
 
 > This component is used to link the page components between them.
 
-At the moment, `<nuxt-link>` is the same as [`<router-link>`](https://router.vuejs.org/en/api/router-link.html), so we recommend you to see how to use it on the [vue-router documentation](https://router.vuejs.org/en/api/router-link.html).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>At the moment, `<nuxt-link>` is the same as [`<router-link>`](https://router.vuejs.org/en/api/router-link.html), so we recommend you to see how to use it on the [vue-router documentation](https://router.vuejs.org/en/api/router-link.html).</p>
 
 Example (`pages/index.vue`):
 

--- a/fr/api/components-nuxt.md
+++ b/fr/api/components-nuxt.md
@@ -3,9 +3,14 @@ title: "API: The <nuxt> Component"
 description: Display the page components inside a layout.
 ---
 
-# The &lt;nuxt&gt; Component
+# The &lt;nuxt&gt; Component (En)
 
 > This component is used only in [layouts](/guide/views#layouts) to display the page components.
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>**Props**:</p>
+- nuxtChildKey: `string`
+  - This prop will be set to `<router-view/>`, useful to make transitions inside a dynamic page and different route.
+  - Default: `$route.fullPath`
 
 Example (`layouts/default.vue`):
 

--- a/fr/api/configuration-build.md
+++ b/fr/api/configuration-build.md
@@ -3,7 +3,7 @@ title: "API: The build Property"
 description: Nuxt.js lets you customize the webpack configuration for building your web application as you want.
 ---
 
-# The build Property
+# The build Property (En)
 
 > Nuxt.js lets you customize the webpack configuration for building your web application as you want.
 
@@ -14,7 +14,7 @@ description: Nuxt.js lets you customize the webpack configuration for building y
 - Type: `Boolean` or `Object`
 - Default: `false`
 
-If an object, see available properties [here](https://github.com/th0r/webpack-bundle-analyzer#as-plugin).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>If an object, see available properties [here](https://github.com/th0r/webpack-bundle-analyzer#as-plugin).</p>
 
 Example (`nuxt.config.js`):
 ```js
@@ -55,6 +55,18 @@ module.exports = {
 }
 ```
 
+## cssSourceMap
+
+- Type: `boolean`
+  - Default: `true` for dev and `false` for production.
+
+> Enables CSS Source Map support
+
+## devMiddleware
+- Type: `Object`
+
+See [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) for available options.
+
 ## extend
 
 - Type: `Function`
@@ -62,6 +74,7 @@ module.exports = {
 > Extend the webpack configuration manually for the client & server bundles.
 
 The extend is called twice, one time for the server bundle, and one time for the client bundle. The arguments of the method are:
+
 1. Webpack config object
 2. Object with the folowing keys (all boolean): `dev`, `isClient`, `isServer`
 
@@ -81,6 +94,17 @@ module.exports = {
 
 If you want to see more about our default webpack configuration, take a look at our [webpack directory](https://github.com/nuxt/nuxt.js/tree/master/lib/webpack).
 
+## extractCSS
+
+- Type: `Boolean`
+  - Default: `false`
+
+> Enables Common CSS Extraction using vue SSR [guidelines](https://ssr.vuejs.org/en/css.html).
+
+Using extract-text-webpack-plugin to extract the CSS in the main chunk into a separate CSS file (auto injected with template),
+which allows the file to be individually cached. This is recommended when there is a lot of shared CSS.
+CSS inside async components will remain inlined as JavaScript strings and handled by vue-style-loader.
+
 ## filenames
 
 - Type: `Object`
@@ -90,71 +114,32 @@ If you want to see more about our default webpack configuration, take a look at 
 Default:
 ```js
 {
-  vendor: 'vendor.bundle.[hash].js',
-  app: 'nuxt.bundle.[chunkhash].js'
+  css: 'common.[contenthash].css',
+  manifest: 'manifest.[hash].js',
+  vendor: 'common.[chunkhash].js',
+  app: 'app.[chunkhash].js',
+  chunk: '[name].[chunkhash].js'
 }
 ```
 
-Example (`nuxt.config.js`):
+This example changes fancy chunk names to numerical ids (`nuxt.config.js`):
+
 ```js
 module.exports = {
   build: {
     filenames: {
-      vendor: 'vendor.[hash].js',
-      app: 'app.[chunkhash].js'
+      chunk: '[id].[chunkhash].js'
     }
   }
 }
 ```
 
-## loaders
+To understand a bit more about the use of manifest and vendor, take a look at this [Webpack documentation](https://webpack.js.org/guides/code-splitting-libraries/).
 
-- Type: `Array`
-  - Items: `Object`
+## hotMiddleware
+- Type: `Object`
 
-> Customize webpack loaders
-
-Default:
-```js
-[
-  {
-    test: /\.(png|jpe?g|gif|svg)$/,
-    loader: 'url-loader',
-    query: {
-      limit: 1000, // 1KO
-      name: 'img/[name].[hash:7].[ext]'
-    }
-  },
-  {
-    test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
-    loader: 'url-loader',
-    query: {
-      limit: 1000, // 1 KO
-      name: 'fonts/[name].[hash:7].[ext]'
-    }
-  }
-]
-```
-
-Example (`nuxt.config.js`):
-```js
-module.exports = {
-  build: {
-    loaders: [
-      {
-        test: /\.(png|jpe?g|gif|svg)$/,
-        loader: 'url-loader',
-        query: {
-          limit: 10000, // 10KO
-          name: 'img/[name].[hash].[ext]'
-        }
-      }
-    ]
-  }
-}
-```
-
-<p class="Alert Alert--orange">When the loaders are defined in the `nuxt.config.js`, the default loaders will be overwritten.</p>
+See [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware) for available options.
 
 ## plugins
 
@@ -180,31 +165,49 @@ module.exports = {
 
 ## postcss
 
-- Type: `Array`
+- Type: `Array` or `Object` (recommended) or `Function` or `Boolean`
 
-> Customize [postcss](https://github.com/postcss/postcss) options
+> Customize [Postcss Loader](https://github.com/postcss/postcss-loader#usage) plugins.
+
+**NOTE:** While default preset is OK and flexible enough for normal use cases, the recommended 
+usage by [vue-loader](https://vue-loader.vuejs.org/en/options.html#postcss) is using `postcss.config.js` file in your project.
+By creating that file it will be automatically detected and this option is ignored.
 
 Default:
+
 ```js
-[
-  require('autoprefixer')({
-    browsers: ['last 3 versions']
-  })
-]
+{
+  plugins: {
+  'postcss-import' : {},
+  'postcss-url': {},
+  'postcss-cssnext': {}
+  }
+}
 ```
 
 Example (`nuxt.config.js`):
+
 ```js
 module.exports = {
   build: {
-    postcss: [
-      require('postcss-nested')(),
-      require('postcss-responsive-type')(),
-      require('postcss-hexrgba')(),
-      require('autoprefixer')({
-        browsers: ['last 3 versions']
-      })
-    ]
+    postcss: {
+      plugins: {
+        // Disable postcss-url
+      'postcss-url': false
+
+      // Customize postcss-cssnext default options
+      'postcss-cssnext': {
+        features: {
+          customProperties: false
+        }
+      }
+
+      // Add some plugins
+      'postcss-nested': {},
+      'postcss-responsive-type': {}
+      'postcss-hexrgba': {}
+      }
+    }
   }
 }
 ```
@@ -228,9 +231,45 @@ module.exports = {
 
 Then, when launching `nuxt build`, upload the content of `.nuxt/dist/` directory to your CDN and voilà!
 
+## ssr
+- Type: `Boolean`
+  - Default `true` for universal mode and `false` for spa mode
+
+> Creates special webpack bundle for SSR renderer.
+
+This option is automatically set based on `mode` value if not provided. 
+
+## templates
+- Type: `Array`
+ - Items: `Object`
+
+> Nuxt.js allows you provide your own templates which will be rendered based on nuxt configuration
+  This feature is specially useful for using with [modules](/guide/modules).
+
+Example (`nuxt.config.js`):
+
+```js
+module.exports = {
+  build: {
+      templates: [
+         {
+           src: '~/modules/support/plugin.js', // src can be absolute or relative
+           dst: 'support.js', // dst is relative to project `.nuxt` dir
+           options: { // Options are provided to template as `options` key
+               live_chat: false
+           }
+         }
+      ]
+  }
+}
+```
+
+Templates are rendered using [lodash.template](https://lodash.com/docs/#template) 
+you can learn more about using them [here](https://github.com/learn-co-students/javascript-lodash-templates-v-000).
+
 ## vendor
 
-> Nuxt.js lets you add modules inside the `vendor.bundle.js` file generated to reduce the size of the app bundle. It's really useful when using external modules (like `axios` for example)
+> Nuxt.js lets you add modules inside the `vendor.bundle.js` file to reduce the size of the application bundle. This is especially helpful when using external modules (like `axios` for example).
 
 - Type: `Array`
  - Items: `String`
@@ -251,8 +290,25 @@ module.exports = {
   build: {
     vendor: [
       'axios',
-      '~plugins/my-lib.js'
+      '~/plugins/my-lib.js'
     ]
+  }
+}
+```
+
+## watch
+- Type: `Array`
+ - Items: `String`
+
+> You can provide your custom files to watch and regenerate after changes.
+  This feature is specially useful for using with [modules](/guide/modules).
+
+```js
+module.exports = {
+  build: {
+      watch: [
+          '~/.nuxt/support.js'
+      ]
   }
 }
 ```

--- a/fr/api/configuration-css.md
+++ b/fr/api/configuration-css.md
@@ -1,32 +1,34 @@
 ---
 title: "API: The css Property"
-description: Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every pages).
+description: Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every page).
 ---
 
-# The css Property
+# The css Property (En)
 
-> Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every pages).
+> Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>In case you want to use ```sass``` make sure that you have installed ```node-sass``` and ```sass-loader``` packages. If you didn't  just</p>
+
+```sh
+npm install --save-dev node-sass sass-loader
+```
 
 - Type: `Array`
- - Items: `String` or `Object`
-
-If the item is an object, the properties are:
-- src: `String` (path of the file)
-- lang: `String` ([pre-processor used](/faq/pre-processors))
+ - Items: `String`
 
 In `nuxt.config.js`, add the CSS resources:
 
 ```js
 module.exports = {
   css: [
-    // Load a node.js module
-    'hover.css/css/hover-min.css',
-    // node.js module but we specify the pre-processor
-    { src: 'bulma', lang: 'sass' },
-    // Css file in the project
-    '~assets/css/main.css',
-    // Sass file in the project
-    { src: '~assets/css/main.scss', lang: 'scss' } // scss instead of sass
+    // Load a node module directly (here it's a SASS file)
+    'bulma',
+    // CSS file in the project
+    '@/assets/css/main.css',
+    // SCSS file in the project
+    '@/assets/css/main.scss'
   ]
 }
 ```
+
+Nuxt.js will automatically guess the file type by it's extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.

--- a/fr/api/configuration-dev.md
+++ b/fr/api/configuration-dev.md
@@ -3,16 +3,17 @@ title: "API: The dev Property"
 description: Define the development or production mode.
 ---
 
-# The dev Property
+# The dev Property (En)
 
 - Type: `Boolean`
 - Default: `true`
 
 > Define the development or production mode of nuxt.js
 
-This property is overwritten by [nuxt commands](/guide/commands):
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This property is overwritten by [nuxt commands](/guide/commands):</p>
+
 - `dev` is forced to `true` with `nuxt`
-- `dev` is force to `false` with `nuxt build`, `nuxt start` and `nuxt generate`
+- `dev` is forced to `false` with `nuxt build`, `nuxt start` and `nuxt generate`
 
 This property should be used when using [nuxt.js programmatically](/api/nuxt):
 
@@ -27,7 +28,7 @@ module.exports = {
 
 `server.js`
 ```js
-const Nuxt = require('nuxt')
+const { Nuxt, Builder } = require('nuxt')
 const app = require('express')()
 const port = process.env.PORT || 3000
 
@@ -38,7 +39,7 @@ app.use(nuxt.render)
 
 // Build only in dev mode
 if (config.dev) {
-  nuxt.build()
+  new Builder(nuxt).build()
   .catch((error) => {
     console.error(error)
     process.exit(1)
@@ -46,8 +47,9 @@ if (config.dev) {
 }
 
 // Listen the server
-app.listen(port, '0.0.0.0')
-console.log('Server listening on localhost:' + port)
+app.listen(port, '0.0.0.0').then(() => {
+  nuxt.showOpen()
+})
 ```
 
 Then in your `package.json`:
@@ -60,4 +62,5 @@ Then in your `package.json`:
   }
 }
 ```
+
 Note: You'll need to run `npm install --save-dev cross-env` for the above example to work. If you're *not* developing on Windows you can leave cross-env out of your `start` script and set `NODE_ENV` directly.

--- a/fr/api/configuration-env.md
+++ b/fr/api/configuration-env.md
@@ -3,13 +3,13 @@ title: "API: The env Property"
 description: Share environment variables between client and server.
 ---
 
-# The env Property
+# The env Property (En)
 
 - Type: `Object`
 
 > Nuxt.js lets you create environment variables that will be shared for the client and server-side.
 
-Example (`nuxt.config.js`):
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Example (`nuxt.config.js`):</p>
 
 ```js
 module.exports = {
@@ -22,8 +22,9 @@ module.exports = {
 This lets me create a `baseUrl` property that will be equal to the `BASE_URL` environment variable if defined, otherwise, equal to `http://localhost:3000`.
 
 Then, I can access my `baseUrl` variable with 2 ways:
+
 1. Via `process.env.baseUrl`
-2. Via `context.baseUrl`, see [context api](/api#context)
+2. Via `context.env.baseUrl`, see [context api](/api/context)
 
 You can use the `env` property for giving public token for example.
 
@@ -38,4 +39,21 @@ export default axios.create({
 })
 ```
 
-Then, in your pages, you can import axios like this: `import axios from '~plugins/axios'`
+Then, in your pages, you can import axios like this: `import axios from '~/plugins/axios'`
+
+## process.env == {}
+Note that nuxt uses webpack's `definePlugin` to define the environmental variable. This means that, the actual `process` or `process.env` from node is not available and is not defined. Each of the env properties defined in nuxt.config.js is individually mapped to process.env.xxxx and converted during compilation. 
+
+Meaning, `console.log(process.env)` will output `{}` but `console.log(process.env.you_var)` will still output your value. When webpack compiles your code, it replaces all instances of `process.env.your_var` to the value you've set it to. ie: `env.test = 'testing123'`. If you use `process.env.test` in your code somewhere, it is actually translated to 'testing123'.
+
+before
+```
+if (process.env.test == 'testing123')
+```
+
+after
+```
+if ('testing123' == 'testing123')
+```
+
+

--- a/fr/api/configuration-generate.md
+++ b/fr/api/configuration-generate.md
@@ -9,7 +9,7 @@ description: Configure the generation of your universal web application to a sta
 
 > Configure the generation of your universal web application to a static web application.
 
-When launching `nuxt generate` or calling `nuxt.generate()`, nuxt.js will use the configuration defined in the `generate` property.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>When launching `nuxt generate` or calling `nuxt.generate()`, nuxt.js will use the configuration defined in the `generate` property.</p>
 
 ## dir
 
@@ -121,7 +121,7 @@ module.exports = {
         return res.data.map((user) => {
           return '/users/' + user.id
         })
-      })
+      })      
     }
   }
 }
@@ -146,5 +146,39 @@ module.exports = {
       .catch(callback)
     }
   }
+}
+```
+
+### Speeding up dynamic route generation with `payload`
+
+In the example above, we're using the `user.id` from the server to generate the routes but tossing out the rest of the data. Typically, we need to fetch it again from inside the `/users/_id.vue`. While we can do that, we'll probably need to set the `generate.interval` to something like `100` in order not to flood the server with calls. Because this will increase the run time of the generate script, it would be preferable to pass along the entire `user` object to the context in `_id.vue`. We do that with by modifying the code above to this:
+
+`nuxt.config.js`
+```js
+const axios = require('axios')
+
+module.exports = {
+  generate: {
+    routes: function () {
+      return axios.get('https://my-api/users')
+      .then((res) => {
+        return res.data.map((user) => {
+          return {
+            route: '/users/' + user.id,
+            payload: user
+          }
+        })
+      })
+    }
+  }
+}
+```
+
+Now we can access the `payload` from `/users/_id.vue` like so:
+
+```js
+async asyncData ({ params, error, payload }) {
+  if (payload) return { user: payload }
+  else return { user: await backend.fetchUser(params.id) }
 }
 ```

--- a/fr/api/configuration-head.md
+++ b/fr/api/configuration-head.md
@@ -3,7 +3,7 @@ title: "API: The head Property"
 description: Nuxt.js let you define all default meta for your application inside nuxt.config.js.
 ---
 
-# The head Property
+# The head Property (En)
 
 > Nuxt.js let you define all default meta for your application inside `nuxt.config.js`, use the same `head` property:
 
@@ -22,6 +22,6 @@ module.exports = {
 }
 ```
 
-To know the list of options you can give to `head`, take a look at [vue-meta documentation](https://github.com/declandewet/vue-meta#recognized-metainfo-properties).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>To know the list of options you can give to `head`, take a look at [vue-meta documentation](https://github.com/declandewet/vue-meta#recognized-metainfo-properties).</p>
 
 <p class="Alert Alert--teal"><b>INFO:</b> You can also use `head` in the page components and access to the component data through `this`, see [component head property](/api/pages-head).</p>

--- a/fr/api/configuration-loading-indicator.md
+++ b/fr/api/configuration-loading-indicator.md
@@ -1,0 +1,49 @@
+---
+title: "API: The loading indicator Property"
+description: Show fancy loading indicator while SPA page is loading!
+---
+
+# The loadingIndicator Property (En)
+
+> Show fancy loading indicator while SPA page is loading!
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>When running nuxt.js in SPA mode, there is no content from the server side on the first page load,
+So instead of showing a blank page while the page loads, we may show a spinner.</p>
+
+This property can have 3 different types: `string` or `false` or `object`.
+If a string value is provided it is converted to object style.
+
+Default value is: 
+```js
+{
+  name: 'circle',
+  color: '#3B8070',
+  background: 'white'
+}
+```
+
+## Built-in Indicators
+
+This indicators are ported from awesome [Spinkit](http://tobiasahlin.com/spinkit) project.
+You can use it's demo page to preview spinners.
+
+- circle
+- cube-grid
+- fading-circle
+- folding-cube
+- chasing-dots
+- nuxt
+- pulse
+- rectangle-bounce
+- rotating-plane
+- three-bounce
+- wandering-cubes
+
+Built-in indicators support `color` and `background` options.
+
+## Custom indicators
+
+If you need your own special indicator, a String value or Name key can also be a path to an html template of indicator source code!
+All of the options are passed to the template too.
+
+Nuxt Built-ins [source code](https://github.com/nuxt/nuxt.js/tree/dev/lib/app/views/loading) is also available if you need a base!

--- a/fr/api/configuration-loading.md
+++ b/fr/api/configuration-loading.md
@@ -1,19 +1,19 @@
 ---
 title: "API: The loading Property"
-description: Nuxt.js uses it's own component to show a progress bar between the routes. You can customize it, disable it or create your own component.
+description: Nuxt.js uses its own component to show a progress bar between the routes. You can customize it, disable it or create your own component.
 ---
 
-# The loading Property
+# The loading Property (En)
 
 - Type: `Boolean` or `Object` or `String`
 
-> Nuxt.js uses it's own component to show a progress bar between the routes. You can customize it, disable it or create your own component.
+> Nuxt.js uses its own component to show a progress bar between the routes. You can customize it, disable it or create your own component.
 
 ## Disable the Progress Bar
 
 - Type: `Boolean`
 
-If you don't want to display the progress bar between the routes, simply add `loading: false` in your `nuxt.config.js` file:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>If you don't want to display the progress bar between the routes, simply add `loading: false` in your `nuxt.config.js` file:</p>
 
 ```js
 module.exports = {
@@ -33,6 +33,7 @@ List of properties to customize the progress bar.
 | `failedColor` | String | `'red'` | CSS color of the progress bar when an error appended while rendering the route (if `data` or `fetch` sent back an error for example). |
 | `height` | String | `'2px'` | Height of the progress bar (used in the `style` property of the progress bar) |
 | `duration` | Number | `5000` | In ms, the maximum duration of the progress bar, Nuxt.js assumes that the route will be rendered before 5 seconds. |
+| `rtl` | Boolean | `false` | Set the direction of the progress bar from right to left. |
 
 For a blue progress bar with 5px of height, we update the `nuxt.config.js` to the following:
 
@@ -104,6 +105,6 @@ Then, we update our `nuxt.config.js` to tell Nuxt.js to use our component:
 
 ```js
 module.exports = {
-  loading: '~components/loading.vue'
+  loading: '~/components/loading.vue'
 }
 ```

--- a/fr/api/configuration-mode.md
+++ b/fr/api/configuration-mode.md
@@ -1,0 +1,15 @@
+---
+title: "API: The mode Property"
+description: Change default nuxt mode
+---
+
+# The mode Property (En)
+- Type: `string`
+  - Default: `universal`
+  - Possible values:
+    - `'spa'`: No server-side rendering (only client-side navigation)
+    - `'universal'`: Isomorphic application (server-side rendering + client-side navigation)
+
+> You can use this option to change default nuxt mode for your project using `nuxt.config.js`
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/api/configuration-modules.md
+++ b/fr/api/configuration-modules.md
@@ -1,0 +1,41 @@
+---
+title: "API: The modules Property"
+description: Modules are Nuxt.js extensions which can extend it's core functionality and add endless integrations.
+---
+
+# The *modules* Property (En)
+
+- Type: `Array`
+
+> Modules are Nuxt.js extensions which can extend it's core functionality and add endless integrations.  [Learn More](/guide/modules)
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Example (`nuxt.config.js`):</p>
+
+```js
+module.exports = {
+  modules: [
+    // Using package name
+    '@nuxtjs/axios',
+
+    // Relative to your project srcDir
+    '~/modules/awesome.js',
+
+    // Providing options
+    ['@nuxtjs/google-analytics', { ua: 'X1234567' }],
+
+    // Inline definition
+    function () { }
+  ]
+}
+```
+Module developers usually provide additional needed steps and details for usage.
+
+Nuxt.js tries to resolve each item in the modules array using node require path (in the `node_modules`) and then
+Will be resolved from project `srcDir` if `~` alias is used. Modules are executed sequential so the order is important.
+
+Modules should export a function to enhance nuxt build/runtime and optionally return a promise until their job is finished.
+Note that they are required at runtime so should be already transpiled if depending on modern ES6 features.
+
+
+Please see [Modules Guide](/guide/modules) for more detailed information on how they work or if interested developing your own module.
+Also we have provided an official [Modules](/modules) Section listing dozens of production ready modules made by Nuxt Community.

--- a/fr/api/configuration-plugins.md
+++ b/fr/api/configuration-plugins.md
@@ -3,22 +3,22 @@ title: "API: The plugins Property"
 description: Use vue.js plugins with the plugins option of nuxt.js.
 ---
 
-# The plugins Property
+# The plugins Property (En)
 
 - Type: `Array`
   - Items: `String` or `Object`
 
-If the item is an object, the properties are:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>If the item is an object, the properties are:</p>
+
   - src: `String` (path of the file)
   - ssr: `Boolean` (default to `true`) *If false, the file will be included only on the client-side.*
-
 
 > The plugins property lets you add vue.js plugins easily to your main application.
 
 Example (`nuxt.config.js`):
 ```js
 module.exports = {
-  plugins: ['~plugins/vue-notifications']
+  plugins: ['~/plugins/vue-notifications']
 }
 ```
 

--- a/fr/api/configuration-render.md
+++ b/fr/api/configuration-render.md
@@ -1,0 +1,71 @@
+---
+title: "API: The render Property"
+description: Nuxt.js lets you customize runtime options for rendering pages
+---
+
+# The render Property (En)
+
+> Nuxt.js lets you customize runtime options for rendering pages
+
+## bundleRenderer
+- Type: `object`
+
+> Use this option to customize vue SSR bundle renderer. This option is skipped for spa mode.
+
+```js
+module.exports = {
+  render: {
+    bundleRenderer: {
+      directives: {
+        custom1: function (el, dir) {
+          // something ...
+        }
+      }
+    }
+  }
+}
+```
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Learn more about available options on [Vue SSR API Reference](https://ssr.vuejs.org/en/api.html#renderer-options).
+It is recommended to not use this option as Nuxt.js is already providing best SSR defaults and misconfiguration might lead to SSR problems.</p>
+
+## etag
+- Type: `object`
+  - Default: `{ weak: true }`
+
+See [etag](https://www.npmjs.com/package/etag) docs for possible options.
+
+### gzip
+- Type `object`
+  - Default: `{ threshold: 0 }`
+
+See [compression](https://www.npmjs.com/package/compression) docs for possible options.
+
+### http2
+- Type `object`
+  - Default: `{ push: false }`
+
+Activate HTTP2 push headers.
+
+## resourceHints
+- Type: `boolean`
+  - Default: `true`
+
+> Adds `prefetch` and `preload` links for faster initial page load time.
+
+You may want to only disable this option if have many pages and routes. 
+
+## ssr
+- Type: `boolean`
+  - Default: `true` on universal mode and `false` on spa mode
+
+> Enable SSR rendering
+
+This option is automatically set based on `mode` value if not provided. 
+This can be useful to dynamically enable/disable SSR on runtime after image builds. (With docker for example)
+
+## static
+- Type: `object`
+  - Default: `{}`
+
+See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible options.

--- a/fr/api/configuration-rootdir.md
+++ b/fr/api/configuration-rootdir.md
@@ -3,14 +3,14 @@ title: "API: The rootDir Property"
 description: Define the workspace of nuxt.js application
 ---
 
-# The rootDir Property
+# The rootDir Property (En)
 
 - Type: `String`
 - Default: `process.cwd()`
 
 > Define the workspace of your nuxt.js application.
 
-This property is overwritten by [nuxt commands](/guide/commands) and set to the argument of the command (example: `nuxt my-app/` will set the `rootDir` to `my-app/` with its absolute path).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This property is overwritten by [nuxt commands](/guide/commands) and set to the argument of the command (example: `nuxt my-app/` will set the `rootDir` to `my-app/` with its absolute path).</p>
 
 This property should be used when using [nuxt.js programmatically](/api/nuxt).
 

--- a/fr/api/configuration-router.md
+++ b/fr/api/configuration-router.md
@@ -3,7 +3,7 @@ title: "API: The router Property"
 description: The router property lets you customize nuxt.js router.
 ---
 
-# The router Property
+# The router Property (En)
 
 > The router property lets you customize nuxt.js router ([vue-router](https://router.vuejs.org/en/)).
 
@@ -12,7 +12,7 @@ description: The router property lets you customize nuxt.js router.
 - Type: `String`
 - Default: `'/'`
 
-The base URL of the app. For example, if the entire single page application is served under `/app/`, then base should use the value `'/app/'`.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>The base URL of the app. For example, if the entire single page application is served under `/app/`, then base should use the value `'/app/'`.</p>
 
 Example (`nuxt.config.js`):
 ```js
@@ -27,23 +27,30 @@ module.exports = {
 
 > This option is given directly to the vue-router [Router constructor](https://router.vuejs.org/en/api/options.html).
 
-## mode
+## extendRoutes
 
-- Type: `String`
-- Default: `'history'`
+- Type: `Function`
 
-Configure the router mode, this is not recommended to change it due to server-side rendering.
+You may want to extend the routes created by nuxt.js. You can do it via the `extendRoutes` option.
 
-Example (`nuxt.config.js`):
+Example of adding a custom route:
+
+`nuxt.config.js`
 ```js
 module.exports = {
   router: {
-    mode: 'hash'
+    extendRoutes (routes, resolve) {
+      routes.push({
+        name: 'custom',
+        path: '*',
+        component: resolve(__dirname, 'pages/404.vue')
+      })
+    }
   }
 }
 ```
 
-> This option is given directly to the vue-router [Router constructor](https://router.vuejs.org/en/api/options.html).
+The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.
 
 ## linkActiveClass
 
@@ -80,6 +87,53 @@ module.exports = {
 ```
 
 > This option is given directly to the [vue-router Router constructor](https://router.vuejs.org/en/api/options.html).
+
+## middleware
+
+- Type: `String` or `Array`
+  - Items: `String`
+
+Set the default(s) middleware for every pages of the application.
+
+Example:
+
+`nuxt.config.js`
+```js
+module.exports = {
+  router: {
+    // Run the middleware/user-agent.js on every pages
+    middleware: 'user-agent'
+  }
+}
+```
+
+`middleware/user-agent.js`
+```js
+export default function (context) {
+  // Add the userAgent property in the context (available in `data` and `fetch`)
+  context.userAgent = context.isServer ? context.req.headers['user-agent'] : navigator.userAgent
+}
+```
+
+To learn more about the middleware, see the [middleware guide](/guide/routing#middleware).
+
+## mode
+
+- Type: `String`
+- Default: `'history'`
+
+Configure the router mode, this is not recommended to change it due to server-side rendering.
+
+Example (`nuxt.config.js`):
+```js
+module.exports = {
+  router: {
+    mode: 'hash'
+  }
+}
+```
+
+> This option is given directly to the vue-router [Router constructor](https://router.vuejs.org/en/api/options.html).
 
 ## scrollBehavior
 
@@ -127,57 +181,3 @@ module.exports = {
 ```
 
 > This option is given directly to the vue-router [Router constructor](https://router.vuejs.org/en/api/options.html).
-
-## middleware
-
-- Type: `String` or `Array`
-  - Items: `String`
-
-Set the default(s) middleware for every pages of the application.
-
-Example:
-
-`nuxt.config.js`
-```js
-module.exports = {
-  router: {
-    // Run the middleware/user-agent.js on every pages
-    middleware: 'user-agent'
-  }
-}
-```
-
-`middleware/user-agent.js`
-```js
-export default function (context) {
-  // Add the userAgent property in the context (available in `data` and `fetch`)
-  context.userAgent = context.isServer ? context.req.headers['user-agent'] : navigator.userAgent
-}
-```
-
-To learn more about the middleware, see the [middleware guide](/guide/routing#middleware).
-
-## extendRoutes
-
-- Type: `Function`
-
-You may want to extend the routes created by nuxt.js. You can do it via the `extendRoutes` option.
-
-Example of adding a custom route:
-
-`nuxt.config.js`
-```js
-module.exports = {
-  router: {
-    extendRoutes (routes, resolve) {
-      routes.push({
-        name: 'custom',
-        path: '*',
-        component: resolve(__dirname, 'pages/404.vue')
-      })
-    }
-  }
-}
-```
-
-The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.

--- a/fr/api/configuration-servermiddleware.md
+++ b/fr/api/configuration-servermiddleware.md
@@ -1,0 +1,78 @@
+---
+title: "API: The serverMiddleware Property"
+description: Define server-side middleware.
+---
+
+# The serverMiddleware Property (En)
+
+- Type: `Array`
+    - Items: `String` or `Object` or `Function`
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Nuxt internally creates a [connect](https://github.com/senchalabs/connect) instance,
+so we can register our middleware to it's stack and having chance
+to provide more routes like API **without need to an external server**.
+Because connect itself is a middleware, registered middleware will work with both `nuxt start` 
+and also when used as a middleware with programmatic usages like [express-template](github.com/nuxt-community/express-template).
+Nuxt [Modules](/guide/modules) can also provide `serverMiddleware`
+using [this.addServerMiddleware()](/api/internals-module-container#addservermiddleware-middleware-)</p>
+
+## serverMiddleware vs middleware!
+Don't confuse it with [routes middleware](/guide/routing#middleware) which are being called before each route by Vue in Client Side or SSR.
+`serverMiddleware` are just running in server side **before** vue-server-renderer and can be used for server specific tasks
+like handling API requests or serving assets.
+
+## Usage
+
+If middleware is String Nuxt.js will try to automatically resolve and require it. 
+
+Example (`nuxt.config.js`):
+
+```js
+const serveStatic = require('serve-static')
+
+module.exports = {
+  serverMiddleware: [
+      // Will register redirect-ssl npm package
+      'redirect-ssl',
+
+      // Will register file from project api directory to handle /api/* requires
+      { path: '/api', handler: '~/api/index.js' },
+
+      // We can create custom instances too
+      { path: '/static2', handler: serveStatic(__dirname + '/static2') }
+  ]
+}
+```
+
+<p class="Alert Alert--danger">
+    <b>HEADS UP! </b>
+    If you don't want middleware to register for all routes you have to use Object form with specific path,
+    otherwise nuxt default handler won't work!
+</p>
+
+## Custom Server Middleware
+
+It is also possible writing custom middleware. For more information See [Connect Docs](https://github.com/senchalabs/connect#appusefn).
+
+Middleware (`api/logger.js`):
+
+```js
+module.exports = function (req, res, next) {
+    // req is the Node.js http request object
+    console.log(req.path)
+    
+    // res is the Node.js http response object
+
+    // next is a function to call to invoke the next middleware
+    // Don't forget to call next at the end if your middleware is not an endpoint!
+    next()
+}
+```
+
+Nuxt Config (`nuxt.config.js`):
+
+```js
+serverMiddleware: [
+    '~/api/logger'
+]
+```

--- a/fr/api/configuration-srcdir.md
+++ b/fr/api/configuration-srcdir.md
@@ -3,14 +3,14 @@ title: "API: The srcDir Property"
 description: Define the source directory of your nuxt.js application
 ---
 
-# The srcDir Property
+# The srcDir Property (En)
 
 - Type: `String`
 - Default: [rootDir value](/api/configuration-rootdir)
 
 > Define the source directory of your nuxt.js application
 
-Example (`nuxt.config.js`):
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Example (`nuxt.config.js`):</p>
 
 ```js
 module.exports = {

--- a/fr/api/configuration-transition.md
+++ b/fr/api/configuration-transition.md
@@ -1,15 +1,15 @@
 ---
 title: "API: The transition Property"
-description: Set the default properties of the pages transitions.
+description: Set the default properties of the page transitions.
 ---
 
-# The transition Property
+# The transition Property (En)
 
 - Type: `String` or `Object`
 
-> Used to set the default properties of the pages transitions.
+> Used to set the default properties of the page transitions.
 
-Default:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Default:</p>
 ```js
 {
   name: 'page',
@@ -33,4 +33,4 @@ module.exports = {
 }
 ```
 
-The transition key in `nuxt.config.js` is used to set the default properties for the pages transitions. To learn more about the available keys when the `transition` key is an object, see the [pages transition property](/api/pages-transition#object).
+The transition key in `nuxt.config.js` is used to set the default properties for the page transitions. To learn more about the available keys when the `transition` key is an object, see the [pages transition property](/api/pages-transition#object).

--- a/fr/api/configuration-watchers.md
+++ b/fr/api/configuration-watchers.md
@@ -3,7 +3,7 @@ title: "API: The watchers Property"
 description: The watchers property lets you overwrite watchers configuration.
 ---
 
-# The watchers Property
+# The watchers Property (En)
 
 - Type: `Object`
 - Default: `{}`
@@ -15,10 +15,9 @@ description: The watchers property lets you overwrite watchers configuration.
 - Type: `Object`
 - Default: `{}`
 
-To learn more about chokidar options, see the [chokidar API](https://github.com/paulmillr/chokidar#api).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>To learn more about chokidar options, see the [chokidar API](https://github.com/paulmillr/chokidar#api).</p>
 
 ## webpack
-
 
 - Type: `Object`
 - Default:

--- a/fr/api/context.md
+++ b/fr/api/context.md
@@ -1,0 +1,28 @@
+---
+title: "API: The Context"
+description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`. 
+---
+
+## Context (En)
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>List of all the available keys in `context`:</p>
+
+| Key | Type | Available | Description |
+|-----|------|--------------|-------------|
+| `app` | Root Vue Instance | Client & Server | The root vue instance that includes all your plugins. For example, when using `axios`, you can get access to `$axios` through `context.app.$axios`
+| `isClient` | Boolean | Client & Server | Boolean to let you know if you're actually renderer from the client-side |
+| `isServer` | Boolean | Client & Server | Boolean to let you know if you're actually renderer from the server-side |
+| `isStatic` | Boolean | Client & Server | Boolean to let you know if you're actually inside a generated app (via `nuxt generate`) |
+| `isDev` | Boolean | Client & Server | Boolean to let you know if you're in dev mode, can be useful for caching some data in production |
+| `isHMR` | Boolean | Client & Server | Boolean to let you know if you're the method/middleware is called from webpack hot module replacement (*only on client-side in dev mode*) |
+| `route` | [vue-router route](https://router.vuejs.org/en/api/route-object.html) | Client & Server | `vue-router` route instance. |
+| `store` | [vuex store](http://vuex.vuejs.org/en/api.html#vuexstore-instance-properties) | Client & Server | `Vuex.Store` instance. **Available only if the [vuex store](/guide/vuex-store) is set** |
+| `env` | Object | Client & Server | Environment variables set in `nuxt.config.js`, see [env api](/api/configuration-env)  |
+| `params` | Object | Client & Server | Alias of route.params |
+| `query` | Object | Client & Server | Alias of route.query |
+| `req` | [http.Request](https://nodejs.org/api/http.html#http_class_http_incomingmessage) | Server | Request from the node.js server. If nuxt is used as a middleware, the req object might be different depending of the framework you're using.<br>**Not available via `nuxt generate`** |
+| `res` | [http.Response](https://nodejs.org/api/http.html#http_class_http_serverresponse) | Server | Response from the node.js server. If nuxt is used as a middleware, the res object might be different depending of the framework you're using.<br>**Not available via `nuxt generate`** |
+| `redirect` | Function | Client & Server | Use this method to redirect the user to another route, the status code is used on the server-side, default to 302. `redirect([status,] path [, query])` |
+| `error` | Function | Client & Server | Use this method to show the error page: `error(params)`. The `params` should have the fields `statusCode` and `message` |
+| `nuxtState` | Object | Client | Nuxt state, useful for plugins which uses `beforeNuxtRender` to get the nuxt state on client-side before hydration. **Available only in `universal` mode.** 
+| `beforeNuxtRender(fn)` | Function | Server | Use this method to update `__NUXT__` variable rendered on client-side, the `fn` (can be asynchronous) is called with `{ Components, nuxtState }`, see [example](https://github.com/nuxt/nuxt.js/blob/cf6b0df45f678c5ac35535d49710c606ab34787d/test/fixtures/basic/pages/special-state.vue).  |

--- a/fr/api/index.md
+++ b/fr/api/index.md
@@ -1,17 +1,18 @@
 ---
-title: "API: La méthode asyncData"
-description: Vous voudrez peut-être récupérer des données et faire le rendu côté serveur. Nuxt.js ajoute une méthode `asyncData` vous permettant de gérer des opérations asynchrones avant de définir les données du composant.
+title: "API: The asyncData Method"
+description: You may want to fetch data and render it on the server-side. Nuxt.js add an `asyncData` method let you handle async operation before setting the component data.
 ---
 
-# La méthode asyncData
+# The asyncData Method (En)
 
-> Vous voudrez peut-être récupérer des données et faire le rendu côté serveur. Nuxt.js ajoute une méthode `asyncData` vous permettant de gérer des opérations asynchrones avant de définir les données du composant.
+> You may want to fetch data and render it on the server-side.
+Nuxt.js add an `asyncData` method let you handle async operation before setting the component data.
 
 - **Type:** `Function`
 
-`asyncData` est appelée avant chaque chargement de composant (**uniquement pour les composants pages**). Elle peut être appelée côté serveur ou avant de nvaiguer sur la route correspondante. Cette méthode reçoit le **context** (objet) comme premier argument; vous pouvez l'utiliser afin de récupérer des données et retourner les données du composant.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>`asyncData` is called every time before loading the component (**only for pages components**). It can be called from the server-side or before navigating to the corresponding route. This method receives the [context](/api/context) (object) as the first argument, you can use it to fetch some data and return the component data.</p>
 
-Le résultat d'asyncData sera **mergé** avec les données.
+The result from asyncData will be **merged** with data.
 
 ```js
 export default {
@@ -24,23 +25,4 @@ export default {
 }
 ```
 
-<div class="Alert Alert--orange">Vous **n'avez pas** accès à l'instance du composant via `this` au sein de `data` parce que la fonciton est appelée **avant d'initialiser** le composant.</div>
-
-## Context
-
-Liste des key disponibles dans `context`:
-
-| Key | Type | Disponibilité | Description |
-|-----|------|--------------|-------------|
-| `isClient` | Boolean | Client & Serveur | Booléen vous permettant de savoir si vous faites le rendu côté client |
-| `isServer` | Boolean | Client & Serveur | Booléen vous permettant de savoir si vous faites le rendu côté serveur |
-| `isDev` | Boolean | Client & Serveur | Booléen vous permettan de savoir si vous êtes en mode dev, peut être utile pour cacher certaines données en production |
-| `route` | [vue-router route](https://router.vuejs.org/en/api/route-object.html) | Client & Server | `vue-router` route instance. |
-| `store` | [vuex store](http://vuex.vuejs.org/en/api.html#vuexstore-instance-properties) | Client & Server | `Vuex.Store` instance. **Disponible uniquement si [vuex store](/guide/vuex-store) est configuré.** |
-| `env` | Object | Client & Serveur | Variables d'environnement configurées dans `nuxt.config.js`, voir [env api](/api/configuration-env)  |
-| `params` | Object | Client & Serveur | Alias de route.params |
-| `query` | Object | Client & Serveur | Alias de route.query |
-| `req` | [http.Request](https://nodejs.org/api/http.html#http_class_http_incomingmessage) | Serveur | Requête du serveur node.js. Si nuxt est utilisé comme middleware, l'objet req pourrait être différent en fonction du framework que vous utilisez. **Non disponible via `nuxt generate`*. |
-| `res` | [http.Response](https://nodejs.org/api/http.html#http_class_http_serverresponse) | Serveur | Réponse du serveur node.js. Si nuxt est utilisé comme middleware, l'bjet res pourrait être différent en fonction du framework que vous utilisez. **Non disponible via `nuxt generate`*. |
-| `redirect` | Function | Client & Serveur | Utilisez cette méthode pour rediriger l'utilisateur d'une route à une autre; le code de statut utilisé côté serveur par défaut est 302. `redirect([status,] path [, query])` |
-| `error` | Function | Client & Serveur | Utilisez cette méthode pour afficher la page d'erreur: `error(params)`. `params` devrait avoir les champs `statusCode` et `message`. |
+<div class="Alert Alert--orange">You do **NOT** have access of the component instance through `this` inside `asyncData` because it is called **before initiating** the component.</div>

--- a/fr/api/internals-builder.md
+++ b/fr/api/internals-builder.md
@@ -1,0 +1,31 @@
+---
+title: "API: The Builder Class"
+description: Nuxt Builder Class
+---
+
+# Builder Class (En)
+
+- Source: **[builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/builder.js)**
+
+
+## Tapable plugins
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>We can register hooks on certain life cycle events.</p>
+
+```js
+nuxt.plugin('build', builder => {
+    builder.plugin('extendRoutes', async ({routes}) =>  {
+        // ...
+    })
+})
+```
+
+Plugin               | Arguments                               | When
+---------------------|-----------------------------------------|--------------------------------------------------------------------------------
+`build`              | builder                                 | First build started
+`built`              | builder                                 | First build finished
+`extendRoutes`       | {routes, templateVars, r}               | Generating routes
+`generate`           | {builder, templatesFiles, templateVars} | Generating `.nuxt` template files
+`done`               | {builder, stats}                        | Webpack build was done
+`compile`            | {builder, compiler}                     | Before webpack compile (compiler is a MultiCompiler instance)
+`compiled`           | builder                                 | Webpack build finished

--- a/fr/api/internals-generator.md
+++ b/fr/api/internals-generator.md
@@ -1,0 +1,26 @@
+---
+title: "API: The Generator Class"
+description: Nuxt Generator Class
+---
+
+# Generator Class (En)
+
+- Source: **[builder/generator.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/generator.js)**
+
+
+## Tapable plugins
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>We can register hooks on certain life cycle events.</p>
+
+```js
+nuxt.plugin('generator', generator => {
+    generator.plugin('generate', ({routes}) => {
+        // ...
+    }))
+})
+```
+
+Plugin               | Arguments                               | When
+---------------------|-----------------------------------------|--------------------------------------------------------------------------------
+`generateRoutes`     | {generator, generateRoutes}             | After resolving routes to generate so we have change to customize them
+`generate`           | {generator, routes}                     | Just before start generating routes. routes are decorated with payloads

--- a/fr/api/internals-module-container.md
+++ b/fr/api/internals-module-container.md
@@ -1,0 +1,76 @@
+---
+title: "API: The ModuleContainer Class"
+description: Nuxt ModuleContainer Class
+---
+
+# ModuleContainer Class (En)
+
+- Source: **[core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/core/module.js)**
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>All [modules](/guide/modules) will be called within context of ModuleContainer instance.</p>
+
+## Tapable plugins
+
+We can register hooks on certain life cycle events.
+
+```js
+nuxt.moduleContainer.plugin('ready', async moduleContainer => {
+    // Do this after all modules where ready
+})
+```
+
+Inside [modules](/guide/modules) context we can use this instead:
+
+```js
+this.plugin('ready', async moduleContainer => {
+    // Do this after all modules where ready
+})
+```
+
+Plugin               | Arguments                 | When
+---------------------|---------------------------|--------------------------------------------------------------
+`ready`              | moduleContainuer          | All modules in `nuxt.config.js` has been initialized
+
+
+## Methods
+
+### addVendor (vendor)
+Adds to `options.build.vendor` and apply uniq filter.
+
+### addTemplate (template)
+- **template**: String Or Object
+    - src
+    - options
+    - fileName
+
+Renders given template using [lodash template](https://lodash.com/docs/4.17.4#template) during build into project `buildDir` (`.nuxt`).
+
+If `fileName` is not provided or template is string, target file name defaults to `[dirName].[fileName].[pathHash].[ext]`
+
+This method returns final `{ dist, src, options }` object.
+
+### addPlugin (template)
+
+Registers a plugin using `addTemplate` and adds it to first of `plugins[]` option.
+You can use `template.ssr: false` to disable plugin including in SSR bundle.
+
+### addServerMiddleware (middleware)
+
+Pushes middleware into [options.serverMiddleware](/api/configuration-servermiddleware). 
+
+### extendBuild (fn)
+
+Allows easily extending webpack build config by chaining [options.build.extend](/api/configuration-build#extend) function.
+
+### extendRoutes (fn)
+
+Allows easily extending routes by chaining [options.build.extendRoutes](/api/configuration-router#extendroutes) function.
+
+### addModule (moduleOpts, requireOnce) 
+
+Registers module. moduleOpts can be string or `[src, options]`.
+If `requireOnce` is `true` and resolved module exports `meta` prevents registering same module twice.
+
+### requireModule (moduleOpts)
+
+Is shortcut to `addModule(moduleOpts, true)`

--- a/fr/api/internals-nuxt.md
+++ b/fr/api/internals-nuxt.md
@@ -1,0 +1,28 @@
+---
+title: "API: The Nuxt Class"
+description: Nuxt Core Class
+---
+
+# Nuxt Class (En)
+
+- Source: **[core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/core/nuxt.js)**
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This is the core container which allows all modules and classes communicate with each other. 
+All modules has access to nuxt instance using `this.nuxt`.</p>
+
+## Tapable plugins
+
+We can register hooks on certain life cycle events.
+
+```js
+nuxt.plugin('ready', async nuxt => {
+    // Your custom code here
+})
+```
+
+Plugin        | Arguments              | When
+--------------|------------------------|--------------------------------------------------------------------------------
+`ready`       | nuxt                   | All modules initialized and before initializing renderer
+`error`       | error args             | An unhandled error by one of nuxt modules caught
+`close`       | -                      | Nuxt instance is gracefully closing
+`listen`      | ({server, host, port}) | Nuxt **Internal** server starts listening. (Using `nuxt start` or `nuxt dev`)

--- a/fr/api/internals-renderer.md
+++ b/fr/api/internals-renderer.md
@@ -1,0 +1,27 @@
+---
+title: "API: The Renderer Class"
+description: Nuxt Renderer Class
+---
+
+# Renderer Class (En)
+
+- Source: **[core/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/core/renderer.js)**
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This class is exporting a connect middleware which handles and serves all SSR and asset requests.</p>
+
+## Tapable plugins
+
+We can register hooks on certain life cycle events.
+
+```js
+nuxt.plugin('renderer', renderer => {
+    renderer.plugin('setupMiddleware', app => {
+        // 
+    })
+})
+```
+
+Plugin               | Arguments                 | When
+---------------------|---------------------------|--------------------------------------------------------------------------------
+`ready`              | renderer                  | SSR Middleware and all resources are ready
+`setupMiddleware`    | connect instance (app)    | Before nuxt adds it's middleware stack. We can use it to register custom server side middleware.

--- a/fr/api/internals.md
+++ b/fr/api/internals.md
@@ -1,0 +1,104 @@
+---
+title: "API: Nuxt Modules Intro"
+description: Better understand Nuxt internals
+---
+
+# Nuxt Internals (En)
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Nuxt.js has a fully modular architecture which allows developers extending any part of Nuxt Core using a flexible API.
+Please see [Modules Guide](/guide/modules) for more detailed information if interested developing your own module. 
+This section helps getting familiar to Nuxt internals and can be used as a reference to understand it better while writing your own modules.</p>
+
+### Core
+
+These classes are the hearth of Nuxt and should exist on both runtime and build time.
+
+#### Nuxt
+
+- [Nuxt Class](/api/internals-nuxt)
+- Source: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/core/nuxt.js)
+
+#### Renderer
+
+- [Renderer Class](/api/internals-renderer)
+- Source: [core/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/core/renderer.js)
+
+#### Module Container
+
+- [ModuleContainer Class](/api/internals-module-container)
+- Source: [core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/core/module.js)
+
+### Build
+
+These classes are only needed for build or dev mode.
+
+### Builder
+
+- [Builder Class](/api/internals-builder)
+- Source: [builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/builder.js)
+
+#### Generator
+
+- [Generator Class](/api/internals-generator)
+- Source: [generator/generator.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/generator.js)
+
+### Common
+
+#### Utils
+
+- Source: [common/utils.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/common/utils.js)
+
+#### Options
+
+- Source: [common/options.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/common/options.js)
+
+
+## Packaging & Usage
+
+Nuxt exports all classes by default. To require them:
+
+```js
+const { Nuxt, Builder, Utils } = require('nuxt')
+```
+
+## Common patterns
+
+All Nuxt classes have a reference to nuxt instance and options. Every class extends [`tappable`](https://github.com/nuxt/tappable), this way we always have a consistent API across classes to access options and nuxt.
+
+```js
+const Tapable = require('tappable')
+
+class SomeClass extends Tapable {
+  constructor (nuxt, builder) {
+    super()
+    this.nuxt = nuxt
+    this.options = nuxt.options
+  }
+
+  someFunction() {
+    // We have access to this.nuxt and this.options
+  }
+}
+```
+
+Classes are *plugable* so they should register a plugin on main nuxt container to register more hooks.
+
+```js
+class FooClass extends Tapable {
+  constructor (nuxt, builder) {
+    super()
+    this.nuxt = nuxt
+    this.options = nuxt.options
+
+    this.nuxt.applyPluginsAsync('foo', this)
+  }
+}
+```
+
+So we can hook into foo module like this:
+
+```js
+nuxt.plugin('foo', foo => {
+    // ...
+})
+```

--- a/fr/api/menu.json
+++ b/fr/api/menu.json
@@ -1,115 +1,141 @@
 [
   {
-    "title": "Pages",
+    "title": "Essentiel",
     "links": [
-      { "name": "asyncData", "to": "/" },
-      { "name": "fetch", "to": "/pages-fetch" },
-      { "name": "head", "to": "/pages-head" },
-      { "name": "layout", "to": "/pages-layout" },
-      { "name": "middleware", "to": "/pages-middleware" },
-      { "name": "scrollToTop", "to": "/pages-scrolltotop" },
-      {
-        "name": "transition", "to": "/pages-transition",
-        "contents": [
-          { "name": "String", "to": "#string" },
-          { "name": "Objet", "to": "#objet" },
-          { "name": "Fonction", "to": "#fonction" }
-        ]
-      },
-      { "name": "validate", "to": "/pages-validate" }
+      { "name": "Context (En)", "to": "/context" }
     ]
   },
   {
-    "title": "Components",
+    "title": "Pages",
     "links": [
-      { "name": "nuxt", "to": "/components-nuxt" },
-      { "name": "nuxt-child", "to": "/components-nuxt-child" },
-      { "name": "nuxt-link", "to": "/components-nuxt-link" }
+      { "name": "asyncData (En)", "to": "/" },
+      { "name": "fetch (En)", "to": "/pages-fetch" },
+      { "name": "head (En)", "to": "/pages-head" },
+      { "name": "layout (En)", "to": "/pages-layout" },
+      { "name": "middleware (En)", "to": "/pages-middleware" },
+      { "name": "scrollToTop (En)", "to": "/pages-scrolltotop" },
+      {
+        "name": "transition (En)", "to": "/pages-transition",
+        "contents": [
+          { "name": "String (En)", "to": "#string" },
+          { "name": "Object (En)", "to": "#object" },
+          { "name": "Function (En)", "to": "#function" }
+        ]
+      },
+      { "name": "validate (En)", "to": "/pages-validate" }
+    ]
+  },
+  {
+    "title": "Composants",
+    "links": [
+      { "name": "nuxt (En)", "to": "/components-nuxt" },
+      { "name": "nuxt-child (En)", "to": "/components-nuxt-child" },
+      { "name": "nuxt-link (En)", "to": "/components-nuxt-link" }
     ]
   },
   {
     "title": "Configuration",
     "links": [
       {
-        "name": "build",
-        "to": "/configuration-build",
+        "name": "build (En)", "to": "/configuration-build",
         "contents": [
-          { "name": "analyze", "to": "#analyze" },
-          { "name": "babel", "to": "#babel" },
-          { "name": "extend", "to": "#extend" },
-          { "name": "filenames", "to": "#filenames" },
-          { "name": "loaders", "to": "#loaders" },
-          { "name": "plugins", "to": "#plugins" },
-          { "name": "postcss", "to": "#postcss" },
-          { "name": "publicPath", "to": "#publicpath" },
-          { "name": "vendor", "to": "#vendor" }
+          { "name": "analyze (En)", "to": "#analyze" },
+          { "name": "babel (En)", "to": "#babel" },
+          { "name": "cssSourceMap (En)", "to": "#css-source-map" },
+          { "name": "devMiddleware (En)", "to": "#devmiddleware" },
+          { "name": "extend (En)", "to": "#extend" },
+          { "name": "extractCSS (En)", "to": "#extractcss" },
+          { "name": "filenames (En)", "to": "#filenames" },
+          { "name": "hotMiddleware (En)", "to": "#hot-middleware" },
+          { "name": "plugins (En)", "to": "#plugins" },
+          { "name": "postcss (En)", "to": "#postcss" },
+          { "name": "publicPath (En)", "to": "#publicpath" },
+          { "name": "ssr (En)", "to": "#ssr" },
+          { "name": "templates (En)", "to": "#templates" },
+          { "name": "vendor (En)", "to": "#vendor" },
+          { "name": "watch (En)", "to": "#watch" }
         ]
       },
-      { "name": "cache", "to": "/configuration-cache" },
-      { "name": "css", "to": "/configuration-css" },
-      { "name": "dev", "to": "/configuration-dev" },
-      { "name": "env", "to": "/configuration-env" },
+      { "name": "css (En)", "to": "/configuration-css" },
+      { "name": "dev (En)", "to": "/configuration-dev" },
+      { "name": "env (En)", "to": "/configuration-env" },
       {
-        "name": "generate",
-        "to": "/configuration-generate",
+        "name": "generate (En)", "to": "/configuration-generate",
         "contents": [
-          { "name": "dir", "to": "#dir" },
-          { "name": "interval", "to": "#interval" },
-          { "name": "minify", "to": "#minify" },
-          { "name": "routes", "to": "#routes" }
+          { "name": "dir (En)", "to": "#dir" },
+          { "name": "interval (En)", "to": "#interval" },
+          { "name": "minify (En)", "to": "#minify" },
+          { "name": "routes (En)", "to": "#routes" }
         ]
       },
-      { "name": "head", "to": "/configuration-head" },
+      { "name": "head (En)", "to": "/configuration-head" },
       {
-        "name": "loading",
-        "to": "/configuration-loading",
+        "name": "loading (En)", "to": "/configuration-loading",
         "contents": [
-          { "name": "Disable the Progress Bar", "to": "#disable-the-progress-bar" },
-          { "name": "Customize the Progress Bar", "to": "#customize-the-progress-bar" },
-          { "name": "Use a Custom Loading Component", "to": "#use-a-custom-loading-component" }
+          { "name": "Disable the Progress Bar (En)", "to": "#disable-the-progress-bar" },
+          { "name": "Customize the Progress Bar (En)", "to": "#customize-the-progress-bar" },
+          { "name": "Use a Custom Loading Component (En)", "to": "#use-a-custom-loading-component" }
         ]
       },
+      { "name": "loadingIndicator (En)", "to": "/configuration-loading-indicator" },
+      { "name": "mode (En)", "to": "/configuration-mode" },
+      { "name": "modules (En)", "to": "/configuration-modules" },
+      { "name": "plugins (En)", "to": "/configuration-plugins" },
       {
-        "name": "performance",
-        "to": "/configuration-performance",
+        "name": "render (En)", "to": "/configuration-render",
         "contents": [
-          { "name": "gzip", "to": "#gzip" },
-          { "name": "prefetch", "to": "#prefetch" }
+          { "name": "bundleRenderer (En)", "to": "#bundleRenderer" },
+          { "name": "etag (En)", "to": "#etag" },
+          { "name": "gzip (En)", "to": "#gzip" },
+          { "name": "http2 (En)", "to": "#http2" },
+          { "name": "resourceHints (En)", "to": "#resourceHints" },
+          { "name": "ssr (En)", "to": "#ssr" },
+          { "name": "static (En)", "to": "#static" }
         ]
       },
-      { "name": "plugins", "to": "/configuration-plugins" },
-      { "name": "rootDir", "to": "/configuration-rootdir" },
+      { "name": "rootDir (En)", "to": "/configuration-rootdir" },
       {
-        "name": "router",
-        "to": "/configuration-router",
+        "name": "router (En)", "to": "/configuration-router",
         "contents": [
-          { "name": "base", "to": "#base" },
-          { "name": "mode", "to": "#mode" },
-          { "name": "linkActiveClass", "to": "#linkactiveclass" },
-          { "name": "scrollBehavior", "to": "#scrollbehavior" },
-          { "name": "middleware", "to": "#middleware" },
-          { "name": "extendRoutes", "to": "#extendroutes" }
+          { "name": "base (En)", "to": "#base" },
+          { "name": "extendRoutes (En)", "to": "#extendroutes" },
+          { "name": "linkActiveClass (En)", "to": "#linkactiveclass" },
+          { "name": "linkExactActiveClass (En)", "to": "#linkexactactiveclass" },
+          { "name": "middleware (En)", "to": "#middleware" },
+          { "name": "mode (En)", "to": "#mode" },
+          { "name": "scrollBehavior (En)", "to": "#scrollbehavior" }
         ]
       },
-      { "name": "srcDir", "to": "/configuration-srcdir" },
-      { "name": "transition", "to": "/configuration-transition" },
+      { "name": "serverMiddleware (En)", "to": "/configuration-servermiddleware" },
+      { "name": "srcDir (En)", "to": "/configuration-srcdir" },
+      { "name": "transition (En)", "to": "/configuration-transition" },
       {
-        "name": "watchers",
-        "to": "/configuration-watchers",
+        "name": "watchers (En)", "to": "/configuration-watchers",
         "contents": [
-          { "name": "chokidar", "to": "#chokidar" },
-          { "name": "webpack", "to": "#webpack" }
+          { "name": "chokidar (En)", "to": "#chokidar" },
+          { "name": "webpack (En)", "to": "#webpack" }
         ]
       }
     ]
   },
   {
-    "title": "Nuxt Module",
+    "title": "Programmation",
     "links": [
-      { "name": "Usage", "to": "/nuxt" },
-      { "name": "render", "to": "/nuxt-render" },
-      { "name": "renderRoute", "to": "/nuxt-render-route" },
-      { "name": "renderAndGetWindow", "to": "/nuxt-render-and-get-window" }
+      { "name": "Usage (En)", "to": "/nuxt" },
+      { "name": "render (En)", "to": "/nuxt-render" },
+      { "name": "renderRoute (En)", "to": "/nuxt-render-route" },
+      { "name": "renderAndGetWindow (En)", "to": "/nuxt-render-and-get-window" }
+    ]
+  },
+  {
+    "title": "Mécanismes",
+    "links": [
+      { "name": "Intro (En)", "to": "/internals" },
+      { "name": "Nuxt (En)", "to": "/internals-nuxt" },
+      { "name": "Renderer (En)", "to": "/internals-renderer" },
+      { "name": "Module Container (En)", "to": "/internals-module-container" },
+      { "name": "Builder (En)", "to": "/internals-builder" },
+      { "name": "Generator (En)", "to": "/internals-generator" }
     ]
   }
 ]

--- a/fr/api/nuxt-render-and-get-window.md
+++ b/fr/api/nuxt-render-and-get-window.md
@@ -3,7 +3,7 @@ title: "API: nuxt.renderAndGetWindow(url, options)"
 description: Get the window from a given url of a nuxt.js application.
 ---
 
-# nuxt.renderAndGetWindow(url, options = {})
+# nuxt.renderAndGetWindow(url, options = {}) (En)
 
 - Type: `Function`
 - Argument: `String`
@@ -17,15 +17,19 @@ description: Get the window from a given url of a nuxt.js application.
 
 <p class="Alert Alert--info">This method is made for [test purposes](guide/development-tools#end-to-end-testing).</p>
 
-To use this function, you have to install `jsdom`:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>To use this function, you have to install `jsdom`:</p>
 ```bash
 npm install --save-dev jsdom
 ```
 
 Example:
 ```js
-const Nuxt = require('nuxt')
-const nuxt = new Nuxt()
+const { Nuxt, Builder } = require('nuxt')
+
+const config = require('./nuxt.config.js')
+config.dev = false
+
+const nuxt = new Nuxt(config)
 
 nuxt.renderAndGetWindow('http://localhost:3000')
 .then((window) => {

--- a/fr/api/nuxt-render-route.md
+++ b/fr/api/nuxt-render-route.md
@@ -3,7 +3,7 @@ title: "API: nuxt.renderRoute(route, context)"
 description: Render a specific route with a given context.
 ---
 
-# nuxt.renderRoute(route, context = {})
+# nuxt.renderRoute(route, context = {}) (En)
 
 - Type: `Function`
 - Arguments:
@@ -16,21 +16,22 @@ description: Render a specific route with a given context.
 
 > Render a specific route with a given context.
 
-This method should be used mostly for [test purposes](/guide/development-tools#end-to-end-testing) as well with [nuxt.renderAndGetWindow](/api/nuxt-render-and-get-window).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This method should be used mostly for [test purposes](/guide/development-tools#end-to-end-testing) as well with [nuxt.renderAndGetWindow](/api/nuxt-render-and-get-window).</p>
 
 <p class="Alert Alert--info">`nuxt.renderRoute` should be executed after the build process in production mode (dev: false).</p>
 
 Example:
 ```js
-const Nuxt = require('nuxt')
-let config = require('./nuxt.config.js')
+const { Nuxt, Builder } = require('nuxt')
+
+const config = require('./nuxt.config.js')
 config.dev = false
+
 const nuxt = new Nuxt(config)
 
-nuxt.build()
-.then(() => {
-  return nuxt.renderRoute('/')
-})
+new Builder(nuxt)
+.build()
+.then(() => nuxt.renderRoute('/'))
 .then(({ html, error, redirected }) => {
   // html will be always a string
 

--- a/fr/api/nuxt-render.md
+++ b/fr/api/nuxt-render.md
@@ -3,7 +3,7 @@ title: "API: nuxt.render(req, res)"
 description: You can use Nuxt.js as a middleware for your node.js server.
 ---
 
-# nuxt.render(req, res)
+# nuxt.render(req, res) (En)
 
 - Type: `Function`
 - Arguments:
@@ -13,15 +13,16 @@ description: You can use Nuxt.js as a middleware for your node.js server.
 
 > You can use nuxt.js as a middleware with `nuxt.render` for your node.js server.
 
-Example with [Express.js](https://github.com/expressjs/express):
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Example with [Express.js](https://github.com/expressjs/express):</p>
 ```js
-const Nuxt = require('nuxt')
+const { Nuxt, Builder } = require('nuxt')
+
 const app = require('express')()
 const isProd = (process.env.NODE_ENV === 'production')
 const port = process.env.PORT || 3000
 
 // We instantiate nuxt.js with the options
-let config = require('./nuxt.config.js')
+const config = require('./nuxt.config.js')
 config.dev = !isProd
 const nuxt = new Nuxt(config)
 
@@ -30,16 +31,22 @@ app.use(nuxt.render)
 
 // Build only in dev mode with hot-reloading
 if (config.dev) {
-  nuxt.build()
+  new Builder(nuxt).build()
+  .then(listen)
   .catch((error) => {
     console.error(error)
     process.exit(1)
   })
 }
+else {
+  listen()
+}
 
-// Listen the server
-app.listen(port, '0.0.0.0')
-console.log('Server listening on localhost:' + port)
+function listen() {
+  // Listen the server
+  app.listen(port, '0.0.0.0')
+  console.log('Server listening on localhost:' + port)
+}
 ```
 
 <p class="Alert">It's recommended to call **nuxt.render** at the end of your middlewares since it will handle the rendering of your web application and won't call next()</p>

--- a/fr/api/nuxt.md
+++ b/fr/api/nuxt.md
@@ -3,31 +3,38 @@ title: "API: Nuxt(options)"
 description: You can use nuxt.js programmatically to use it as a middleware giving you the freedom of creating your own server for rendering your web applications.
 ---
 
-# Using Nuxt.js Programmatically
+# Using Nuxt.js Programmatically (En)
 
-You might want to use your own server with your middleware and your API. That's why you can use Nuxt.js programmatically.
-Nuxt.js is built on the top of ES2015, which makes the code more enjoyable and cleaner to read. It doesn't make use of any transpilers and depends upon Core V8 implemented features. For these reasons, Nuxt.js targets Node.js `4.0` or higher.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>You might want to use your own server with your middleware and your API. That's why you can use Nuxt.js programmatically.</p>
 
 You can require Nuxt.js like this:
 ```js
-const Nuxt = require('nuxt')
+const { Nuxt, Builder } = require('nuxt')
 ```
 
-## Nuxt(options)
+## Nuxt Constructor
 
 To see the list of options to give to Nuxt.js, see the configuration section.
 
 ```js
-const options = {}
+// Require Nuxt And Builder modules
+const { Nuxt, Builder } = require('nuxt')
 
-const nuxt = new Nuxt(options)
-nuxt.build()
-.then(() => {
-  // We can use nuxt.render(req, res) or nuxt.renderRoute(route, context)
-})
+// Require nuxt config
+const config = require('./nuxt.config.js')
+
+// Create a new nuxt instance
+const nuxt = new Nuxt(config)
+
+// Enable live build & reloading on dev
+if (nuxt.options.dev) {
+  new Builder(nuxt).build()
+}
+
+// We can use nuxt.render(req, res) or nuxt.renderRoute(route, context)
 ```
 
-You can take a look at the [nuxt-express](https://github.com/nuxt/express) and [adonuxt](https://github.com/nuxt/adonuxt) starters to start quickly.
+You can take a look at the [nuxt-express](https://github.com/nuxt/express) and [adonuxt](https://github.com/nuxt/adonuxt) starters to get started quickly.
 
 ### Debug logs
 

--- a/fr/api/pages-fetch.md
+++ b/fr/api/pages-fetch.md
@@ -1,19 +1,19 @@
 ---
-title: "API: La méthode fetch"
-description: La méthode fetch est utilisée pour remplir le store avant de rendre la page, c'est comme la méthode data  sauf qu'elle ne définit pas les données du composant.
+title: "API: The fetch Method"
+description: The fetch method is used to fill the store before rendering the page, it's like the asyncData method except it doesn't set the component data.
 ---
 
-# La méthode fetch
+# The fetch Method (En)
 
-> La méthode fetch est utilisée pour remplir le store avant de rendre la page, c'est comme la méthode data  sauf qu'elle ne définit pas les données du composant.
+> The fetch method is used to fill the store before rendering the page, it's like the asyncData method except it doesn't set the component data.
 
 - **Type:** `Function`
 
-La méthode `fetch` est appelée avant chaque chargement de composant (**uniquement pour les composants pages**). Elle peut être appelée côté serveur ou avant de nvaiguer sur la route correspondante.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>The `fetch` method, *if set*, is called every time before loading the component (**only for pages components**). It can be called from the server-side or before navigating to the corresponding route.</p>
 
-La méthode `fetch` reçoit le [context](/api#context) comme premier argument, vous pouvez l'utiliser afin de récupérer des données et remplir le store. Pour rendre la méthode fetch asynchrone, **retourner une Promise**, nuxt.js attendra la résolution de la promise avand de faire le rendu du cmoposant.
+The `fetch` method receives [the context](/api/context) as the first argument, we can use it to fetch some data and fill the store. To make the fetch method asynchronous, **return a Promise**, nuxt.js will wait for the promise to be resolved before rendering the Component.
 
-Exemple de `pages/index.vue`:
+Example of `pages/index.vue`:
 ```html
 <template>
   <h1>Stars: {{ $store.state.stars }}</h1>
@@ -31,7 +31,7 @@ export default {
 </script>
 ```
 
-Vous pouvez également utiliser async/await pour rendre votre code plus propre:
+You can also use async/await to make your code cleaner:
 
 ```html
 <template>

--- a/fr/api/pages-head.md
+++ b/fr/api/pages-head.md
@@ -1,17 +1,17 @@
 ---
-title: "API: la méthode head"
-description: Nuxt.js utilise vue-meta pour mettre à jours les `headers` et les attributs html de votre application.
+title: "API: The head Method"
+description: Nuxt.js uses vue-meta to update the `headers` and `html attributes` of your application.
 ---
 
-# La méthode head
+# The head Method (En)
 
-> Nuxt.js utilise [vue-meta](https://github.com/declandewet/vue-meta) pour mettre à jours les `headers` et les attributs html de votre application.
+> Nuxt.js uses [vue-meta](https://github.com/declandewet/vue-meta) to update the `headers` and `html attributes` of your application.
 
-- **Type:** `Object` ou `Function`
+- **Type:** `Object` or `Function`
 
-Utilisez la méthode `head` pour définir les tags HTML head de la page courante.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Use the `head` method to set the HTML Head tags for the current page.</p>
 
-Les données de votre composant sont disponibles avec `with` au sein de la méthode `head`, vous pouvez définir des meta tags personnalisés avec les données de page.
+Your component data are available with `this` in the `head` method, you can use set custom meta tags with the page data.
 
 ```html
 <template>
@@ -37,4 +37,4 @@ export default {
 </script>
 ```
 
-<p class="Alert">Afin d'éviter un doublon quand vous utilisez un composant enfant, utilisez un identifiant unique à l'aide de la clef `hid`; [plus à ce propos](https://github.com/declandewet/vue-meta#lists-of-tags).</p>
+<p class="Alert">To avoid any duplication when used in child component, please give a unique identifier with the `hid` key, please [read more about it](https://github.com/declandewet/vue-meta#lists-of-tags).</p>

--- a/fr/api/pages-layout.md
+++ b/fr/api/pages-layout.md
@@ -1,28 +1,28 @@
 ---
-title: "API: la propriété layout"
-description: Chaque fichier (premier niveau) dans le répertoire layouts créera un layout personnalisé accessible avec la propriété layout dans le composant page.
+title: "API: The layout Property"
+description: Every file (first level) in the layouts directory will create a custom layout accessible with the layout property in the page component.
 ---
 
-# La propriété layout
+# The layout Property (En)
 
-> Chaque fichier (premier niveau) dans le répertoire layouts créera un layout personnalisé accessible avec la propriété layout dans le composant page.
+> Every file (first level) in the layouts directory will create a custom layout accessible with the layout property in the page component.
 
-- **Type:** `String` ou `Function` (defaut: `'default'`)
+- **Type:** `String` or `Function` (default: `'default'`)
 
-Utilisez la clef `layout` dans vos composants de pages pour définir le layout à utiliser:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Use the `layout` key in your pages components to define which layout to use:</p>
 
 ```js
 export default {
   layout: 'blog',
-  // OU
+  // OR
   layout (context) {
     return 'blog'
   }
 }
 ```
 
-Dans cet exemple, Nuxt.js incluera le fichier `layouts/blog.vue` comme layout pour ce composant page.
+In this example, Nuxt.js will include the `layouts/blog.vue` file as a layout for this page component.
 
-En action dans [cette vidéo de démonstration](https://www.youtube.com/watch?v=YOKnSTp7d38).
+Check the [demonstration video](https://www.youtube.com/watch?v=YOKnSTp7d38) to see it in action.
 
-Afin de comprendre comment les layouts fonctionnent avec nuxt.js, regarder la [documentation sur les layouts](/guide/views#layouts).
+To understand how the layouts work with nuxt.js, take a look at the [layout documentation](/guide/views#layouts).

--- a/fr/api/pages-middleware.md
+++ b/fr/api/pages-middleware.md
@@ -1,21 +1,21 @@
 ---
-title: "API: La propriété middleware"
-description: Définit le middleware pour une page spécifique de l'application.
+title: "API: The middleware Property"
+description: Set the middleware for a specific page of the application.
 ---
 
-# La propriété middleware
+# The middleware Property (En)
 
-- Type: `String` ou `Array`
+- Type: `String` or `Array`
   - Items: `String`
 
-Définit le middleware pour une page spécifique de l'application.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Set the middleware for a specific page of the application.</p>
 
-Exemple:
+Example:
 
 `pages/secret.vue`
 ```html
 <template>
-  <h1>Page secrète</h1>
+  <h1>Secret page</h1>
 </template>
 
 <script>
@@ -28,11 +28,11 @@ export default {
 `middleware/authenticated.js`
 ```js
 export default function ({ store, redirect }) {
-  // Si l'utilisateur n'est pas authentifié
+  // If the user is not authenticated
   if (!store.state.authenticated) {
     return redirect('/login')
   }
 }
 ```
 
-Pour en savoir plus sur les middleware, voir le [guide middleware](/guide/routing#middleware).
+To learn more about the middleware, see the [middleware guide](/guide/routing#middleware).

--- a/fr/api/pages-scrolltotop.md
+++ b/fr/api/pages-scrolltotop.md
@@ -1,19 +1,19 @@
 ---
-title: "API: la propriété scrollToTop"
-description: La propriété scrollToTop vous permets d'indiquer à nuxt.js de scroller en haut de la page avant de faire le rendu.
+title: "API: The scrollToTop Property"
+description: The scrollToTop property lets you tell nuxt.js to scroll to the top before rendering the page.
 ---
 
-# La propriété scrollToTop
+# The scrollToTop Property
 
-> La propriété scrollToTop vous permets d'indiquer à nuxt.js de scroller en haut de la page avant de faire le rendu.
+> The scrollToTop property lets you tell nuxt.js to scroll to the top before rendering the page.
 
-- **Type:** `Boolean` (défaut: `false`)
+- **Type:** `Boolean` (default: `false`)
 
-Par défaut, nuxt.js scroll vers le haut de la page quand vous changer de page. Mais dans le cas de routes enfants, nuxt.js reste à sa position actuelle. Si vous désirez indiquer à nuxt.js de scroller en haut de la page lors du rendu de la page enfant, utilisez `scrollToTop: true`:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>By default, nuxt.js scrolls to the top when you go to another page, but with children routes, nuxt.js keeps the scroll position. If you want to tell nuxt.js to scroll to the top when rendering your child route, set `scrollToTop: true`:</p>
 
 ```html
 <template>
-  <h1>Mon composant enfant</h1>
+  <h1>My child component</h1>
 </template>
 
 <script>
@@ -23,4 +23,4 @@ export default {
 </script>
 ```
 
-Si vous désirez écraser le comportonent par défaut du scroll, regardez l'[option scrollBehavior](/api/configuration-router#scrollBehavior).
+If you want to overwrite the default scroll behavior of nuxt.js, take a look at the [scrollBehavior option](/api/configuration-router#scrollBehavior).

--- a/fr/api/pages-transition.md
+++ b/fr/api/pages-transition.md
@@ -1,15 +1,15 @@
 ---
-title: "API: la propriété transition"
-description: Nuxt.js utilise le composant transition afin de créer des transitions/animations époustouflantes entre vos pages.
+title: "API: The transition Property"
+description: Nuxt.js uses the transition component to let you create amazing transitions/animations between your pages.
 ---
 
-# La propriété transition
+# The transition Property (En)
 
-> Nuxt.js utilise le composant [&lt;transition&gt;](http://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) afin de créer des transitions/animations époustouflantes entre vos pages.
+> Nuxt.js uses the [&lt;transition&gt;](http://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages. 
 
-- **Type:** `String` ou `Object` ou `Function`
+- **Type:** `String` or `Object` or `Function`
 
-Pour définir une transition personalisée pour une route spécifique, ajouter la clef `transition` au composant de page.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>To define a custom transition for a specific route, simply add the `transition` key to the page component.</p>
 
 ```js
 export default {
@@ -24,7 +24,7 @@ export default {
 
 ## String
 
-Si la clef `transition` est défini en tant que string, il sera utilisé comme `transition.name`.
+If the `transition` key is set as a string, it will be used as the `transition.name`.
 
 ```js
 export default {
@@ -32,15 +32,15 @@ export default {
 }
 ```
 
-Nuxt.js utilisera ces paramètres pour définir le composant comme suit:
+Nuxt.js will use these settings to set the component as follows:
 
 ```html
 <transition name="test">
 ```
 
-## Objet
+## Object
 
-Si la clef `transition` est un objet:
+If the `transition` key is set as an object:
 
 ```js
 export default {
@@ -51,29 +51,30 @@ export default {
 }
 ```
 
-Nuxt.js utilisera ces paramètres pour définir le composant comme suit:
+Nuxt.js will use these settings to set the component as follows:
 
 ```html
 <transition name="test" mode="out-in">
 ```
 
-L'objet `transition` peut avoir les propriétés suivantes:
+The following properties that the `transition` object can have:
 
-| clef  | type | défaut | définition |
+| key  | Type | Default | definition |
 |------|------|---------|-----------|
-| `name` | String | `"page"` | Le nom de la transition appliqué aux routes. |
-| `mode` | String | `"out-in"` | Le mode de la transition appliqué aux routes; voir la [documentation Vue.js](http://vuejs.org/v2/guide/transitions.html#Transition-Modes). |
+| `name` | String | `"page"` | The transition name applied on all the routes transitions. |
+| `mode` | String | `"out-in"` | The transition mode applied on all routes, see [Vue.js documentation](http://vuejs.org/v2/guide/transitions.html#Transition-Modes). |
 | `css` | Boolean | `true` | Whether to apply CSS transition classes. Defaults to `true`. If set to false, will only trigger JavaScript hooks registered via component events. |
 | `duration` | Integer | `n/a` | The duration (in milliseconds) applied on the transition, see [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations). |
 | `type` | String | `n/a` | Specify the type of transition events to wait for to determine transition end timing. Available values are "transition" and "animation". By default, it will automatically detect the type that has a longer duration. |
-| `enterClass` | String | `n/a` | L'état de départ de la classe de transition. Voir la [documentation Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
-| `enterToClass` | String | `n/a` | L'état final de la transition. Voir la [documentation Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
-| `enterActiveClass` | String | `n/a` | La classe appliquée pendant l'intégralité de la transition. Voir la [documentation Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
-| `leaveClass` | String | `n/a` | L'état de départ de la classe de transition. Voir la [documentation Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
-| `leaveToClass` | String | `n/a` | L'état final de la transition. Voir la [documentation Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
-| `leaveActiveClass` | String | `n/a` | La classe appliquée pendant l'intégralité de la transition. Voir la [documentation Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
+| `enterClass` | String | `n/a` | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
+| `enterToClass` | String | `n/a` | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
+| `enterActiveClass` | String | `n/a` | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
+| `leaveClass` | String | `n/a` | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
+| `leaveToClass` | String | `n/a` | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
+| `leaveActiveClass` | String | `n/a` | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes) |
 
-Vous pouvez également définir des méthodes dans l'objet `transition` afin de pouvoir utiliser des [hooks JavaScript](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
+
+You can also define methods in the `transition`, these are for the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
 
 - beforeEnter(el)
 - enter(el, done)
@@ -84,11 +85,11 @@ Vous pouvez également définir des méthodes dans l'objet `transition` afin de 
 - afterLeave(el)
 - leaveCancelled(el)
 
-*Note: c'est une bonne pratique que de définir explicitement `css: false` pour les transitions uniquement JavaScript afin que Vue passe la détection CSS. Cela prévient également les potentielles interférences entre les déclarations CSS.*
+*Note: it’s also a good idea to explicitly add `css: false` for JavaScript-only transitions so that Vue can skip the CSS detection. This also prevents CSS rules from accidentally interfering with the transition.*
 
-## Fonction
+## Function
 
-Si la clef `transition` est une fonction:
+If the `transition` key is set as a function:
 
 ```js
 export default {
@@ -99,7 +100,7 @@ export default {
 }
 ```
 
-Transitions appliquées à la navigation:
+Transitions applied on navigation:
 - `/` to `/posts` => `slide-left`
 - `/posts` to `/posts?page=3` => `slide-left`
 - `/posts?page=3` to `/posts?page=2` => `slide-right`

--- a/fr/api/pages-validate.md
+++ b/fr/api/pages-validate.md
@@ -1,11 +1,11 @@
 ---
-title: "API: la méthode validate"
-description: Nuxt.js vous permet de définir une méthode de validation dans votre composant de route dynamique.
+title: "API: The validate Method"
+description: Nuxt.js lets you define a validator method inside your dynamic route component.
 ---
 
-# La méthode validate
+# The validate Method (En)
 
-> Nuxt.js vous permet de définir une méthode de validation dans votre composant de route dynamique.
+> Nuxt.js lets you define a validator method inside your dynamic route component.
 
 - **Type:** `Function`
 
@@ -16,9 +16,9 @@ validate({ params, query, store }) {
 }
 ```
 
-Nuxt.js vous permet de définir une méthode de validation dans votre composant de route dynamique (dans cet exemple : `pages/users/_id.vue`).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Nuxt.js lets you define a validator method inside your dynamic route component (In this example: `pages/users/_id.vue`).</p>
 
-Si la méthode de validation retourne `false`, Nuxt.js chargera automatiquement la page d'erreur 404.
+If the validate method does not return `true`, Nuxt.js will automatically load the 404 error page.
 
 ```js
 export default {
@@ -29,7 +29,7 @@ export default {
 }
 ```
 
-Vous pouvez également utiliser des données de votre [store](/guide/vuex-store) pour la validation comme par exemple (remplie par [l'action nuxtServerInit](/guide/vuex-store#the-nuxtserverinit-action) auparavant):
+You can also check some data in your [store](/guide/vuex-store) for example (filled by [nuxtServerInit action](/guide/vuex-store#the-nuxtserverinit-action) before):
 
 ```js
 export default {

--- a/fr/examples/async-data.md
+++ b/fr/examples/async-data.md
@@ -1,6 +1,8 @@
 ---
-title: Async Data
-description: Exemple de données asynchrone avec Nuxt.js
+title: Async Data (En)
+description: Async Data example with Nuxt.js
 github: async-data
 documentation: /guide/async-data
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/auth-routes.md
+++ b/fr/examples/auth-routes.md
@@ -1,6 +1,6 @@
 ---
-title: Auth Routes
-description: Exemple d'authentification de routes avec Nuxt.js
+title: Auth Routes (En)
+description: Authenticated routes example with Nuxt.js
 github: auth-routes
 livedemo: https://nuxt-auth-routes.gomix.me
 liveedit: https://gomix.com/#!/project/nuxt-auth-routes
@@ -8,20 +8,20 @@ liveedit: https://gomix.com/#!/project/nuxt-auth-routes
 
 # Documentation
 
-> Nuxt.js peut être utilisé pour créer des routes authentifiées facilement.
+> Nuxt.js can be used to create authenticated routes easily.
 
-## Utilisation de Express et Sessions
+## Using Express and Sessions
 
-Pour ajouter la fonctionnalité de sessions dans notre application, nous utiliserons `express` et` express-session`, pour cela, nous devons utiliser Nuxt.js de manière programmatique.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>To add the sessions feature in our application, we will use `express` and `express-session`, for this, we need to use Nuxt.js programmatically.</p>
 
-Premièrement, nous installons les dépendances:
+First, we install the dependencies:
 ```bash
 yarn add express express-session body-parser whatwg-fetch
 ```
 
-*Nous parlerons de `whatwg-fetch` dans un instant.*
+*We will talk about `whatwg-fetch` later.*
 
-Puis nous créons notre `server.js`:
+Then we create our `server.js`:
 ```js
 const { Nuxt, Builder } = require('nuxt')
 const bodyParser = require('body-parser')
@@ -67,7 +67,7 @@ app.listen(3000)
 console.log('Server is listening on http://localhost:3000')
 ```
 
-Et nous modifions nos script dans `package.json`:
+And we update our `package.json` scripts:
 ```json
 // ...
 "scripts": {
@@ -77,13 +77,14 @@ Et nous modifions nos script dans `package.json`:
 }
 // ...
 ```
-Note: Vous devrez exécuter `npm install --save-dev cross-env` afin de faire fonctionner l'exemple précédent. Si vous n'êtes pas en train de développer sur Windows, vous pouvez laisser cross-env en dehors de votre script `start` et définir `NODE_ENV` directement.
+Note: You'll need to run `npm install --save-dev cross-env` for the above example to work. If you're *not* developing on Windows you can leave cross-env out of your `start` script and set `NODE_ENV` directly.
 
-## Utilisation du store
+## Using the store
 
-Nous avons besoin d'un état global pour informer notre application si l'utilisateur est connecté sur les pages.
+We need a global state to let our application know if the user is connected **across the pages**.
 
-Pour laisser Nuxt.js utiliser Vuex, nous créons un fichier `store/index.js`:
+To let Nuxt.js use Vuex, we create a `store/index.js` file:
+
 ```js
 import Vue from 'vue'
 import Vuex from 'vuex'
@@ -93,7 +94,7 @@ Vue.use(Vuex)
 // Polyfill for window.fetch()
 require('whatwg-fetch')
 
-const store = new Vuex.Store({
+const store = () => new Vuex.Store({
 
   state: {
     authUser: null
@@ -114,16 +115,16 @@ const store = new Vuex.Store({
 export default store
 ```
 
-1. Nous importons `Vue` et `Vuex` (inclus dans Nuxt.js) et nous indiquons à Vue d'utiliser Vuex afin de pouvoir utiliser `$store` dans nos composants
-2. Nous `require('whatwg-fetch')` afin de *polyfill* la méthode `fetch()` pour tous les navigateurs (voir [fetch repo](https://github.com/github/fetch))
-3. Nous créons notre mutation `SET_USER` qui va instancier `state.authUser` avec l'utilisateur connecté
-4. Nous exportons notre instance du *store* vers Nuxt.js afin qu'il puisse l'injecter dans notre application principale
+1. We import `Vue` and `Vuex` (included in Nuxt.js) and we tell Vue to use Vuex to let us use `$store` in our components
+2. We `require('whatwg-fetch')` to polyfill the `fetch()` method across all browsers (see [fetch repo](https://github.com/github/fetch))
+3. We create our `SET_USER` mutation which will set the `state.authUser` to the connected user
+4. We export our store instance to Nuxt.js can inject it to our main application
 
-### Fonction nuxtServerInit()
+### nuxtServerInit() action
 
-Nuxt.js appelle une action spécifique nommée `nuxtServerInit` avec le contexte comme l'argument, de telle manière à ce que lorsque l'application sera chargée, le magasin sera déjà rempli avec certaines données que nous pouvons obtenir du serveur.
+Nuxt.js will call a specific action called `nuxtServerInit` with the context in argument, so when the app will be loaded, the store will be already filled with some data we can get from the server.
 
-Dans notre `store/index.js`, nous pouvons ajouter l'action `nuxtServerInit`:
+In our `store/index.js`, we can add the `nuxtServerInit` action:
 ```js
 nuxtServerInit ({ commit }, { req }) {
   if (req.session && req.session.authUser) {
@@ -132,14 +133,14 @@ nuxtServerInit ({ commit }, { req }) {
 }
 ```
 
-Pour rendre la méthode de données asynchrone, nuxt.js vous offre différents moyens, choisissez celui dont vous êtes le plus familier:
+To make the data method asynchronous, nuxt.js offers you different ways, choose the one you're the most familiar with:
 
-1. retourner une `Promise`, nuxt.js attendra la résolution de la `Promise` avant d'afficher le composant.
-2. en utilisant [async/await](https://github.com/lukehoban/ecmascript-asyncawait) ([en savoir plus](https://zeit.co/blog/async-and-await))
+1. returning a `Promise`, nuxt.js will wait for the promise to be resolved before rendering the component.
+2. Using the [async/await proposal](https://github.com/lukehoban/ecmascript-asyncawait) ([learn more about it](https://zeit.co/blog/async-and-await))
 
-### Fonction login()
+### login() action
 
-Nous ajoutons une action `login` qui sera appelée à partir de nos composant pages pour connecter l'utilisateur:
+We add a `login` action which will be called from our pages component to log in the user:
 ```js
 login ({ commit }, { username, password }) {
   return fetch('/api/login', {
@@ -167,7 +168,7 @@ login ({ commit }, { username, password }) {
 }
 ```
 
-### Fonction logout()
+### logout() method
 
 ```js
 logout ({ commit }) {
@@ -182,13 +183,13 @@ logout ({ commit }) {
 }
 ```
 
-## Composants Pages
+## Pages components
 
-Ensuite, nous pouvons utiliser `$store.state.authUser` dans nos composants Pages pour vérifier si l'utilisateur est connecté ou non dans notre application.
+Then we can use `$store.state.authUser` in our pages components to check if the user is connected in our application or not.
 
-### Rediriger l'utilisateur s'il n'est pas connecté
+### Redirect user if not connected
 
-Ajoutons une route `/secret` où seul l'utilisateur connecté peut voir son contenu:
+Let's add a `/secret` route where only the connected user can see its content:
 ```html
 <template>
   <div>
@@ -209,4 +210,4 @@ export default {
 </script>
 ```
 
-Nous pouvons voir dans la méthode `fetch` que nous appelons `redirect('/')` lorsque notre utilisateur n'est pas connecté.
+We can see in the `fetch` method that we call `redirect('/')` when our user is not connected.

--- a/fr/examples/cached-components.md
+++ b/fr/examples/cached-components.md
@@ -1,6 +1,8 @@
 ---
-title: Composants en cache
-description: Example de composants en cache avec Nuxt.js
+title: Cached Components (En)
+description: Cached Components example with Nuxt.js
 github: cached-components
 documentation: /api/configuration-cache
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/custom-loading.md
+++ b/fr/examples/custom-loading.md
@@ -1,7 +1,9 @@
 ---
-title: Composant de chargement personalisé
-description: Exemple de composant de chargement personalisé avec Nuxt.js
+title: Custom Loading Component (En)
+description: Custom Loading Component example with Nuxt.js
 github: custom-loading
 livedemo: https://custom-loading.nuxtjs.org
 documentation: /api/configuration-loading
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/custom-routes.md
+++ b/fr/examples/custom-routes.md
@@ -1,7 +1,9 @@
 ---
-title: Routes personalisées
-description: Example de routes personalisées avec Nuxt.js
+title: Custom Routes (En)
+description: Custom Routes example with Nuxt.js
 github: custom-routes
 livedemo: https://custom-routes.nuxtjs.org
-documentation: /guide/routing#routes-dynamiques
+documentation: /guide/routing#dynamic-routes
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/global-css.md
+++ b/fr/examples/global-css.md
@@ -1,7 +1,9 @@
 ---
-title: CSS Global
-description: Exemple de CSS global avec Nuxt.js
+title: Global CSS (En)
+description: Global CSS example with Nuxt.js
 github: global-css
 livedemo: https://global-css.nuxtjs.org
 documentation: /api/configuration-css
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/hello-world.md
+++ b/fr/examples/hello-world.md
@@ -1,9 +1,11 @@
 ---
-title: Hello World
-description: Exemple Hello World avec Nuxt.js
+title: Hello World (En)
+description: Hello World example with Nuxt.js
 github: hello-world
 youtube: https://www.youtube.com/embed/kmf-p-pTi40
 livedemo: https://hello-world.nuxtjs.org
 liveedit: https://gomix.com/#!/project/nuxt-hello-world
-documentation: /guide/installation#commencer-depuis-z-ro
+documentation: /guide/installation#starting-from-scratch
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/i18n.md
+++ b/fr/examples/i18n.md
@@ -1,7 +1,9 @@
 ---
-title: Internationalisation (i18n)
-description: Exemple d'internationalisation (i18n) avec Nuxt.js
+title: Internationalization (i18n) (En)
+description: Internationalization (i18n) example with Nuxt.js
 github: i18n
 livedemo: https://i18n.nuxtjs.org
 documentation: /guide/routing#middleware
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/layouts.md
+++ b/fr/examples/layouts.md
@@ -1,8 +1,10 @@
 ---
-title: Mise en page (layouts)
-description: Exemple de mise en page avec Nuxt.js
+title: Layouts (En)
+description: Layouts example with Nuxt.js
 github: custom-layouts
 livedemo: https://nuxt-custom-layouts.gomix.me/
 liveedit: https://gomix.com/#!/project/nuxt-custom-layouts
-documentation: /guide/views#mise-en-page
+documentation: /guide/views#layouts
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/menu.json
+++ b/fr/examples/menu.json
@@ -1,33 +1,33 @@
 [
   {
-    "title": "Essentiels",
+    "title": "Essentiel",
     "links": [
-      { "name": "Hello world", "to": "" },
-      { "name": "SEO HTML Head", "to": "/seo-html-head" }
+      { "name": "Hello world (En)", "to": "" },
+      { "name": "SEO HTML Head (En)", "to": "/seo-html-head" }
     ]
   },
   {
     "title": "Personnalisation",
     "links": [
-      { "name": "Composants en cache", "to": "/cached-components" },
-      { "name": "Composant de chargement personalisé", "to": "/custom-loading" },
-      { "name": "Routes personalisées", "to": "/custom-routes" },
-      { "name": "CSS Global", "to": "/global-css" },
-      { "name": "Mise en page (layouts)", "to": "/layouts" },
-      { "name": "Middleware", "to": "/middleware" },
-      { "name": "Routes imbriquées", "to": "/nested-routes" },
-      { "name": "Plugins", "to": "/plugins" },
-      { "name": "Routes transitions", "to": "/routes-transitions" }
+      { "name": "Cached Components (En)", "to": "/cached-components" },
+      { "name": "Custom Loading (En)", "to": "/custom-loading" },
+      { "name": "Custom Routes (En)", "to": "/custom-routes" },
+      { "name": "Global CSS (En)", "to": "/global-css" },
+      { "name": "Layouts (En)", "to": "/layouts" },
+      { "name": "Middleware (En)", "to": "/middleware" },
+      { "name": "Nested Routes (En)", "to": "/nested-routes" },
+      { "name": "Plugins (En)", "to": "/plugins" },
+      { "name": "Routes transitions (En)", "to": "/routes-transitions" }
     ]
   },
   {
-    "title": "Avancé",
+    "title": "Avancées",
     "links": [
-      { "name": "Données asynchrones", "to": "/async-data" },
-      { "name": "Auth Routes", "to": "/auth-routes" },
-      { "name": "Vuex Store", "to": "/vuex-store" },
-      { "name": "i18n", "to": "/i18n" },
-      { "name": "Test", "to": "/testing" }
+      { "name": "Async Data (En)", "to": "/async-data" },
+      { "name": "Auth Routes (En)", "to": "/auth-routes" },
+      { "name": "Vuex Store (En)", "to": "/vuex-store" },
+      { "name": "i18n (En)", "to": "/i18n" },
+      { "name": "Testing (En)", "to": "/testing" }
     ]
   }
 ]

--- a/fr/examples/middleware.md
+++ b/fr/examples/middleware.md
@@ -1,7 +1,8 @@
 ---
-title: Middleware
-description: Exemple de middleware avec Nuxt.js
+title: Middleware (En)
+description: Middleware example with Nuxt.js
 github: middleware
-livedemo: https://middleware.nuxtjs.org
 documentation: /guide/routing#middleware
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/nested-routes.md
+++ b/fr/examples/nested-routes.md
@@ -1,7 +1,9 @@
 ---
-title: Routes imbriquées
-description: Exmeple de routes imbriquées avec Nuxt.js
+title: Nested Routes (En)
+description: Nested Routes example with Nuxt.js
 github: nested-routes
 livedemo: https://nested-routes.nuxtjs.org
-documentation: /guide/routing#routes-imbriqu-es
+documentation: /guide/routing#nested-routes
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/plugins.md
+++ b/fr/examples/plugins.md
@@ -1,7 +1,9 @@
 ---
-title: Plugins
-description: Exemple d'utilisation de modules externes et de plugins avec nuxt.js
+title: Plugins (En)
+description: Using external modules and plugins with nuxt.js
 github: plugins-vendor
 livedemo: https://plugins-vendor.nuxtjs.org
 documentation: /guide/plugins
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/routes-transitions.md
+++ b/fr/examples/routes-transitions.md
@@ -1,8 +1,10 @@
 ---
-title: Routes transitions
-description: Exemple de transitions de routes avec Nuxt.js
+title: Routes transitions (En)
+description: Routes transitions example with Nuxt.js
 github: routes-transitions
 youtube: https://www.youtube.com/embed/RIXOzJWFfc8
 livedemo: https://routes-transitions.nuxtjs.org
 documentation: /guide/routing#transitions
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/seo-html-head.md
+++ b/fr/examples/seo-html-head.md
@@ -1,7 +1,9 @@
 ---
-title: SEO HTML Head
-description: Exemple SEO HTML Head avec Nuxt.js
+title: SEO HTML Head (En)
+description: SEO HTML Head example with Nuxt.js
 github: head-elements
 livedemo: https://head-elements.nuxtjs.org
 documentation: /guide/views#html-head
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/testing.md
+++ b/fr/examples/testing.md
@@ -1,6 +1,8 @@
 ---
-title: Testing
-description: Exmeple de test avec Nuxt.js
+title: Testing (En)
+description: Testing example with Nuxt.js
 github: with-ava
 documentation: /guide/development-tools#end-to-end-testing
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/examples/vuex-store.md
+++ b/fr/examples/vuex-store.md
@@ -1,7 +1,9 @@
 ---
-title: Vuex Store
-description: Exemple de Vuex Store avec Nuxt.js
+title: Vuex Store (En)
+description: Vuex Store example with Nuxt.js
 github: vuex-store
 livedemo: https://vuex-store.nuxtjs.org
 documentation: /guide/vuex-store
 ---
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>

--- a/fr/faq/async-data-components.md
+++ b/fr/faq/async-data-components.md
@@ -1,11 +1,11 @@
 ---
-title: Données asynchrones dans les composants
-description: Données asynchrones dans les composants?
+title: Async data in components
+description: Async data in components?
 ---
 
-# Données asynchrones dans les composants?
+# Async data in components? (En)
 
-Étant donné que les composants ne comportent pas de méthode asyncData, vous ne pouvez pas récupérer directement côté serveur de données asynchrone dans un composant. Pour contourner cette limitation, vous avez deux possibilités:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Because components do not have an asyncData method, you cannot directly fetch async data server side within a component. In order to get around there limitation you have two basic options:</p>
 
-1. Effectuez l'appel API dans le hook mounted() et définissez les données quand le composant est loadé. *Problème: ne fonctionne pas pour le rendu côté serveur
-2. Effectuez l'appel API dans la méthode asyncData() ou fetch() du composant page et passez les données en tant que props au sous-composant. Le rendu côté serveur fonctionnera. *Problème: asyncData() ou fetch() d'une page peuvent êtres moins lisibles car elles chargent les données pour d'autres composants*
+1. Make the API call in the mounted() hook and set data properties when loaded. *Downside: Won't work for server side rendering.*
+2. Make the API call in the asyncData() or fetch() methods of the page component and pass the data as props to the sub components. Server rendering will work fine. *Downside: the asyncData() or fetch() of the page might be less readable because it's loading the data for other components*

--- a/fr/faq/css-flash.md
+++ b/fr/faq/css-flash.md
@@ -1,12 +1,12 @@
 ---
 title: CSS Flash
-description: Pourquoi un flash CSS apparaît avec Nuxt.js?
+description: Why a CSS Flash appears with Nuxt.js?
 ---
 
-# Pourquoi un flash CSS apparaît?
+# Why a CSS Flash appears? (En)
 
 ![cssflash](/flash_css.gif)
 
-C'est parce qu'en **mode développement** le CSS se trouve dans le JavaScript afin de permettre le hot-reloading via Webpack.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This is because the CSS is in the JavaScript build in **development mode** to allow hot-reloading via Webpack.</p>
 
-Ne vous inquiétez pas; en mode de production le CSS est séparé et placé dans l'en-tête afin que ce "flash" n'apparaisse plus.
+Don't worry in production mode, the CSS is separated and put in the header so this "flash" does not appear anymore.

--- a/fr/faq/dokku-deployment.md
+++ b/fr/faq/dokku-deployment.md
@@ -1,32 +1,35 @@
 ---
-title: Déploiement sur Dokku
-description: Déployer nuxt.js sur Dokku
+title: Dokku Deployment
+description: How to deploy a Nuxt.js application on Dokku?
 ---
 
-# Déployer sur Dokku
+# How to deploy on Dokku? (En)
 
-Nous vous recommandons de lire la [documentation du setup Dokku](http://dokku.viewdocs.io/dokku/getting-started/installation/) et [Deploying a Node.js Application on Digital Ocean using dokku](http://jakeklassen.com/post/deploying-a-node-app-on-digital-ocean-using-dokku/)
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>We recommend to read [Dokku documentation for the setup](http://dokku.viewdocs.io/dokku/getting-started/installation/) and [Deploying a Node.js Application on Digital Ocean using dokku](http://jakeklassen.com/post/deploying-a-node-app-on-digital-ocean-using-dokku/)</p>
 
-Pour l'exemple, nous allons appeler notre application nuxt.js `my-nuxt-app`.
+For the example, we will call our nuxt.js application `my-nuxt-app`
 
-Demandons à Dokku d'installer les `devDependencies` de notre projet (afin de pouvoir exécuter `npm run build`):
+We need to tell Dokku to install the `devDependencies` of the project (to be able to launch `npm run build`):
+
 ```bash
 // on Dokku Server
 dokku config:set my-nuxt-app NPM_CONFIG_PRODUCTION=false
 ```
 
-Nous voulons également que notre application écoute le port `0.0.0.0` et s'exécute en mode production:
+Also, we want our application to listen on the port `0.0.0.0` and run in production mode:
+
 ```bash
 // on Dokku Server
 dokku config:set my-nuxt-app HOST=0.0.0.0 NODE_ENV=production
 ```
 
-Vous devriez voir ces trois lignes quand vous tapez `dokku config my-nuxt-app`
+You should see these 3 line when you type `dokku config my-nuxt-app`
 
 ![nuxt config vars Dokku](https://i.imgur.com/9FNsaoQ.png)
 
-Puis nous pouvons demander à Dokku d'exécuter `npm run build` via le script `scripts.dokku.predeploy` dans `app.json`:
-`créez un fichier nommé app.json dans le répertoire racine de votre projet`
+Then, we tell Dokku to launch `npm run build` via the `scripts.dokku.predeploy` script in our project `app.json`:
+`create a file name app.json in our project root folder`
+
 ```js
 {
   "scripts": {
@@ -37,11 +40,12 @@ Puis nous pouvons demander à Dokku d'exécuter `npm run build` via le script `s
 }
 ```
 
-Pour finir, nous pouvons déployer notre application sur Dokku:
+Finally, we can push our app on Dokku with:
+
 ```bash
 // commit your change before push.
 git remote add dokku dokku@yourServer:my-nuxt-app
 git push dokku master
 ```
 
-Voilà! Votre application nuxt.js est hébergée sur Dokku!
+Voilà! Our nuxt.js application is now hosted on Dokku!

--- a/fr/faq/duplicated-meta-tags.md
+++ b/fr/faq/duplicated-meta-tags.md
@@ -1,17 +1,17 @@
 ---
-title: Meta Tags dupliqués
-description: Meta Tags dupliqués avec Nuxt.js?
+title: Duplicated Meta tags
+description: Duplicated Meta tags with Nuxt.js?
 ---
 
-# Meta Tags dupliqués?
+# Duplicated Meta tags? (En)
 
-Il s'agit d'une "fonctionnalité" de [vue-meta](https://github.com/declandewet/vue-meta), merci de libre la [documentation des éléments head](/guide/views#html-head).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This is a "feature" of [vue-meta](https://github.com/declandewet/vue-meta), please take a look at the [documentation of head elements](/guide/views#html-head).</p>
 
-> Afin d'éviter toute duplication lors de l'utilisation d'un composant enfant, donner un identifiant unique à l'aide de la clef hid, merci [d'en lire plus](https://github.com/declandewet/vue-meta#lists-of-tags).
+> To avoid any duplication when used in child component, please give an unique identifier with the `hid` key, please [read more](https://github.com/declandewet/vue-meta#lists-of-tags) about it.
 
-Pour le meta "description", vous devez ajouter un identifiant unique `hid` afin que vue-meta sache qu'il doit remplacer le tag par défaut.
+For the meta description, you need to add the unique identifier `hid` so vue-meta will know that it has to overwrite the default tag.
 
-Votre `nuxt.config.js`:
+Your `nuxt.config.js`:
 ```js
 ...head: {
     title: 'starter',
@@ -25,18 +25,18 @@ Votre `nuxt.config.js`:
 ...
 ```
 
-Dans votre page individuelle:
+An then in your individual page:
 ```js
 export default {
   head () {
     return {
       title: `Page 1 (${this.name}-side)`,
       meta: [
-        { hid: 'description', name: 'description', content: "Page 1 description" }
-      ],
+        { hid: 'description', name: 'description', content: 'Page 1 description' }
+      ]
     }
   }
 }
 ```
 
-Pour apprendre à utiliser la propriété `head` dans vos pages, lire la documentation [HTML head](/guide/views#html-head).
+To learn how to use the `head` property in your pages, please see the [HTML head documentation](/guide/views#html-head).

--- a/fr/faq/extend-webpack.md
+++ b/fr/faq/extend-webpack.md
@@ -1,16 +1,16 @@
 ---
-title: Étendre Webpack
-description: Comment étendre la configuration de webpack?
+title: Extend Webpack
+description: How to extend webpack config into my Nuxt.js application?
 ---
 
-# Comment étendre la configuration de webpack?
+# How to extend webpack config? (En)
 
-Vous pouvez étendre la configuration de webpack via l'option `extend` de votre fichier `nuxt.config.js`:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>You can extend the webpack configuration via the `extend` option in your `nuxt.config.js`:</p>
 
 ```js
 module.exports = {
   build: {
-     extend (config, { isDev, isClient }) {
+     extend (config, { dev, isClient }) {
        // ...
      }
   }

--- a/fr/faq/external-resources.md
+++ b/fr/faq/external-resources.md
@@ -1,13 +1,13 @@
 ---
-title: Ressources externes
-description: Comment utiliser des ressources externes avec Nuxt.js?
+title: External resources
+description: How to use external resources with Nuxt.js?
 ---
 
-# Comment utiliser des ressources externes?
+# How to use external resources? (En)
 
-## Paramètres globaux
+## Global Settings
 
-Inclure vos ressources dans le fichier `nuxt.config.js`:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Include your resources in the `nuxt.config.js` file:</p>
 
 ```js
 module.exports = {
@@ -22,13 +22,13 @@ module.exports = {
 }
 ```
 
-## Paramètres locaux
+## Local Settings
 
-Inclure vos ressources dans votre fichier .vue dans votre répertoire *pages*:
+Include your resources in your `.vue` file inside the `pages/` directory:
 
 ```html
 <template>
-  <h1>Page avec jQuery et la police de caractère Roboto</h1>
+  <h1>About page with jQuery and Roboto font</h1>
 </template>
 
 <script>
@@ -43,4 +43,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+h1 {
+  font-family: Roboto, sans-serif;
+}
+</style>
 ```

--- a/fr/faq/github-pages.md
+++ b/fr/faq/github-pages.md
@@ -1,32 +1,34 @@
 ---
-title: Déployer sur GitHub Pages
-description: Déployer nuxt.js sur GitHub Pages
+title: GitHub Pages Deployment
+description: How to deploy Nuxt.js on GitHub Pages?
 ---
 
-# Déployer sur GitHub Pages
+# How to deploy on GitHub Pages? (En)
 
-Nuxt.js vous offre la possibilité d'héberger votre application web sur n'importe quel hébergeur statique tel que [GitHub Pages](https://pages.github.com/) par exemple.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Nuxt.js gives you the possibility to host your web application on any static hosting like [GitHub Pages](https://pages.github.com/) for example.</p>
 
-Pour déployer sur GitHub Pages, vous devez générer votre applicaiton web de manière statique:
+To deploy on GitHub Pages, you need to generate your static web application:
+
 ```bash
 npm run generate
 ```
 
-Cette commande créé un répertoire `dist` contenant l'intégralité de l'application prêts à être déployés sur GitHub Pages.
-Branche `gh-pages` pour un repository de projet OU branche `master` pour un site d'un utilisateur/d'une organisation.
+It will create a `dist` folder with everything inside ready to be deployed on GitHub Pages hosting.
+Branch `gh-pages` for project repository OR branch `master` for user or organization site
 
-<p class="Alert Alert--nuxt-green"><b>INFO:</b> Si vous utilisez un nom de domaine personalisé pour GitHub Pages à l'aide d'un fichier `CNAME`, il est recommandé de placer ce fichier dans le répertoire `static`. [Plus d'informations](/guide/assets#static) à ce propos.</p>
+<p class="Alert Alert--nuxt-green"><b>INFO:</b> If you use a custom domain for your GitHub Pages and put `CNAME` file, it is recommended that CNAME file is put in the `static` directory. [More documentation](/guide/assets#static) about it.</p>
 
-## Déploiement en ligne de commande
+## Command line deployment
 
-Vous pouvez également utiliser le package [push-dir](https://github.com/L33T-KR3W/push-dir):
+You can also use [push-dir package](https://github.com/L33T-KR3W/push-dir):
 
-Installez le via npm:
+First install it via npm:
+
 ```bash
 npm install push-dir --save-dev
 ```
 
-Ajouter une commande `deploy` à votre package.json avec la branche `gh-pages` un repository de projet OU branche `master` pour un site d'un utilisateur/d'une organisation.
+Add a `deploy` command to your package.json with the branch as `gh-pages` for project repository OR `master` for user or organization site.
 
 ```js
 "scripts": {
@@ -38,7 +40,8 @@ Ajouter une commande `deploy` à votre package.json avec la branche `gh-pages` u
 },
 ```
 
-Puis générez et déployez votreapplication statique:
+Then generate and deploy your static application:
+
 ```bash
 npm run generate
 npm run deploy

--- a/fr/faq/google-analytics.md
+++ b/fr/faq/google-analytics.md
@@ -1,18 +1,22 @@
 ---
-title: Intégration de Google Analytics
-description: Comment intégrer Google Analytics?
+title: Google Analytics Integration
+description: How to use Google Analytics?
 ---
 
-# Comment intégrer Google Analytics?
+# How to use Google Analytics? (En)
 
-Pour utiliser [Google Analytics](https://analytics.google.com/analytics/web/) avec votre application nuxt.js, nous recommandons de créer un plugin `plugins/ga.js`:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>First, please check the [official Google Analytics module](https://github.com/nuxt-community/modules/tree/master/modules/google-analytics) for nuxt.js*</p>
+
+Ortherwise, to use [Google Analytics](https://analytics.google.com/analytics/web/) with your nuxt.js application, we recommend to create a file `plugins/ga.js`:
 
 ```js
-import router from '~router'
-/*
-** Only run on client-side and only in production mode
-*/
-if (process.env.NODE_ENV === 'production') {
+/* eslint-disable */
+
+export default ({ app }) => {
+  /*
+  ** Only run on client-side and only in production mode
+  */
+  if (process.env.NODE_ENV !== 'production') return
   /*
   ** Include Google Analytics Script
   */
@@ -27,7 +31,7 @@ if (process.env.NODE_ENV === 'production') {
   /*
   ** Every time the route changes (fired on initialization too)
   */
-  router.afterEach((to, from) => {
+  app.router.afterEach((to, from) => {
     /*
     ** We tell Google Analytic to add a page view
     */
@@ -37,9 +41,9 @@ if (process.env.NODE_ENV === 'production') {
 }
 ```
 
-> Remplace `UA-XXXXXXXX-X` par votre ID de tracking Google Analytics.
+> Replace `UA-XXXXXXXX-X` by your Google Analytics tracking ID.
 
-Puis, nous importons le plugin dans notre application pricinpale:
+Then, we tell nuxt.js to import it in our main application:
 
 `nuxt.config.js`
 ```js
@@ -50,6 +54,6 @@ module.exports = {
 }
 ```
 
-Voilà, Google Analytics est intégré dans notre application nuxt.js et trackera chaque page vue!
+Voilà, Google Analytics is integrated into your nuxt.js application and will track every page view!
 
-<p class="Alert Alert--nuxt-green"><b>INFO:</b> cette méthode est valable pour n'importe quel autre service de tracking.</p>
+<p class="Alert Alert--nuxt-green"><b>INFO:</b> you can use this method for any other tracking service.</p>

--- a/fr/faq/heroku-deployment.md
+++ b/fr/faq/heroku-deployment.md
@@ -1,28 +1,28 @@
 ---
-title: Déployer sur Heroku
-description: Déployer nuxt.js sur Heroku
+title: Heroku Deployment
+description: How to deploy Nuxt.js on Heroku?
 ---
 
-# Déployer sur Heroku
+# How to deploy on Heroku? (En)
 
-Nous vous recommandons de lire la [documentation Heroku pour node.js](https://devcenter.heroku.com/articles/nodejs-support).
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>We recommend you to read the [Heroku documentation for node.js](https://devcenter.heroku.com/articles/nodejs-support).</p>
 
-Premièrement, nous devons demander à Heroku d'installer les `devDependencies` du projet (afin de pouvoir exécuter `npm run build`):
+First, we need to tell Heroku to install the `devDependencies` of the project (to be able to launch `npm run build`):
 ```bash
 heroku config:set NPM_CONFIG_PRODUCTION=false
 ```
 
-Nous voulons également que notre application écoute le port `0.0.0.0` et s'exécute en mode production:
+Also, we want our application to listen on the host `0.0.0.0` and run in production mode:
 ```bash
 heroku config:set HOST=0.0.0.0
 heroku config:set NODE_ENV=production
 ```
 
-Vous devriez voir cela dans votre tableau de bord Heroku (section Settings):
+You should see this in your Heroku dashboard (Settings section):
 
 ![nuxt config vars Heroku](https://i.imgur.com/EEKl6aS.png)
 
-Puis nous demandons à Heroku d'exécuter `npm run build` via le script `heroku-postbuild` de notre `package.json`:
+Then, we tell Heroku to launch `npm run build` via the `heroku-postbuild` script in our `package.json`:
 ```js
 "scripts": {
   "dev": "nuxt",
@@ -32,9 +32,9 @@ Puis nous demandons à Heroku d'exécuter `npm run build` via le script `heroku-
 }
 ```
 
-Pour finir, nous pouvons déployer notre application sur Heroku:
+Finally, we can push the app on Heroku with:
 ```bash
 git push heroku master
 ```
 
-Voilà! Votre application nuxt.js est hébergée sur Heroku!
+Voilà! Your nuxt.js application is now hosted on Heroku!

--- a/fr/faq/host-port.md
+++ b/fr/faq/host-port.md
@@ -1,18 +1,38 @@
 ---
-title: HOST et PORT
-description: Comment changer HOST et PORT avec Nuxt.js?
+title: HOST and PORT
+description: How to edit HOST and PORT with Nuxt.js?
 ---
 
-# Comment changer HOST et PORT?
+# How to edit HOST and PORT? (En)
 
-Vous pouvez configurer le PORT de deux façons:
-- Via une variable d'environnement
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>You can configure the PORT with 3 different ways:</p>
+
+1. With env variables
 ```js
 "scripts": {
   "dev": "HOST=0.0.0.0 PORT=3333 nuxt"
 }
 ```
-- Via la configuration nuxt dans `package.json`:
+
+2. Add better cross platform development support
+
+**Note**: for better cross platform development support you can use [cross-env](https://www.npmjs.com/package/cross-env) package.
+
+Installation:
+
+```bash
+npm install --save-dev cross-env
+```
+
+```js
+"scripts": {
+  "dev": "cross-env HOST=0.0.0.0 PORT=3333 nuxt"
+}
+```
+
+- Via a nuxt config in the `package.json`:
+
+3. Inside your `package.json`:
 ```js
 "config": {
   "nuxt": {

--- a/fr/faq/jsx.md
+++ b/fr/faq/jsx.md
@@ -1,13 +1,13 @@
 ---
 title: JSX
-description: Commen utiliser JSX avec Nuxt.js?
+description: How to use JSX with Nuxt.js?
 ---
 
-# Comment utiliser JSX?
+# How to use JSX? (En)
 
-Nuxt.js utilise le preset [babel-preset-vue-app](https://github.com/vuejs/babel-preset-vue-app) officiel comme configuration de défaut afin de pouvoir utiliser JSX dans vos composants.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Nuxt.js use the official [babel-preset-vue-app](https://github.com/vuejs/babel-preset-vue-app) for babel default configuration, so you can use JSX in your components.</p>
 
-Vous pouvez utiliser JSX dans la méthode `render` de vos composants:
+You can now use JSX in your `render` method of your components:
 
 ```html
 <script>
@@ -22,6 +22,6 @@ export default {
 </script>
 ```
 
-<p class="Alert Alert--info">Créer un alias `h` pour `createElement` est une convention commune que vous rencontrerez dans l'écosystème Vue mais n'est pas nécessaire pour JSX depuis qu'il [injecte automatiquement](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` dans toutes les méthodes et getter (pas les fonctions/arrow functions) déclarée avec la syntaxe ES2015 supportant JSX; vous pouvez alors laissez tomber le paramètre `h`.</p>
+<p class="Alert Alert--info">Aliasing `createElement` to `h` is a common convention you’ll see in the Vue ecosystem but is actually optional for JSX since it [automatically injects](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` in any method and getter (not functions or arrow functions) declared in ES2015 syntax that has JSX so you can drop the (h) parameter</p>
 
-Vous pouvez en savoir plus dans la [section JSX] (https://vuejs.org/v2/guide/render-function.html#JSX) de la documentation Vue.js.
+You can learn more how to use it in the [JSX section](https://vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.

--- a/fr/faq/menu.json
+++ b/fr/faq/menu.json
@@ -2,33 +2,33 @@
   {
     "title": "Configuration",
     "links": [
-      { "name": "Comment utiliser des ressources externes?", "to": "" },
-      { "name": "Comment utiliser des pré-processeurs?", "to": "/pre-processors" },
-      { "name": "Comment utiliser JSX?", "to": "/jsx" },
-      { "name": "Comment utiliser des plugins postcss?", "to": "/postcss-plugins" },
-      { "name": "Comment étendre la configuration de webpack?", "to": "/extend-webpack" },
-      { "name": "Comment ajouter des plugins webpack?", "to": "/webpack-plugins" },
-      { "name": "Comment changer HOST et PORT?", "to": "/host-port" },
-      { "name": "Comment intégrer Google Analytics?", "to": "/google-analytics" }
+      { "name": "How to use external resources? (En)", "to": "" },
+      { "name": "How to use pre-processors? (En)", "to": "/pre-processors" },
+      { "name": "How to use JSX? (En)", "to": "/jsx" },
+      { "name": "How to add postcss plugins? (En)", "to": "/postcss-plugins" },
+      { "name": "How to extend webpack config? (En)", "to": "/extend-webpack" },
+      { "name": "How to add webpack plugins? (En)", "to": "/webpack-plugins" },
+      { "name": "How to edit HOST and PORT? (En)", "to": "/host-port" },
+      { "name": "How to use Google Analytics? (En)", "to": "/google-analytics" }
     ]
   },
   {
     "title": "Développement",
     "links": [
-      { "name": "Window/Document undefined?", "to": "/window-document-undefined" },
-      { "name": "Pourquoi un flash CSS apparaît?", "to": "/css-flash" },
-      { "name": "Données asynchrones dans les composants?", "to": "/async-data-components" },
-      { "name": "Meta Tags dupliqués?", "to": "/duplicated-meta-tags" }
+      { "name": "Window/Document undefined? (En)", "to": "/window-document-undefined" },
+      { "name": "Why a CSS Flash appears? (En)", "to": "/css-flash" },
+      { "name": "Async data in components? (En)", "to": "/async-data-components" },
+      { "name": "Duplicated Meta Tags? (En)", "to": "/duplicated-meta-tags" }
     ]
   },
   {
     "title": "Déploiement",
     "links": [
-      { "name": "Déployer sur Heroku", "to": "/heroku-deployment" },
-      { "name": "Déployer sur Dokku", "to": "/dokku-deployment" },
-      { "name": "Déployer avec Now.sh", "to": "/now-deployment" },
-      { "name": "Déployer avec Surge.sh", "to": "/surge-deployment" },
-      { "name": "Déployer sur GitHub Pages", "to": "/github-pages" }
+      { "name": "How to deploy on Heroku? (En)", "to": "/heroku-deployment" },
+      { "name": "How to deploy with Now.sh? (En)", "to": "/now-deployment" },
+      { "name": "How to deploy on Dokku? (En)", "to": "/dokku-deployment" },
+      { "name": "How to deploy with Surge.sh? (En)", "to": "/surge-deployment" },
+      { "name": "How to deploy on GitHub? (En)", "to": "/github-pages" }
     ]
   }
 ]

--- a/fr/faq/now-deployment.md
+++ b/fr/faq/now-deployment.md
@@ -1,11 +1,11 @@
 ---
-title: Déployer avec Now.sh
-description: Déployer nuxt.js avec Now.sh
+title: Now Deployment
+description: How to deploy Nuxt.js with Now.sh?
 ---
 
-# Déployer avec Now.sh
+# How to deploy with Now.sh? (En)
 
-Pour déployer avec [now.sh](https://zeit.co/now), un fichier `package.json` comme suit est recommandé:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>To deploy with [now.sh](https://zeit.co/now) a `package.json` like follows is recommended:</p>
 ```json
 {
   "name": "my-app",
@@ -20,6 +20,6 @@ Pour déployer avec [now.sh](https://zeit.co/now), un fichier `package.json` com
 }
 ```
 
-Puis exécutez `now` et profiter!
+Then run `now` and enjoy!
 
-Note: nous recommandons d'ajouter `.nuxt` dans `.npmignore` ou `.gitignore`.
+Note: we recommend putting `.nuxt` in `.npmignore` or `.gitignore`.

--- a/fr/faq/postcss-plugins.md
+++ b/fr/faq/postcss-plugins.md
@@ -1,11 +1,11 @@
 ---
-title: Plugins postcss
-description: Comment utiliser des plugins postcss
+title: Postcss plugins
+description: How to add postcss plugins?
 ---
 
-# Comment utiliser des plugins postcss
+# How to add postcss plugins? (En)
 
-Dans votre fichier `nuxt.config.js`:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>In your `nuxt.config.js` file:</p>
 
 ```js
 module.exports = {

--- a/fr/faq/pre-processors.md
+++ b/fr/faq/pre-processors.md
@@ -1,13 +1,13 @@
 ---
-title: Pré-processeurs
-description: Comment utiliser des pré-processeurs avec Nuxt.js?
+title: Pre-processors
+description: How to use pre-processors with Nuxt.js?
 ---
 
-# Comment utiliser des pré-processeurs?
+# How to use pre-processors? (En)
 
-Grâce à [vue-loader](http://vue-loader.vuejs.org/en/configurations/pre-processors.html), vous pouvez utiliser n'importe quel pré-processeur pour vos `<template>`, `<script>` or `<style>`: il suffit d'utiliser l'attribut `lang`.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Thanks to [vue-loader](http://vue-loader.vuejs.org/en/configurations/pre-processors.html), you can use any kind of pre-processors for your `<template>`, `<script>` or `<style>`: simply use the `lang` attribute.</p>
 
-Exemple d'une `pages/index.vue` utilisant [Pug](https://github.com/pugjs/pug), [CoffeeScript](http://coffeescript.org) et [Sass](http://sass-lang.com/):
+Example of our `pages/index.vue` using [Pug](https://github.com/pugjs/pug), [CoffeeScript](http://coffeescript.org) and [Sass](http://sass-lang.com/):
 
 ```html
 <template lang="pug">
@@ -25,7 +25,7 @@ module.exports = data: ->
 </style>
 ```
 
-Pour ête en mesure d'utiliser ces pré-processeurs, nous devons installer leurs loaders webpack:
+To be able to use these pre-processors, we need to install their webpack loaders:
 ```bash
 npm install --save-dev pug@2.0.0-beta6 pug-loader coffee-script coffee-loader node-sass sass-loader
 ```

--- a/fr/faq/surge-deployment.md
+++ b/fr/faq/surge-deployment.md
@@ -1,31 +1,33 @@
 ---
-title: Déployer avec Surge.sh
-description: Déployer nuxt.js avec Surge.sh
+title: Surge Deployment
+description: How to deploy Nuxt.js with Surge.sh?
 ---
 
-# Déployer avec Surge.sh
+# How to deploy with Surge.sh? (En)
 
-Nuxt.js vous donne la possibilité d'héberger votre application web sur n'importe quel hébergeur statique tel que [surge.sh](https://surge.sh/) par exemple.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Nuxt.js gives you the possibility to host your web application on any static hosting like [surge.sh](https://surge.sh/) for example.</p>
 
-Pour déployer sur surge.sh, installez surge sur votre ordinateur:
+To deploy on surge.sh, first install it on your computer:
 ```bash
 npm install -g surge
 ```
 
-Puis demander à nuxt.js de générer votre applicaiton web:
+Then, we tell nuxt.js to generate our web application:
+
 ```bash
 npm run generate
 ```
 
-Cela créera un répertoire `dist` contenant les fichiers prêts à être déployés sur un hébergement statique.
+It will create a `dist` folder with everything inside ready to be deployed on a static hosting.
 
-Nous pouvons alors déployer sur surge.sh:
+We can then deploy it to surge.sh:
+
 ```bash
 surge dist/
 ```
 
-Tadaaa :)
+Done :)
 
-Si vous avez un projet avec des [routes dynamiques](/guide/routing#dynamic-routes), lisez la configuration de [generate](/api/configuration-generate) afin d'expliquer à nuxt.js comment les générer.
+If you have a project with [dynamic routes](/guide/routing#dynamic-routes), take a look at the [generate configuration](/api/configuration-generate) to tell nuxt.js how to generate these dynamic routes.
 
-<div class="Alert">Quand vous générez votre application web via `nuxt generate`, [le contexte](/api) passé to [data()](/guide/async-data#the-data-method) et [fetch()](/guide/vuex-store#the-fetch-method) ne disposent pas de `req` ni de `res`</div>
+<div class="Alert">When generating your web application with `nuxt generate`, [the context](/api) given to [data()](/guide/async-data#the-data-method) and [fetch()](/guide/vuex-store#the-fetch-method) will not have `req` and `res`.</div>

--- a/fr/faq/webpack-plugins.md
+++ b/fr/faq/webpack-plugins.md
@@ -1,11 +1,11 @@
 ---
-title: Plugins webpack
-description: Comment ajouter des plugins webpack?
+title: Webpack plugins
+description: How to add webpack plugins into my Nuxt.js application?
 ---
 
-# Comment ajouter des plugins webpack?
+# How to add webpack plugins? (En)
 
-Dans `nuxt.config.js`:
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>In your `nuxt.config.js` file:</p>
 
 ```js
 const webpack = require('webpack')

--- a/fr/faq/window-document-undefined.md
+++ b/fr/faq/window-document-undefined.md
@@ -1,21 +1,21 @@
 ---
-title: Window/Document undefined
-description: Window/Document undefined avec Nuxt.js?
+title: Window or Document undefined
+description: Window or Document undefined with Nuxt.js?
 ---
 
-# Window/Document undefined?
+# Window or Document undefined? (En)
 
-Cette erreur est du au rendu côté serveur.
-Si vous devez spécifier que vous souhaitez importer une ressource uniquement côté client, vous devez utiliser la variable `process.BROWSER_BUILD`.
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>This is due to the server-side rendering.
+If you need to specify that you want to import a resource only on the client-side, you need to use the `process.browser` variable.</p>
 
-Par exemple, dans votre fichier .vue:
+For example, in your `.vue` file:
 ```js
-if (process.BROWSER_BUILD) {
+if (process.browser) {
   require('external_library')
 }
 ```
 
-N'oubliez pas d'ajouter la librairie dans le [bundle vendor](/api/configuration-build#build-vendor) dans `nuxt.config.js`:
+If you are using this library within multiple files, we recommend that you add it into your [vendor bundle](/api/configuration-build#build-vendor) via `nuxt.config.js`:
 ```js
   build: {
     vendor: ['external_library']

--- a/fr/guide/assets.md
+++ b/fr/guide/assets.md
@@ -1,15 +1,15 @@
 ---
-title: Assets
-description: Nuxt utilise vue-loader, file-loader et url-loader avec Webpack par défaut pour un servir les fichiers statiques, mais vous pouvez également utiliser le répertoire "Static" pour les fichiers statiques.
+title: Ressources
+description: Nuxt utilise vue-loader, file-loader et url-loader avec webpack par défaut pour servir les fichiers statiques mais vous pouvez également utiliser un répertoire `static` pour les fichiers statiques.
 ---
 
-> Nuxt utilise vue-loader, file-loader et url-loader avec Webpack par défaut pour un servir les fichiers statiques, mais vous pouvez également utiliser le répertoire "Static" pour les fichiers statiques.
+> Nuxt utilise vue-loader, file-loader et url-loader avec webpack par défaut pour servir les fichiers statiques mais vous pouvez également utiliser un répertoire `static` pour les fichiers statiques.
 
-## Avec Webpack
+## Avec webpack
 
-Par défaut, [vue-loader](http://vue-loader.vuejs.org/en/) traite automatiquement vos fichiers de style et vos templates à l'aide de `css-loader` et du compilatuer de template de Vue. Dans ce processus de compilation, toutes les URLs des fichiers comme `<img src="...">`, `background: url(...)` et le CSS `@import` sont résolues en tant que dépendances des modules.
+Par défaut, [vue-loader](http://vue-loader.vuejs.org/en/) traite automatiquement vos fichiers de styles et vos templates à l'aide de `css-loader` et du compilateur de template de Vue. Dans ce processus de compilation, toutes les URL des fichiers comme `<img src="...">`, `background: url(...)` et les CSS `@import` sont résolus en tant que dépendances des modules.
 
-Par exemple, avec cette arborescence:
+Imaginons par exemple cette arborescence :
 
 ```bash
 -| assets/
@@ -18,28 +18,29 @@ Par exemple, avec cette arborescence:
 ----| index.vue
 ```
 
-Dans notre CSS, si nous utilisons `url('~assets/image.png')`, ce sera transformé en `require('~assets/image.png')`.
+Dans votre CSS, si nous utilisons `url('~/assets/image.png')`, ce sera transformé en `require('~/assets/image.png')`.
 
-Ou si dans `pages/index.vue` nous utilisons:
+Ou si dans `pages/index.vue` vous utilisez :
+
 ```html
 <template>
   <img src="~assets/image.png">
 </template>
 ```
 
-Ce sera compilé en:
+Ce sera compilé en :
 
 ```js
-createElement('img', { attrs: { src: require('~assets/image.png') }})
+createElement('img', { attrs: { src: require('~/assets/image.png') }})
 ```
 
-Puisque que les fichiers `.png` ne sont pas des fichiers JavaScript, nuxt.js configure Webpack afin d'utiliser [file-loader](https://github.com/webpack/file-loader) et [url-loader](https://github.com/webpack/url-loader) afin de pouvoir s'en charger.
+Puisque que les fichiers `.png` ne sont pas des fichiers JavaScript, Nuxt.js configure webpack pour utiliser [file-loader](https://github.com/webpack/file-loader) et [url-loader](https://github.com/webpack/url-loader) afin de pouvoir s'en charger.
 
 Leurs avantages sont:
-- `file-loader` vous laisse définir ou copier les assets, comment les nommer et vous permets d'utiliser des hash de version pour un meilleur cache.
-- `url-loader` vous permet d'insérer de façon conditionnelle un fichier en tant qu'URL encodée en base 64 si sa taille est inférieure à un seuil donné. Cela peut réduire un certain nombre de demandes HTTP pour les fichiers triviaux. Si la taille du fichier est supérieur au seuil, il retombe automatiquement sur `file-loader`.
+- file-loader vous laisse définir ou copier les ressources, comment les nommer et vous permet d'utiliser des hashs de version pour un meilleur cache.
+- url-loader vous permet d'insérer de façon conditionnelle un fichier en tant qu'URL encodé en base 64 si sa taille est inférieure à un seuil donné. Cela peut réduire un certain nombre de demandes HTTP pour les fichiers triviaux. Si la taille du fichier est supérieure au seuil, il retombe automatiquement sur file-loader.
 
-Actuellement, la configuration des loaders par défaut de Nuxt.js est la suivante:
+Actuellement, la configuration des loaders par défaut de Nuxt.js est la suivante :
 
 ```js
 [
@@ -55,44 +56,45 @@ Actuellement, la configuration des loaders par défaut de Nuxt.js est la suivant
     test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
     loader: 'url-loader',
     query: {
-      limit: 1000, // 1KO
+      limit: 1000, // 1ko
       name: 'fonts/[name].[hash:7].[ext]'
     }
   }
 ]
 ```
 
-Ce qui signifie que tous les fichiers inférieurs à 1KO seront intégrés comme URL base-64. Sinon, l'image/police sera copiée dans son dossier correspondant (dans le répertoire `.nuxt`) avec un nom contenant des hach de version pour une meilleure mise en cache.
+Ce qui signifie que tous les fichiers inférieurs à 1ko seront intégrés comme URL base-64. Sinon, l'image / police sera copiée dans son dossier correspondant (dans le répertoire `.nuxt`) avec un nom contenant des hashs de version pour une meilleure mise en cache.
 
-Lors du lancement de notre application avec `nuxt`, notre modèle dans` pages/index.vue`:
+Lors du lancement de notre application avec `nuxt`, notre template dans `pages/index.vue` :
 
 ```html
 <template>
-  <img src="~assets/image.png">
+  <img src="~/assets/image.png">
 </template>
 ```
 
-Sera transformé en:
+Sera transformé en :
+
 ```html
 <img src="/_nuxt/img/image.0c61159.png">
 ```
 
-Si vous désirez modifier ou désactiver ces loaders, regarder la [documentation sur les loaders](/api/configuration-build#loaders).
+Si vous désirez modifier ou désactiver ces loaders, consultez la documentation sur [la propriété `extend` de la page La propriété `build`](/api/configuration-build#extend).
 
-## Static
+## Avec des fichiers statiques
 
-Si vous ne souhaitez pas utiliser les assets à l'aide de Webpack à partir du répertoire `assets`, vous pouvez créer et utiliser le répertoire` static` dans le répertoire racine du projet.
+Si vous ne souhaitez pas utiliser les ressources à l'aide de webpack à partir du répertoire `assets`, vous pouvez créer et utiliser le répertoire `static` dans le répertoire racine du projet.
 
 Ces fichiers seront automatiquement servis par Nuxt et accessibles via l'URL racine du projet.
 
-Cette option est utile pour les fichiers tels que `robots.txt`,` sitemap.xml` ou `CNAME` (pour GitHub Pages et autres).
+Cette option est utile pour les fichiers tels que `robots.txt`, `sitemap.xml` ou `CNAME` (pour les pages hébergées sur GitHub par ex.).
 
-À partir de votre code, vous pouvez ensuite référencer ces fichiers avec de URLs commencant par `/`:
+À partir de votre code vous pouvez ensuite référencer ces fichiers avec un URL commencant par `/` :
 
 ```html
-<!-- Static image from static directory -->
-<img src="/my-image.png"/>
+<!-- Image statique du répertoire `static` -->
+<img src="/mon-image.png"/>
 
-<!-- Webpacked image from assets directory -->
-<img src="/assets/my-image-2.png"/>
+<!-- Image avec webpack du répertoire `assets` -->
+<img src="~/assets/mon-image-2.png"/>
 ```

--- a/fr/guide/async-data.md
+++ b/fr/guide/async-data.md
@@ -1,25 +1,28 @@
 ---
 title: Données asynchrones
-description: Vous voudrez peut-être récupérer des données et faire le rendu côté serveur. Nuxt.js ajoute une méthode `asyncData` pour vous permettre de gérer les opérations asynchrones avant de définir les données du composant.
+description: Vous voudriez peut-être récupérer des données et faire le rendu côté serveur. Nuxt.js ajoute une méthode `asyncData` pour vous permettre de gérer les opérations asynchrones avant de définir les données du composant.
 ---
 
-> Vous voudrez peut-être récupérer des données et faire le rendu côté serveur. Nuxt.js ajoute une méthode `asyncData` pour vous permettre de gérer les opérations asynchrones avant de définir les données du composant.
+> Vous voudriez peut-être récupérer des données et faire le rendu côté serveur.
+Nuxt.js ajoute une méthode `asyncData` pour vous permettre de gérer les opérations asynchrones avant de définir les données du composant.
 
 ## La méthode asyncData
 
-Parfois, vous souhaitez simplement récupérer des données et les faire le rendu côté serveur sans utiliser de *store*. `asyncData` est appelé avant chaque chargement du composant (**uniquement pour les composants pages**).
+Parfois vous souhaitez simplement récupérer des données et faire le rendu côté serveur sans utiliser de store.
+`asyncData` est appelé avant chaque chargement du composant (**uniquement pour les composants de pages**).
 On peut l'appeler côté serveur ou avant de naviguer vers la route correspondante.
-Cette méthode reçoit [le contexte](/api#context) comme premier argument, vous pouvez l'utiliser pour récupérer des données et nuxt.js fusionnera avec les données du composant.
+Cette méthode reçoit [le contexte](/api#context) comme premier argument, vous pouvez l'utiliser pour récupérer différentes données et Nuxt.js les fusionnera avec les données du composant.
 
-<div class="Alert Alert--orange">Vous **n'avez pas** accès à l'instance du composant via `this` au sein de `data` parce que la fonction est appelée **avant d'initier** le composant.</div>
+<div class="Alert Alert--orange">Vous **n'**avez **PAS** accès à l'instance du composant via `this` au sein de `asyncData` parce que la fonction est appelée **avant d'initier** le composant.</div>
 
-Nuxt.js vous propose différentes façons d'utiliser `asyncData`. Choisissez celle avec laquelle vous êtes le plus familier:
+Nuxt.js vous propose différentes façons d'utiliser `asyncData`. Choisissez celle avec laquelle vous êtes le plus à l'aise :
 
-1. Retourner une `Promise`. Nuxt.js attends que la Promise soit résolue avant de faire le rendu du composant.
-2. En utilisant [async/await](https://github.com/lukehoban/ecmascript-asyncawait) ([en savoir plus](https://zeit.co/blog/async-and-await))
-3. En définissant un callback comme second argument. Il doit être appelé comme suit: `callback(err, data)`
+1. Retourner une `Promise`. Nuxt.js attend que la promesse soit résolue avant de faire le rendu du composant.
+2. En utilisant [async / await](https://github.com/lukehoban/ecmascript-asyncawait) ([en savoir plus](https://zeit.co/blog/async-and-await))
+3. En définissant une fonction de rappel comme second argument. Elle doit être appelée comme suit : `callback(err, data)`
 
-### Retourner une Promise
+### Retourner une promesse
+
 ```js
 export default {
   asyncData ({ params }) {
@@ -31,7 +34,8 @@ export default {
 }
 ```
 
-### Utiliser async/await
+### Utiliser async / await
+
 ```js
 export default {
   async asyncData ({ params }) {
@@ -41,7 +45,9 @@ export default {
 }
 ```
 
-### Utiliser un callback
+### Utiliser une fonction de rappel
+
+>>>>>>> upstream/master
 ```js
 export default {
   asyncData ({ params }, callback) {
@@ -55,8 +61,8 @@ export default {
 
 ### Afficher les données
 
-Le résultat d'`asyncData` sera **mergé** avec les données.
-Vous pouvez afficher les données au sein du template comme habituellement.
+Le résultat de `asyncData` sera **fusionné** avec les données.
+Vous pouvez afficher les données au sein du template comme habituellement :
 
 ```html
 <template>
@@ -64,19 +70,20 @@ Vous pouvez afficher les données au sein du template comme habituellement.
 </template>
 ```
 
-## Le Context
+## Le contexte
 
-Pour voir la liste des attributs disponibles dans le `context`, jeter un oeil à [API Pages data](/api).
+Pour voir la liste des attributs disponibles dans `context`, jeter un œil à [la partie Essentielle de l'API pour `context`](/api/context).
 
 ### Accéder aux données des routes dynamiques
 
-Vous pouvez utiliser l'objet contexte injecté à la propriété `asyncData` afin d'accéder aux données des routes dynamiques. Par example, les données des routes dynamiques peuvent être accédées en utilisant le nom du fichier ou du dossier qui la configure; si vous définissez un fichier nommé `_slug.vue`, vous pourrez y accéder via `context.params.slug`.
+Vous pouvez utiliser l'objet du contexte injecté à la propriété `asyncData` afin d'accéder aux données des routes dynamiques. Par exemple, les données des routes dynamiques peuvent être accédées en utilisant le nom du fichier ou du dossier qui la configure. Si vous définissez un fichier nommé `_slug.vue`, vous pourrez y accéder via `context.params.slug`.
 
 ## Gestion des erreurs
 
-Nuxt.js ajoute la méthode `error(params)` au `context`, vous pouvez l'appeler pour afficher la page d'erreur. `Params.statusCode` sera également utilisé pour faire le rendu avec le code de status approprié côté serveur.
+Nuxt.js ajoute la méthode `error(params)` au `context`, vous pouvez l'appeler pour afficher la page d'erreur. `params.statusCode` sera également utilisée pour faire le rendu avec le code de statut approprié côté serveur.
 
-Exemple avec une `Promise`:
+Exemple avec une `Promise` :
+
 ```js
 export default {
   asyncData ({ params, error }) {
@@ -85,13 +92,14 @@ export default {
       return { title: res.data.title }
     })
     .catch((e) => {
-      error({ statusCode: 404, message: 'Post not found' })
+      error({ statusCode: 404, message: 'Billet non trouvé' })
     })
   }
 }
 ```
 
-Si vous utilisez l'argument `callback`, vous pouvez l'appeler directement en lui passant l'erreur et nuxt.js appellera la méthode `error` pour vous:
+Si vous utilisez l'argument `callback`, vous pouvez l'appeler directement en lui passant l'erreur et Nuxt.js appellera la méthode `error` pour vous :
+
 ```js
 export default {
   asyncData ({ params }, callback) {
@@ -106,4 +114,4 @@ export default {
 }
 ```
 
-Pour modifier la page d'erreur, voir [Views layouts section](/guide/views#layouts).
+Pour personnaliser la page d'erreur, consultez [la partie Mises en page de la section Vues](/guide/views#mises-en-page).

--- a/fr/guide/commands.md
+++ b/fr/guide/commands.md
@@ -1,5 +1,5 @@
 ---
-title: Commandes
+title: Commandes et déploiement
 description: Nuxt.js est livré avec un ensemble de commandes utiles, tant pour le développement que pour la production.
 ---
 
@@ -7,14 +7,23 @@ description: Nuxt.js est livré avec un ensemble de commandes utiles, tant pour 
 
 ## Liste des commandes
 
-| Commande | Description |
-|---------|-------------|
-| nuxt | Lancer un serveur de développement sur [localhost:3000](http://localhost: 3000) avec hot-reloading. |
-| nuxt build | Créez votre application avec un serveur Web et minifiez le JS & CSS (pour la production). |
-| nuxt start | Démarrez le serveur en mode production (après avoir exécuté `nuxt build`). |
+| Commande      | Description                                                                                                       |
+|---------------|-------------------------------------------------------------------------------------------------------------------|
+| nuxt          | Lancer un serveur de développement sur localhost:3000 avec du rechargement à chaud.                               |
+| nuxt build    | Créez votre application avec un serveur web et minifiez les JS & CSS (pour la production).                        |
+| nuxt start    | Démarrez le serveur en mode production (après avoir exécuté `nuxt build`).                                        |
 | nuxt generate | Créez l'application et générez toutes les routes en tant que fichiers HTML (utilisé pour l'hébergement statique). |
 
-Vous devriez ajouter ces commandes à `package.json`:
+#### Arguments
+
+Vous pouvez utiliser `--help` avec n'importe quelle commande pour obtenir des détails d'utilisation. Les arguments communs sont :
+
+- **`--config-file` ou `-c`:** spécifie le chemin vers le fichier `nuxt.config.js`.
+- **`--spa` ou `-s`:** lance la commande en mode application monopage en désactivant le rendu côté serveur.
+
+#### Utiliser un fichier package.json
+
+Vous devriez ajouter ces commandes au `package.json` :
 
 ```json
 "scripts": {
@@ -25,11 +34,13 @@ Vous devriez ajouter ces commandes à `package.json`:
 }
 ```
 
-Ensuite, vous pouvez lancer vos commandes via `npm run <command>` (exemple: `npm run dev`).
+Ensuite, vous pouvez lancer vos commandes via `npm run <command>` (exemple : `npm run dev`).
+
+<p class="Alert Alert--nuxt-green"><b>Astuce :</b> pour passer des arguments à une commande npm, vous devez utiliser un <code>--</code> supplémentaire après le nom du script (exemple : <code>npm run dev -- --spa</code>).</p>
 
 ## Environnement de développement
 
-Pour lancer Nuxt dans le mode de développement avec le hot-reloading:
+Pour lancer Nuxt dans le mode de développement avec le rechargement à chaud :
 
 ```bash
 nuxt
@@ -39,18 +50,19 @@ npm run dev
 
 ## Déploiement en production
 
-Nuxt.js permet de choisir entre 2 modes de déploiement de votre application: Rendu côté serveur ou généré de manière statique.
+Nuxt.js permet de choisir entre trois modes de déploiement pour votre application : rendu côté serveur, application monopage ou généré de manière statique.
 
-### Rendu côté serveur
+### Déploiement pour un rendu côté serveur (universelle)
 
-Pour déployer, au lieu d'exécuter nuxt, vous voulez probablement construire à l'avance. Par conséquent, la construction et le démarrage sont des commandes distinctes:
+Pour déployer, au lieu d'exécuter `nuxt`, vous voulez probablement faire d'abord la construction. Par conséquent, la construction et le démarrage sont des commandes distinctes :
 
 ```bash
 nuxt build
 nuxt start
 ```
 
-Le fichier `package.json` suivant est recommandé:
+Le fichier `package.json` suivant est recommandé :
+
 ```json
 {
   "name": "my-app",
@@ -65,13 +77,13 @@ Le fichier `package.json` suivant est recommandé:
 }
 ```
 
-Note: nous recommandaons d'ajouter `.nuxt` dans `.npmignore` ou `.gitignore`.
+Note : nous recommandons d'ajouter `.nuxt` dans `.npmignore` ou `.gitignore`.
 
-### Généré de manière statique
+### Déploiement pour une génération statique
 
-Nuxt.js vous offre la possibilité d'héberger votre application Web sur tout hébergement statique.
+Nuxt.js vous offre la possibilité d'héberger votre application web sur tout hébergement statique.
 
-Pour générer votre application Web en fichiers statiques:
+Pour générer votre application web en fichiers statiques :
 
 ```bash
 npm run generate
@@ -79,6 +91,22 @@ npm run generate
 
 Il créera un dossier `dist` avec tout à l'intérieur prêt à être déployé sur un hébergement statique.
 
-Si vous avez un projet avec des [routes dynamiques](/guide/routing#dynamic-routes), regarder la [configuration de la commande generate](/api/configuration-generate) afin de dire à nuxt.js comment générer ces routes dynamiques.
+Si vous avez un projet avec des [routes dynamiques](/guide/routing#dynamic-routes), regardez la [configuration de la commande generate](/api/configuration-generate) afin de dire à Nuxt.js comment générer ces routes dynamiques.
 
-<div class="Alert">Lors de la génération de votre application Web avec `nuxt generate`, le contexte donné à [data()](/guide/async-data#the-data-method) et [fetch()](/guide/vuex-store#the-fetch-method) n'a pas de `req` et `res`.</div>
+<div class="Alert">Lors de la génération de votre application web avec `nuxt generate`, [le contexte](/api/context) donné à [data()](/guide/async-data#la-m-thode-data) et [fetch()](/guide/vuex-store#la-m-thode-fetch) n'aura pas de `req` et `res`.</div>
+
+### Déploiement pour une application monopage (SPA)
+
+`nuxt generate` a toujours besoin du SSR pendant le temps de génération afin de prérendre nos pages dans le but d'obtenir un chargement de page rapide et du contenu solide pour la SEO. Le contenu est généré lors de la *phase de build*. Il ne faut pas l'utiliser, par exemple, pour les applications ou le contenu dépend de l'authentification de l'utilisateur ou pour une API en temps réel (du moins pour le premier chargement).
+
+L'idée de l'application monopage est simple ! Quand le mode SPA est activé en utilisant `mode: 'spa'` ou l'option `--spa`, la génération se lance automatiquement après le build mais cette fois sans contenu de page et seulement avec les meta, ressources et liens communs.
+
+Donc pour un déploiement en mode SPA :
+
+- Changez le `mode` dans `nuxt.config.js` pour `spa`.
+- Lancez `npm run build`.
+- Déployez le dossier `dist/` créé sur votre hébergement statique comme Surge, GitHub Pages ou nginx.
+
+Une autre possibilité de déploiement est que nous pouvons utiliser Nuxt comme un middleware dans des frameworks si le mode est `spa`. Ceci aide à réduire le temps de chargement et à utiliser Nuxt dans des projets ou le SSR n'est pas possible.
+
+<div class="Alert">Consultez [Comment déployer sur Heroku ?](/faq/heroku-deployment) pour un exemple de déploiement sur des hébergements populaires.</div>

--- a/fr/guide/configuration.md
+++ b/fr/guide/configuration.md
@@ -1,85 +1,92 @@
 ---
 title: Configuration
-description: La configuration par défaut de Nuxt.js couvre la plupart des usages. Cependant, le fichier nuxt.config.js vous permet de la modifier.
+description: La configuration par défaut de Nuxt.js couvre la plupart des cas d'usage. Cependant, le fichier `nuxt.config.js` vous permet de la modifier.
 ---
 
-> La configuration par défaut de Nuxt.js couvre la plupart des usages. Cependant, le fichier nuxt.config.js vous permet de la modifier.
+> La configuration par défaut de Nuxt.js couvre la plupart des cas d'usage. Cependant, le fichier `nuxt.config.js` vous permet de la modifier.
 
+## Options
 
 ### build
 
-Cette option vous permet d'ajouter des modules à l'intérieur du fichier vendor.bundle.js généré pour réduire la taille du *bundle* de l'application. Vraiment utile lors de l'utilisation de modules externes.
+Cette option vous permet d'ajouter des modules à l'intérieur du fichier `vendor.bundle.js` généré pour réduire la taille du paquetage de l'application. Vraiment utile lors de l'utilisation de modules externes.
 
-[Documentation à propos de build](/api/configuration-build)
+[Consultez la documentation à propos de `build`](/api/configuration-build)
 
 ### cache
 
 Cette option vous permet de mettre en cache les composants pour améliorer les performances de rendu.
 
-[Documentation à propos de cache](/api/configuration-cache)
+[Consultez la documentation à propos de `cache`](/api/configuration-cache)
 
 ### css
 
-Cette option vous permet de définir les fichiers/modules/librairies CSS que vous voulez comme global (incluts dans chaque page).
+Cette option vous permet de définir les fichiers / modules / bibliothèques CSS que vous voulez en global (inclus dans chaque page).
 
-[Documentation à propos de css](/api/configuration-css)
+[Consultez la documentation à propos de `css`](/api/configuration-css)
 
 ### dev
 
-Cette option vous permet de définir le mode de développement ou de production de nuxt.js
+Cette option vous permet de définir le mode `development` ou le mode `production` de Nuxt.js.
 
-[Documentation à propos de dev](/api/configuration-dev)
+[Consultez la documentation à propos de `dev`](/api/configuration-dev)
 
 ### env
 
 Cette option vous permet de définir des variables d'environnements disponible côté client et côté serveur.
 
-[Documentation à propos de env](/api/configuration-env)
+[Consultez la documentation à propos de `env`](/api/configuration-env)
 
 ### generate
 
 Cette option vous permet de définir chaque paramètre pour chaque route dynamique de votre application transformée en fichiers HTML par Nuxt.js.
 
-[Documentation à propos de generate](/api/configuration-generate)
+[Consultez la documentation à propos de `generate`](/api/configuration-generate)
 
 ### head
 
-Cette option vous permet de définir les attributs *meta* par défaut de votre application.
+Cette option vous permet de définir les balises meta par défaut de votre application.
 
-[Documentation à propos de head](/api/configuration-head)
+[Consultez la documentation à propos de `head`](/api/configuration-head)
 
 ### loading
 
-Cette option vous permet de customiser le *loading component* chargé par défaut par Nuxt.js
+Cette option vous permet de personnaliser le composant de chargement par défaut chargé par Nuxt.js
 
-[Documentation à propos de loading](/api/configuration-loading)
+[Consultez la documentation à propos de `loading`](/api/configuration-loading)
+
+### modules
+
+Cette option vous permet d'ajouter des modules Nuxt a votre projet.
+
+[Consultez la documentation à propos de `modules`](/api/configuration-modules)
 
 ### plugins
 
-Cette option vous permet de définir des plugins Javascript qui seront exécutés avant d'instancier la racine de l'application vue.js.
+Cette option vous permet de définir des plugins JavaScript qui seront exécutés avant d'instancier la racine de l'application Vue.js.
 
-[Documentation à propos de plugins](/api/configuration-plugins)
+[Consultez la documentation à propos de `plugins`](/api/configuration-plugins)
 
 ### rootDir
 
-Cette option vous permet de définir le workspace de votre application nuxt.js.
+Cette option vous permet de définir l'espace de travail de votre application Nuxt.js.
 
-[Documentation à propos de rootDir](/api/configuration-rootdir)
+[Consultez la documentation à propos de `rootDir`](/api/configuration-rootdir)
 
 ### router
 
-Cette option vous permet de modifier la configuration Nuxt.js par défaut de vue-router.
+Cette option vous permet de modifier la configuration Nuxt.js par défaut de Vue Router.
 
-[Documentation à propos de router](/api/configuration-router)
+[Consultez la documentation à propos de `router`](/api/configuration-router)
 
 ### srcDir
 
-Cette option vous permet de définir le dossier source de votre application nuxt.js.
+Cette option vous permet de définir le dossier source de votre application Nuxt.js.
 
-[Documentation à propos de srcDir](/api/configuration-srcdir)
+[Consultez la documentation à propos de `srcDir`](/api/configuration-srcdir)
 
 ### transition
 
 Cette option vous permet de définir les propriétés par défaut des transitions de pages.
 
-[Documentation à propos de transition](/api/configuration-transition)
+[Consultez la documentation à propos de `transition`](/api/configuration-transition)

--- a/fr/guide/contribution-guide.md
+++ b/fr/guide/contribution-guide.md
@@ -1,19 +1,19 @@
 ---
 title: Guide de contribution
-description: Toute contribution à Nuxt.js est plus que bienvenue!
+description: Toute contribution à Nuxt.js est plus que bienvenue !
 ---
 
-> Toute contribution à Nuxt.js est plus que bienvenue!
+> Toute contribution à Nuxt.js est plus que bienvenue !
 
-## Reporter les problèmes (Issues)
+## Rapports de problème
 
-Une excellente façon de contribuer au projet est d'envoyer un rapport détaillé lorsque vous rencontrez un problème. Nous apprécions toujours un rapport de bogue bien écrit et nous vous en remercierons! Avant de signaler un problème, lisez attentivement la documentation et recherchez votre problème n'a pas déjà été reporté ou résolu: [https://github.com/nuxt/nuxt.js/issues](https://github.com/nuxt/nuxt.js/issues)
+Une excellente façon de contribuer au projet est d'envoyer un rapport (« issue ») détaillé lorsque vous rencontrez un problème. Nous apprécions toujours un rapport de bogue bien écrit et nous vous en remercierons ! Avant de signaler un problème, lisez attentivement la documentation et vérifiez si votre problème n'a pas déjà été reporté ou résolu : [https://github.com/nuxt/nuxt.js/issues](https://github.com/nuxt/nuxt.js/issues)
 
-## Pull Requests
+## Propositions de fusion
 
-Nous adorerons de voir vos *pull requests*, même si il s'agit uniquement de la correction d'une typo. Toute amélioration significative devrait être documentée en tant qu'[*issue* sur GitHub](https://github.com/nuxt/nuxt.js/issues) avant que quelqu'un ne commence à y travailler.
+Nous adorerions voir vos propositions de fusion (« pull requests »), même s'il s'agit uniquement de corrections orthographiques. Toute amélioration significative devrait être documentée dans [un rapport détaillé sur GitHub](https://github.com/nuxt/nuxt.js/issues) avant que quelqu'un ne commence à y travailler.
 
 ### Convention
 
-- Pour un correctif, le nom de la branche devrait être `fix-XXX` où XXX est le numéro de l'issue correspondante ou le nom de votre correctif
-- Pour une fonctionnalité, le nom de la branche doit être `feature-XXX` où XXX est le numéro de l'issue correspondante à cette demande de fonctionnalité
+- Pour un correctif, le nom de la branche devrait être `fix-XXX` où `XXX` est le numéro du rapport correspondant ou le nom de votre correctif.
+- Pour une fonctionnalité, le nom de la branche doit être `feature-XXX` où `XXX` est numéro du rapport correspondante à cette demande de fonctionnalité.

--- a/fr/guide/development-tools.md
+++ b/fr/guide/development-tools.md
@@ -1,20 +1,21 @@
 ---
 title: Outils de développement
-description: Nuxt.js rend votre développement web agréable.
+description: Nuxt.js vous aide à rendre votre développement web agréable.
 ---
 
 > Le test de votre application fait partie du développement web. Nuxt.js vous aide à le rendre aussi facile que possible.
 
-## Tests End-to-End
+## Tests de bout en bout
 
-[Ava](https://github.com/avajs/ava) est un framework JavaScript de test puissant, mixé avec [jsdom](https://github.com/tmpvar/jsdom), nous pouvons les utiliser pour écrire des tests end-to-end testing facilement.
+[AVA](https://github.com/avajs/ava) est un framework JavaScript de test puissant, mixé avec [jsdom](https://github.com/tmpvar/jsdom), nous pouvons les utiliser pour écrire des tests de bout en bout facilement.
 
-Tout d'abord, nous devons ajouter ava et jsdom en tant que dépendances de développement:
+Tout d'abord, nous devons ajouter AVA et jsdom en tant que dépendances de développement :
+
 ```bash
 npm install --save-dev ava jsdom
 ```
 
-Et ajouter un script de test à notre `package.json` et configurer ava pour compiler les fichiers que nous importons dans nos tests.
+Puis ajouter un script de test à notre `package.json` et configurer AVA pour compiler les fichiers que nous importons dans nos tests.
 
 ```javascript
 "scripts": {
@@ -32,21 +33,23 @@ Et ajouter un script de test à notre `package.json` et configurer ava pour comp
 }
 ```
 
-Nous allons écrire nos tests dans le répertoire `test`:
+Nous allons écrire nos tests dans le répertoire `test` :
+
 ```bash
 mkdir test
 ```
 
-Mettons que nous avons une page dans `pages/index.vue`:
+Imaginons que nous avons une page dans `pages/index.vue` :
+
 ```html
 <template>
-  <h1 class="red">Hello {{ name }}!</h1>
+  <h1 class="red">Hello {{ name }} !</h1>
 </template>
 
 <script>
 export default {
   data () {
-    return { name: 'world' }
+    return { name: 'World' }
   }
 }
 </script>
@@ -58,20 +61,20 @@ export default {
 </style>
 ```
 
-Lorsque nous lançons notre application avec `npm run dev` et que nous visitons [http://localhost:3000](http://localhost:3000), nous voyons notre titre `Hello world!` rouge.
+Lorsque nous lançons notre application avec `npm run dev` et que nous visitons http://localhost:3000, nous voyons notre titre `Hello World !` rouge.
 
-Nous ajoutons notre fichier de test `test/index.test.js`:
+Nous ajoutons notre fichier de test `test/index.test.js` :
 
 ```js
 import test from 'ava'
 import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
-// We keep the nuxt and server instance
-// So we can close them at the end of the test
+// Nous gardons une référence à Nuxt pour fermer
+// le serveur à la fin du test
 let nuxt = null
 
-// Init Nuxt.js and create a server listening on localhost:4000
+// Initialiser Nuxt.js et démarrer l'écoute sur localhost:4000
 test.before('Init Nuxt.js', async t => {
   const rootDir = resolve(__dirname, '..')
   let config = {}
@@ -83,47 +86,49 @@ test.before('Init Nuxt.js', async t => {
   nuxt.listen(4000, 'localhost')
 })
 
-// Example of testing only generated html
+// Exemple de test uniquement sur le HTML généré
 test('Route / exits and render HTML', async t => {
   let context = {}
   const { html } = await nuxt.renderRoute('/', context)
-  t.true(html.includes('<h1 class="red">Hello world!</h1>'))
+  t.true(html.includes('<h1 class="red">Hello World !</h1>'))
 })
 
-// Example of testing via dom checking
+// Exemple de test via la vérification du DOM
 test('Route / exits and render HTML with CSS applied', async t => {
   const window = await nuxt.renderAndGetWindow('http://localhost:4000/')
   const element = window.document.querySelector('.red')
   t.not(element, null)
-  t.is(element.textContent, 'Hello world!')
+  t.is(element.textContent, 'Hello World !')
   t.is(element.className, 'red')
   t.is(window.getComputedStyle(element).color, 'red')
 })
 
-// Close server and ask nuxt to stop listening to file changes
-test.after('Closing server and nuxt.js', t => {
+// Arrêter le serveur Nuxt
+test.after('Closing server', t => {
   nuxt.close()
 })
 ```
 
-Nous pouvons désormais lancer nos tests:
+Nous pouvons désormais lancer nos tests :
+
 ```bash
 npm test
 ```
 
-jsdom a certaines limitations parce qu'il n'utilise pas de navigateur. Cependant, cela couvrira la plupart de nos tests. Si vous souhaitez utiliser un navigateur pour tester votre application, vous pouvez consulter [Nightwatch.js] (http://nightwatchjs.org).
+jsdom a certaines limitations parce qu'il n'utilise pas de navigateur. Cependant, cela couvrira la plupart de nos tests. Si vous souhaitez utiliser un navigateur pour tester votre application, vous pouvez consulter [Nightwatch.js](http://nightwatchjs.org).
 
 ## ESLint
 
-> ESLint est un excellent outil pour garder votre code propre
+> ESLint est un excellent outil pour garder votre code propre.
 
-Vous pouvez ajouter [ESLint](http://eslint.org) assez facilement avec nuxt.js. Ajouter les dépendances npm:
+Vous pouvez ajouter [ESLint](http://eslint.org) assez facilement avec Nuxt.js. Ajouter les dépendances npm :
 
 ```bash
 npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard
 ```
 
-Puis, configurez ESLint via un fichier `.eslintrc.js` à la racine de votre projet:
+Puis, configurez ESLint via un fichier `.eslintrc.js` à la racine de votre projet :
+
 ```js
 module.exports = {
   root: true,
@@ -143,7 +148,7 @@ module.exports = {
 }
 ```
 
-Ensuite, vous pouvez ajouter un script `lint` à `package.json`:
+Ensuite, vous pouvez ajouter un script `lint` à `package.json` :
 
 ```js
 "scripts": {
@@ -151,11 +156,12 @@ Ensuite, vous pouvez ajouter un script `lint` à `package.json`:
 }
 ```
 
-Vous pouvez alors lancer:
+Vous pouvez alors lancer :
+
 ```bash
 npm run lint
 ```
 
 ESLint va linter tous vos fichiers JavaScript et Vue sauf ceux ignorés par `.gitignore`.
 
-<p class="Alert Alert--info">Une bonne pratique est également d'ajouter `"precommit": "npm run lint"` dans package.json afin de linter votre code automatiquement avant de le commiter.</p>
+<p class="Alert Alert--info">Une bonne pratique est également d'ajouter `"precommit": "npm run lint"` dans `package.json` afin de linter votre code automatiquement avant de l'acter.</p>

--- a/fr/guide/directory-structure.md
+++ b/fr/guide/directory-structure.md
@@ -1,97 +1,89 @@
 ---
 title: Structure des répertoires
-description: La structure d'application Nuxt.js par défaut est destinée à fournir un excellent point de départ pour les applications petites et grandes. Bien sûr, vous êtes libre d'organiser votre application comme vous le souhaitez.
+description: La structure par défaut d'une application Nuxt.js est destinée à fournir un excellent point de départ pour les petites et grandes applications. Bien sûr, vous êtes libre d'organiser votre application comme vous le souhaitez.
 ---
 
-> La structure d'application Nuxt.js par défaut est destinée à fournir un excellent point de départ pour les applications petites et grandes. Bien sûr, vous êtes libre d'organiser votre application comme vous le souhaitez.
+> La structure par défaut d'une application Nuxt.js est destinée à fournir un excellent point de départ pour les petites et grandes applications. Bien sûr, vous êtes libre d'organiser votre application comme vous le souhaitez.
 
 ## Répertoires
 
-### Le répertoire Assets
+### Le répertoire des ressources
 
-Le répertoire `assets` contient vos *assets*  non-compilés (p.e. LESS, SASS, or JavaScript).
+Le répertoire `assets` contient vos ressources non compilées tels que vos fichiers Less, Sass ou JavaScript.
 
-[Plus de documentation à propos des Assets](/guide/assets)
+[Consultez la documentation à propos de l'intégration des ressources](/guide/assets)
 
-### Le répertoire Components
+### Le répertoire des composants
 
-Le répertoire `components` contient vos composants Vue.js. Nuxt.js ne *supercharge* pas la méthode `data` sur ces composants.
+Le répertoire `components` contient vos composants Vue.js. Nuxt.js ne surcharge pas la méthode `data` sur ces composants.
 
-### Le répertoire Layouts
+### Le répertoire des mises en page
 
-Le répertoire `layouts` contient vos layouts.
+Le répertoire `layouts` contient vos mises en page.
 
-*Ce répertoire ne peut pas être renommé.*
+_Ce répertoire ne peut pas être renommé._
 
-[Plus de documentation à propos des Layouts](/guide/views#layouts)
+[Consultez la documentation à propos de l'intégration des mises en page](/guide/views#layouts)
 
-### Le répertoire Middleware
+### Le répertoire des middlewares
 
-Le répertoire `middleware` contient vos Middleware. Un middleware vous permets de définir une fonction qui sera exécutée avant de faire le rendu d'une page ou d'un groupe de pages (layouts).
+Le répertoire `middleware` contient vos middlewares. Un middleware vous permet de définir une fonction qui sera exécutée avant de faire le rendu d'une mise en page ou d'un groupe de mises en page.
 
-[Plus de documentation à propos des Middleware](/guide/routing#middleware)
+[Consultez la documentation à propos de l'intégration des middlewares](/guide/routing#middleware)
 
-### Le répertoire Pages
+### Le répertoire des pages
 
-Le répertoire `pages` contient vos vues (*Views*) et vos routes (*Routes*). Le framework lit tous vos fichiers `.vue` au sein de ce répertoire et créé automatiquement le routage de votre application.
+Le répertoire `pages` contient vos vues et routes de l'application. Le framework lit tous vos fichiers `.vue` au sein de ce répertoire et crée automatiquement le routage de votre application.
 
-*Ce répertoire ne peut pas être renommé.*
+_Ce répertoire ne peut pas être renommé._
 
-[Plus de documentation à propos des Pages](/guide/views)
+[Consultez la documentation à propos de l'intégration des pages](/guide/views)
 
-### Le répertoire Plugins
+### Le répertoire des plugins
 
-Le répertoire `plugins` contient vos plugins Javascript que vous désirez exécuter avant d'instancier la racine de l'application vue.js.
+Le répertoire `plugins` contient les plugins JavaScript que vous désirez exécuter avant d'instancier l'application Vue.js racine.
 
-[Plus de documentation à propos des Plugins](/guide/plugins)
+[Consultez la documentation à propos de l'intégration des plugins](/guide/plugins)
 
-### Le répertoire Static
+### Le répertoire des fichiers statiques
 
-Le répertoire `static` contient vos fichiers statiques. Chaque fichier au sein de ce répertoire est mappé vers /.
+Le répertoire `static` contient vos fichiers statiques. Chaque fichier au sein de ce répertoire est mappé à `/`.
 
-**Exemple:** /static/robots.txt est mappé vers /robots.txt
+**Exemple :** `/static/robots.txt` est mappé à `/robots.txt`
 
-*Ce répertoire ne peut pas être renommé.*
+_Ce répertoire ne peut pas être renommé._
 
-[Plus de documentation à propos des fichiers statiques](/guide/assets#static)
+[Consultez la documentation à propos de l'intégration des fichiers statiques](/guide/assets#static)
 
-### Le répertoire Store
+### Le répertoire des stores
 
-Le répertoire `store` contient vos fichiers [Vuex Store](http://vuex.vuejs.org). Vuex Store est implémenté de manière optionnelle dans le framework Nuxt.js. La création d'un fichier `index.js` dans ce répertoire active automatiquement l'option dans le framework.
+Le répertoire `store` contient vos fichiers de [store Vuex](https://vuex.vuejs.org/fr/). Les stores Vuex sont implémentés de manière optionnelle dans le framework Nuxt.js. La création d'un fichier `index.js` dans ce répertoire active automatiquement l'option dans le framework.
 
-*Ce répertoire ne peut pas être renommé.*
+_Ce répertoire ne peut pas être renommé._
 
-[Plus de documentation à propos des Store](/guide/vuex-store)
+[Consultez la documentation à propos de l'intégration des stores Vuex](/guide/vuex-store)
 
 ### Le fichier nuxt.config.js
 
 Le fichier `nuxt.config.js` contient vos configurations personnalisées concernant Nuxt.js.
 
-*Ce fichier ne peut pas être renommé.*
+_Ce fichier ne peut pas être renommé._
 
-[Plus de documentation à propos de nuxt.config.js](/guide/configuration)
+[Consultez la documentation à propos de l'intégration de `nuxt.config.js`](/guide/configuration)
 
 ### Le fichier package.json
 
 Le fichier `package.json` contient les dépendances et scripts de votre application.
 
-*Ce fichier ne peut pas être renommé.*
+_Ce fichier ne peut pas être renommé._
 
 ## Alias
 
 | Alias | Répertoire |
 |-----|------|
-| ~ | / |
-| ~assets | /assets |
-| ~components | /components |
-| ~middleware | /middleware |
-| ~pages | /pages |
-| ~plugins | /plugins |
-| ~static | /static |
+| `~` or `@` | [srcDir](/api/configuration-srcdir) |
+| `~~` or `@@` | [rootDir](/api/configuration-rootdir) |
 
-Alias redirigeant vers des fichiers:
+Par défaut, `srcDir` est le même répertoire que `rootDir`.
 
-| Alias | Utilisation | Description |
-|-------|------|--------------|
-| ~store | `const store = require('~store')` | Importe l'instance du store `vuex`. |
-| ~router | `const router = require('~router')`| Importe l'instance `vue-router`. |
+<p class="Alert Alert--nuxt-green"><b>Info :</b> à l'intérieur de vos templates `vue`, si vous avez besoin de faire référence à vos répertoires `assets` ou `static`, utilisez par ex. `~/assets/votre_image.png` et `~/static/votre_image.png`.</p>

--- a/fr/guide/index.md
+++ b/fr/guide/index.md
@@ -1,75 +1,82 @@
 ---
 title: Introduction
-description: "Le 25 octobre 2016, l'équipe derrière zeit.co, annoncait Next.js, un framework pour les applications React rendues côtés serveur. Quelques heures après l'annonce, l'idée de créer un équivalent pour les applications Vue.js était évident: Nuxt.js était né."
+description: "Le 25 octobre 2016, l'équipe derrière zeit.co, annonçait Next.js, un framework pour les applications React rendues côté serveur. Quelques heures après l'annonce, l'idée de créer un équivalent pour les applications Vue.js était évidente : Nuxt.js était né."
 ---
 
-> Le 25 octobre 2016, l'équipe derrière [zeit.co](https://zeit.co/), annoncait [Next.js](https://zeit.co/blog/next), un framework pour les applications React rendues côtés serveur. Quelques heures après l'annonce, l'idée de créer un équivalent pour les applications [Vue.js](https://vuejs.org) était évident: Nuxt.js était né.
+> Le 25 octobre 2016, l'équipe derrière [zeit.co](https://zeit.co/), annonçait [Next.js](https://zeit.co/blog/next), un framework pour les applications React rendues côté serveur. Quelques heures après l'annonce, l'idée de créer un équivalent pour les applications [Vue.js](https://fr.vuejs.org) était évidente : Nuxt.js était né.
 
-## Qu'est-ce que Nuxt.js ?
+## Nuxt.js, qu’est-ce que c’est ?
 
 Nuxt.js est un framework pour créer des applications Vue.js universelles.
 
-Son champ principal est le **rendu UI** tout en abstrayant la distribution client/server.
+Son principal but est de **faire le rendu d'interface utilisateur (« UI »)** en faisant abstraction de la distribution entre le client et le serveur.
 
-Notre but est de créer un framework suffisament flexible afin que vous puissiez l'utiliser comme base dans un projet principal ou en tant que supplément pour votre projet actuel basé sous Node.js.
+Notre but est de créer un framework suffisamment flexible afin que vous puissiez l'utiliser comme base dans un projet principal ou en tant que supplément pour votre projet actuel basé sur Node.js.
 
-Nuxt.js prédéfinit toute la configuration nécessaire pour rendre votre développement d'une application Vue.js rendue côté serveur plus agréable.
+Nuxt.js prédéfinit toute la configuration nécessaire pour faire de votre développement d'application Vue.js rendue côté serveur quelque chose d'agréable.
 
-En outre, nous fournissons également une autre option de déploiement appelée: *nuxt generate*. Elle permet de construire une application Vue.js générée statiquement (**Static Generated**).
-Nous croyons que cette option pourrait être la prochaine étape importante dans le développement d'applications Web avec microservices.
+En outre, nous fournissons également une autre option de déploiement appelée : *nuxt generate*. Elle permet de construire une application Vue.js **générée statiquement**.
+Nous croyons que cette option pourrait être la prochaine étape importante dans le développement d'applications web avec des microservices.
 
-En tant que framework, Nuxt.js est doté de nombreuses fonctionnalités pour vous aider dans votre développement entre le côté client et le côté serveur telles que les données asynchrones, les *middlewares*, les *layouts*, etc.
+En tant que framework, Nuxt.js est doté de nombreuses fonctionnalités pour vous aider dans votre développement entre côté client et serveur tels que les données asynchrones, les *middlewares*, les *layouts*, etc.
 
 ## Comment ça marche
 
-![Vue avec Webpack et Babel](https://i.imgur.com/avEUftE.png)
+![Vue avec webpack et Babel](https://i.imgur.com/avEUftE.png)
 
-Nuxt.js comprends les éléments suivants afin de créer une expérience de développement optimale:
-- [Vue 2](https://github.com/vuejs/vue)
-- [Vue-Router](https://github.com/vuejs/vue-router)
-- [Vuex](https://github.com/vuejs/vuex) (inclut uniquement quand l'[option "store"](/guide/vuex-store) est activée)
-- [Vue-Meta](https://github.com/declandewet/vue-meta)
+Nuxt.js inclut les éléments suivants afin de créer une expérience de développement optimale :
 
-Un total de seulement **28kb min+gzip** (31kb avec vuex).
+- [Vue 2](https://fr.vuejs.org/)
+- [Vue Router](https://router.vuejs.org/fr/)
+- [Vuex](https://ssr.vuejs.org/fr/) (inclut uniquement quand l'[option `store`](/guide/vuex-store) est activée)
+- [vue-meta](https://github.com/declandewet/vue-meta)
 
-Sous le capot, nous utilisons [Webpack](https://github.com/webpack/webpack) avec [vue-loader](https://github.com/vuejs/vue-loader) et [babel-loader](https://github.com/babel/babel-loader) pour regrouper (*bundle*), *code-split* et minifier votre code.
+Un total de seulement **57ko min+gzip** (53ko avec Vuex).
+
+Sous le capot, nous utilisons [webpack](https://github.com/webpack/webpack) avec [vue-loader](https://github.com/vuejs/vue-loader) et [babel-loader](https://github.com/babel/babel-loader) pour empaqueter (« bundle »), scinder (« code-split ») et minifier votre code.
 
 ## Fonctionnalités
 
-- Écris des fichiers Vue (**.vue*)
-- *Code splitting* automatique
-- Rendu coté serveur (*Server-Side Rendering* / SSR)
-- Système de routage puissant à l'aide des données asynchrones (*Asynchronous Data*)
-- Sert les fichiers statiques (*Static File Serving*)
-- ES6/ES7 Transpilation
-- Bundle et minification de vos fichiers JS et CSS
-- Management des éléments *Head*
-- Hot reloading pendant le développement
-- Pré-processeur: SASS, LESS, Stylus, etc
+- Écriture des fichiers Vue (`*.vue*`)
+- Scission de code automatique
+- Rendu coté serveur (ou « SSR » pour « Server-Side Rendering »)
+- Routage puissant à l'aide de données asynchrones
+- Génération de fichiers statiques
+- Transpilation ES6/ES7
+- Empaquetage et minification de vos fichiers JS et CSS
+- Gestion des éléments de balise d'en-tête `<head>` HTML (`<title>`, `<meta>`, etc.)
+- Rechargement à chaud pendant le développement
+- Préprocesseur : Sass, Less, Stylus, etc.
+- Entête HTTP/2 PUSH
+- Extensibilité avec une architecture modulaire
 
 ## Schéma
 
-Ce schéma (en anglais) montre ce qui est invoqué par nuxt.js quand le serveur est appelé ou quand l'utilisateur navigue dans l'application à l'aide de `<nuxt-link>`:
+Ce schéma (en anglais) montre ce qui est invoqué par Nuxt.js quand le serveur est appelé ou quand l'utilisateur navigue dans l'application à l'aide de `<nuxt-link>` :
 
 ![nuxt-schema](/nuxt-schema.png)
 
-## Rendu côté serveur
+## Rendu côté serveur (SSR universel)
 
-Vous pouvez utiliser nuxt.js en tant que framework afin de gérer le rendu complet de l'UI de votre projet.
+Vous pouvez utiliser Nuxt.js comme framework pour gérer le rendu complet de l'interface utilisateur de votre projet.
 
-Lors de la commande `nuxt`, il va démarrer un serveur de développement avec *hot-reloading* et *vue-server-renderer* configurés afin de servir atuomatiquement votre application rendue côté serveur.
+En utilisant la commande `nuxt`, Nuxt démarrera un serveur de développement avec rechargement à chaud et [Vue Server Renderer](https://ssr.vuejs.org/fr/) sera configuré pour faire automatiquement le rendu de votre application côté serveur.
 
-Jetez un oeil aux [commandes](/guide/commands) pour en savoir plus.
+### Application monopage
 
-Si vous avez déjà un serveur, vous pouvez greffer nuxt.js en l'utilisant comme middleware. Il n'y a aucune restrictions quand vous utilisez nuxt.js pour développer votre application web universelle; voir le guide [Using Nuxt.js Programmatically](/api/nuxt).
+Si pour une quelconque raison vous préférez ne pas utiliser le rendu côté serveur ou que vous avez besoin d'un hébergement statique pour votre application, vous pouvez simplement utiliser le mode application monopage (ou « SPA » pour « Simple Page Application ») en utilisant la commande `nuxt --spa`. Combiné avec la fonctionnalité de *génération*, vous avez la une puissante application monopage qui ne nécessite aucunement de Node.js ou d'un serveur spécial pour fonctionner.
 
-## Génération d'applications statique
+Jetez un œil à [la liste des commandes](/guide/commands) pour en savoir plus.
 
-La grande innovation de nuxt.js est: `nuxt generate`
+Si vous avez déjà un serveur, vous pouvez greffer Nuxt.js en l'utilisant comme middleware. Il n'y a aucune restriction quand vous utilisez Nuxt.js pour développer votre application web universelle. Consultez le guide d'[Utilisation de Nuxt.js par programmation](/api/nuxt).
 
-Lors de la création de votre application, il générera le code HTML de chacune de vos routes pour le stocker dans un fichier.
+## Génération statique (pré-rendu)
 
-Exemple:
+La grande innovation de Nuxt.js est : `nuxt generate`
+
+Lors de la création de votre application, il génèrera le code HTML de chacune de vos routes pour le stocker dans un fichier.
+
+Exemple :
 
 ```bash
 -| pages/
@@ -77,7 +84,8 @@ Exemple:
 ----| index.vue
 ```
 
-Va générer:
+Cela générera :
+
 ```
 -| dist/
 ----| about/
@@ -85,18 +93,20 @@ Va générer:
 ----| index.html
 ```
 
-De cette façon, vous pouvez héberger votre application web sur n'importe quel hébergement statique!
+De cette façon, vous pouvez héberger votre application web sur n'importe quel hébergement statique !
 
-Le meilleur exemple est ce site web. Il est généré et hébergé sur GitHub Pages:
+Le meilleur exemple est ce site web. Il est généré et hébergé sur le système d'hébergement de page de GitHub :
+
 - [Code source](https://github.com/nuxt/nuxtjs.org) (en anglais)
 - [Code généré](https://github.com/nuxt/nuxtjs.org/tree/gh-pages) (en anglais)
 
-Nous ne voulons pas devoir générer manuellement l'application à chaque fois que nous mettons à jour la [documentation](https://github.com/nuxt/docs), du coup chaque modification réalisée invoque une fonction AWS Lambda qui:
-1. Clone le [répertoire nuxtjs.org](https://github.com/nuxt/nuxtjs.org)
+Nous ne voulons pas générer manuellement l'application à chaque fois que nous mettons à jour la [documentation](https://github.com/nuxt/docs), du coup chaque modification réalisée invoque une fonction AWS Lambda qui :
+
+1. Clone le [dépôt nuxtjs.org](https://github.com/nuxt/nuxtjs.org)
 2. Installe les dépendances via `npm install`
 3. Lance `nux generate`
 4. Déploie le dossier `dist` sur la branche `gh-pages`
 
-Et nous voilà avec une **Serverless Static Generated Web Application** :)
+Et nous voilà avec une **application web générée sans fichiers statiques serveurs** :)
 
-Nous pouvons aller plus loin en imaginant une application d'e-commerce créée avec `nuxt generate` et hébergée sur un CDN, et regénérée à chaque fois qu'un produit est en rupture de stock ou de retour en stock. Mais si l'utilisateur navigue à sur l'application en attendant, il vera les informations à jour grâce aux appels API effectués sur l'API de l'e-commerce. Pas besoin d'avoir plusieurs instances d'un serveur ainsi qu'un cache supplémentaire!
+Nous pouvons aller plus loin en imaginant une application d'e-commerce créée avec `nuxt generate` et hébergée sur un CDN. Chaque fois qu'un produit est en rupture de stock ou de nouveau en stock nous régénérons l'application. Mais si l'utilisateur navigue sur l'application en même temps, il verra les informations à jour grâce aux appels d'API effectués sur l'API de l'e-commerce. Pas besoin d'avoir plusieurs instances d'un serveur d'un cache !

--- a/fr/guide/installation.md
+++ b/fr/guide/installation.md
@@ -1,7 +1,6 @@
 ---
 title: Installation
-description: Débuter avec Nuxt.js est vraiment facile. Un projet simple n'a besoin
-  que d'une dépendance à `nuxt`.
+description: Débuter avec Nuxt.js est vraiment facile. Un projet simple n'a besoin que d'une dépendance à `nuxt`.
 ---
 
 > Débuter avec Nuxt.js est vraiment facile. Un projet simple n'a besoin que d'une dépendance à `nuxt`.
@@ -26,18 +25,14 @@ $ npm install
 ```
 
 et démarrez le projet avec :
-
 ```bash
 $ npm run dev
 ```
-
-L'application est désormais accessible à l'adresse [http://localhost:3000](http://localhost:3000)
-
+L'application est désormais accessible à l'adresse http://localhost:3000.
 
 <p class="Alert">Nuxt.js va surveiller les modifications faites sur les fichiers du répertoire <code>pages</code> aussi il n'y a pas besoin de redémarrer le serveur quand vous ajoutez de nouvelles pages.</p>
 
-
-Pour en savoir plus sur la structure des dossiers du projet consultez [la documentation de l'architecture des dossiers](/guide/directory-structure).
+Pour en savoir plus sur l'organisation des répertoires dans un projet, consultez la documentation de l'[Architecture des répertoires](/guide/directory-structure).
 
 ## Commencer depuis zéro
 
@@ -48,7 +43,7 @@ $ mkdir <nom-du-projet>
 $ cd <nom-du-projet>
 ```
 
-*Info : remplacez <code><nom-du-projet></code> par le nom du projet.*
+<p class="Alert Alert--nuxt-green"><b>Info :</b> remplacez <code>&lt;nom-du-projet&gt;</nom-du-projet></code> par le nom du projet.</p>
 
 ### Le package.json
 
@@ -64,6 +59,7 @@ Le projet a besoin d'un fichier `package.json` avec un script permettant de lanc
 ```
 
 `scripts` lancera Nuxt.js via `npm run dev`.
+
 
 ### Installation de `nuxt`
 
@@ -87,7 +83,7 @@ puis créez la première page `pages/index.vue`:
 
 ```html
 <template>
-  <h1>Hello world!</h1>
+  <h1>Hello world !</h1>
 </template>
 ```
 
@@ -97,10 +93,8 @@ et lancez le projet avec :
 $ npm run dev
 ```
 
-L'application est désormais accessible à l'adresse [http://localhost:3000](http://localhost:3000)
-
+L'application est désormais accessible à l'adresse http://localhost:3000.
 
 <p class="Alert">Nuxt.js va surveiller les modifications faites sur les fichiers du répertoire <code>pages</code> aussi il n'y a pas besoin de redémarrer le serveur quand vous ajoutez de nouvelles pages</p>
 
-
-Pour en savoir plus sur la structure des dossier du projet consultez [la documentation de l'architecture des dossiers](/guide/directory-structure).
+Pour en savoir plus sur la structure des dossiers du projet, consultez la documentation de l'[Architecture des répertoires](/guide/directory-structure).

--- a/fr/guide/menu.json
+++ b/fr/guide/menu.json
@@ -5,25 +5,29 @@
       {
         "to": "", "name": "Introduction",
         "contents": [
-          { "to": "#qu-39-est-ce-que-nuxt-js-", "name": "Qu'est-ce que Nuxt.js?" },
+          { "to": "#nuxt-js-qu-est-ce-que-c-est-", "name": "Nuxt.js, qu’est-ce que c’est ?" },
           { "to": "#comment-a-marche", "name": "Comment ça marche" },
           { "to": "#fonctionnalit-s", "name": "Fonctionnalités" },
           { "to": "#sch-ma", "name": "Schéma" },
-          { "to": "#rendu-c-t-serveur", "name": "Rendu côté serveur" },
-          { "to": "#g-n-ration-d-39-applications-statique", "name": "Génération d'applications statique" }
+          { "to": "#rendu-c-t-serveur-ssr-universel-", "name": "Rendu côté serveur" },
+          { "to": "#g-n-ration-statique-pr-rendu-", "name": "Génération statique" }
         ]
       },
-      { "to": "/contribution-guide", "name": "Guide de contribution" },
-      { "to": "/release-notes", "name": "Notes de version (EN)" }
+      { "to": "/contribution-guide", "name": "Guide de contribution",
+        "contents": [
+          { "to": "#rapports-de-probl-me", "name": "Rapports de problème" },
+          { "to": "#propositions-de-fusion", "name": "Propositions de fusion" }
+        ] },
+      { "to": "/release-notes", "name": "Notes de versions" }
     ]
   },
   {
-    "title": "Mise en route",
+    "title": "Pour commencer",
     "links": [
       {
         "to": "/installation", "name": "Installation",
         "contents": [
-          { "to": "#utilisation-du-template-de-base-de-nuxt-js", "name": "Utilisation du template de base de Nuxt.js" },
+          { "to": "#utiliser-le-template-de-base-de-nuxt-js", "name": "Utiliser le template de base de Nuxt.js" },
           { "to": "#commencer-depuis-z-ro", "name": "Commencer depuis zéro" }
         ]
       },
@@ -34,7 +38,10 @@
           { "to": "#alias", "name": "Alias" }
         ]
       },
-      { "to": "/configuration", "name": "Configuration" },
+      { "to": "/configuration", "name": "Configuration",
+        "contents": [
+          { "to": "#options", "name": "Options" }
+        ] },
       {
         "to": "/routing", "name": "Routage",
         "contents": [
@@ -50,24 +57,24 @@
         "to": "/views", "name": "Vues",
         "contents": [
           { "to": "#document", "name": "Document" },
-          { "to": "#mise-en-page", "name": "Mise en page" },
+          { "to": "#mises-en-page", "name": "Mises-en-page" },
           { "to": "#pages", "name": "Pages" },
-          { "to": "#html-head", "name": "HTML Head" }
+          { "to": "#ent-te-html", "name": "Entête HTML" }
         ]
       },
       {
         "to": "/async-data", "name": "Données asynchrones",
         "contents": [
           { "to": "#la-m-thode-asyncdata", "name": "La méthode asyncData" },
-          { "to": "#le-context", "name": "Le Context" },
+          { "to": "#le-contexte", "name": "Le contexte" },
           { "to": "#gestion-des-erreurs", "name": "Gestion des erreurs" }
         ]
       },
       {
-        "to": "/assets", "name": "Assets",
+        "to": "/assets", "name": "Ressources",
         "contents": [
-          { "to": "#avec-webpack", "name": "Avec Webpack" },
-          { "to": "#static", "name": "Static" }
+          { "to": "#avec-webpack", "name": "Avec webpack" },
+          { "to": "#avec-des-fichiers-statiques", "name": "Avec des fichiers statiques" }
         ]
       },
       {
@@ -75,13 +82,23 @@
         "contents": [
           { "to": "#modules-externes", "name": "Modules externes" },
           { "to": "#plugins-vue", "name": "Plugins Vue" },
+          { "to": "#injection-dans-root-et-context", "name": "Injection dans $root et context" },
           { "to": "#c-t-client-uniquement", "name": "Côté client uniquement" }
         ]
       },
       {
-        "to": "/vuex-store", "name": "Vuex Store",
+        "to": "/modules", "name": "Modules (En)",
         "contents": [
-          { "to": "#activer-le-store", "name": "Activer le Store" },
+          { "to": "#introduction", "name": "Introduction" },
+          { "to": "#write-a-basic-module", "name": "Write a basic Module" },
+          { "to": "#async-modules", "name": "Async Modules" },
+          { "to": "#common-snippets", "name": "Common Snippets" }
+        ]
+      },
+      {
+        "to": "/vuex-store", "name": "Store Vuex",
+        "contents": [
+          { "to": "#activer-le-store", "name": "Activer le store" },
           { "to": "#mode-classique", "name": "Mode classique" },
           { "to": "#mode-modules", "name": "Mode modules" },
           { "to": "#la-m-thode-fetch", "name": "La méthode fetch" },
@@ -89,7 +106,7 @@
         ]
       },
       {
-        "to": "/commands", "name": "Commandes",
+        "to": "/commands", "name": "Commandes et déploiement",
         "contents": [
           { "to": "#liste-des-commandes", "name": "Liste des commandes" },
           { "to": "#environnement-de-d-veloppement", "name": "Environnement de développement" },
@@ -99,7 +116,7 @@
       {
         "to": "/development-tools", "name": "Outils de développement",
         "contents": [
-          { "to": "#tests-end-to-end", "name": "Tests End-to-End" },
+          { "to": "#tests-de-bout-en-bout", "name": "Tests de bout en bout" },
           { "to": "#eslint", "name": "ESLint" }
         ]
       }

--- a/fr/guide/modules.md
+++ b/fr/guide/modules.md
@@ -1,0 +1,326 @@
+---
+title: Modules (En)
+description: Modules are Nuxt.js extensions which can extend it's core functionality and add endless integrations.
+---
+
+> Modules are Nuxt.js extensions which can extend it's core functionality and add endless integrations. 
+
+## Introduction
+
+<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>While developing production grade application using Nuxt, you will find out soon that nuxt core functionalities are not enough
+and writing configs and plugins for each project is a repetitive, boring and time consuming job.
+Also adding every new feature into Nuxt is not possible as it would make it a fat framework.</p>
+   
+This was the reason Nuxt introduces a higher order modular system to easily extend the core.
+Modules are basically **functions** which are called sequentially when booting Nuxt and core awaits for all of them
+to be finished before continue it's job. So they have the chance to customize almost any aspect of Nuxt and thanks to modular design of nuxt itself and Webpack [Tapable](https://github.com/webpack/tapable) technology they can also register hooks
+for certain entry points like builder initialization.
+
+Another point of using modules is that they can be refactored and packaged out of the project and released as NPM packages
+so you can share and use high quality integration and solutions from nuxt community with no pain! You might interested in modules if you:
+
+- Are a member of an **agile team** that want to set up your project instantly and avoid **re-inventing** the wheel for common tasks like google-analytics for your new project.
+- Are an **enterprise** company which **quality** and **reusability** is important for your projects.
+- Are a lovely **open source** enthusiast and interested in **sharing** your works with community in an easy manner.
+- Are a lazy programmer and don't like digging into details setting up every new library or integration.
+ (Someone else should already provided a module for that but you can always ask community for making one)
+- Tired of breaking low level API and Usage changes, and need **things that just work™**.
+
+
+## Write a basic Module
+As already mentioned modules are just simple functions.
+They can be packaged as NPM modules or directly included in project source code.
+
+**modules/simple.js**
+```js
+module.exports = function SimpleModule (moduleOptions) { 
+  // Write your code here
+}
+
+// REQUIRED if publishing as an NPM package
+// module.exports.meta = require('./package.json')
+```
+
+**`moduleOptions`**
+
+This is the object passed using `modules` array by user we can use it to customize it's behavior.
+
+
+**`this.options`**
+
+You can directly access to Nuxt options using this reference.
+This is _nuxt.config.js_ with all default options assigned to and can be used for shared options between modules.
+
+
+**`this.nuxt`**
+
+This is a reference to current nuxt instance. Refer to nuxt class docs for available methods.
+
+
+**`this`**
+
+Context of modules. Refer to [ModuleContainer](/api/internals-module-container) class docs for available methods.
+
+**`module.exports.meta`**
+
+This line is **required** if you are publishing module as an NPM package.
+Nuxt internally uses meta to work better with your package.
+
+
+**nuxt.config.js**
+
+```js
+module.exports = {
+  modules: [
+    // Simple usage
+    '~/modules/simple'
+
+    // Passing options
+    ['~/modules/simple', { token: '123' }]
+  ]
+}
+```
+
+We then tell Nuxt to load some specific modules for a project with optional parameters as options.
+Please refer to [modules configuration](/api/configuration-modules) docs for more info!
+
+
+## Async Modules
+
+Not all modules will do everything synchronous.
+For example you may want to develop a module which needs fetching some API or doing async IO.
+For this, Nuxt supports async modules which can return a Promise or call a callback.
+
+### Use async/await
+
+<p class="Alert Alert--orange">
+  Be aware that async/await is only supported in Node.js > 7.2
+  So if you are a module developer at least warn users about that if using them.
+  For heavily async modules or better legacy support you can use either a bundler to transform it for older node comparability or using promise method.
+</p>
+
+```js
+const fse = require('fs-extra')
+
+module.exports = async function asyncModule() {
+  // You can do async works here using async/await
+  let pages = await fse.readJson('./pages.json')
+}
+```
+
+### Return a Promise
+
+```js
+const axios = require('axios')
+
+module.exports = function asyncModule() {
+  return axios.get('https://jsonplaceholder.typicode.com/users')
+    .then(res => res.data.map(user => '/users/' + user.username))
+    .then(routes => {
+      // Do something by extending nuxt routes
+    })
+}
+```
+
+### Use callbacks
+
+```js
+const axios = require('axios')
+
+module.exports = function asyncModule(callback) {
+  axios.get('https://jsonplaceholder.typicode.com/users')
+    .then(res => res.data.map(user => '/users/' + user.username))
+    .then(routes => {
+      callback()
+    })
+}
+```
+
+
+## Common Snippets
+
+### Top level options
+Sometimes it is more convenient if we can use top level options while register modules in `nuxt.config.js`. 
+So we can combine multiply option sources.
+
+**nuxt.config.js**
+
+```js
+module.exports = {
+  modules: [
+    '@nuxtjs/axios'
+  ],
+
+  // axios module is aware of this by using this.options.axios
+  axios: {
+    option1,
+    option2
+  }
+} 
+```
+
+**module.js**
+
+```js
+module.exports = function (moduleOptions) {
+  const options = Object.assign({}, this.options.axios, moduleOptions)
+  // ...
+}
+```
+
+### Provide plugins
+It is common that modules provide one or more plugins when added.
+For example [bootstrap-vue](https://bootstrap-vue.js.org) module would require to register itself into Vue.
+For this we can use `this.addPlugin` helper. 
+
+**plugin.js**
+```js
+import Vue from 'vue'
+import BootstrapVue from 'bootstrap-vue/dist/bootstrap-vue.esm'
+
+Vue.use(BootstrapVue)
+```
+
+**module.js**
+```js
+const path = require('path')
+
+module.exports = function nuxtBootstrapVue (moduleOptions) {
+  // Register plugin.js template
+  this.addPlugin(path.resolve(__dirname, 'plugin.js'))
+}
+```
+
+### Template plugins
+Registered templates and plugins can leverage [lodash templates](https://lodash.com/docs/4.17.4#template) 
+to conditionally change registered plugins output.
+
+**plugin.js**
+```js
+// Set Google Analytics UA
+ga('create', '<%= options.ua %>', 'auto')
+
+<% if (options.debug) { %>
+// Dev only code
+<% } %>
+```
+
+**module.js**
+```js
+const path = require('path')
+
+module.exports = function nuxtBootstrapVue (moduleOptions) {
+  // Register plugin.js template
+  this.addPlugin({
+    src: path.resolve(__dirname, 'plugin.js'),
+    options: {
+      // Nuxt will replace options.ua with 123 when copying plugin to project
+      ua: 123,
+
+      // conditional parts with dev will be stripped from plugin code on production builds
+      debug: this.options.dev
+    }
+  })
+}
+```
+
+### Add a CSS library
+It is recommended checking if user already not provided same library to avoid adding duplicates.
+Also always consider having **an option to disable** adding css files by module.
+
+**module.js**
+
+```js
+module.exports = function (moduleOptions) {
+  if (moduleOptions.fontAwesome !== false) {
+    // Add font-awesome
+    this.options.css.push('font-awesome/css/font-awesome.css')
+  }
+}
+```
+
+### Emit assets
+We can register webpack plugins to emit assets during build.
+
+**module.js**
+
+```js
+module.exports = function (moduleOptions) {
+  const info = 'Built by awesome module - 1.3 alpha on ' + Date.now() 
+
+  this.options.build.plugins.push({
+    apply (compiler) {
+      compiler.plugin('emit', (compilation, cb) => {
+        
+        // This will generate `.nuxt/dist/info.txt' with contents of info variable.
+        // Source can be buffer too
+        compilation.assets['info.txt'] = { source: () => info, size: () => info.length }
+
+        cb()
+      })
+    }
+  })
+}
+```
+
+### Register custom loaders
+
+We can do the same as `build.extend` in `nuxt.config.js` using `this.extendBuild`
+
+**module.js**
+
+```js
+module.exports = function (moduleOptions) {
+    this.extendBuild((config, { isClient, isServer }) => {
+      // .foo Loader
+      config.module.rules.push({
+        test: /\.foo$/,
+        use: [...]
+      })
+
+      // Customize existing loaders
+      // Refer to source code for Nuxt internals:
+      // https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/webpack/base.config.js
+      const barLoader = config.module.rules.find(rule => rule.loader === 'bar-loader')
+  })
+}
+```
+
+## Run Tasks on Specific hooks
+Your module may need to do things only on specific conditions not just during Nuxt initialization.
+We can use powerful [tapable](https://github.com/webpack/tapable) plugin system to do tasks on specific events.
+Nuxt will await for us if hooks return a Promise or are defined as `async`.
+
+```js
+module.exports = function () {
+  // Add hook for modules
+  this.nuxt.plugin('module', moduleContainer => {
+    // This will be called when all modules finished loading
+  })
+
+  // Add hook for renderer
+  this.nuxt.plugin('renderer', renderer => {
+    // This will be called when renderer was created
+  })
+
+  // Add hook for build
+  this.nuxt.plugin('build', async builder => {
+    // This Will be called once when builder created
+
+    // We can even register internal hooks here
+    builder.plugin('compile', ({compiler}) => {
+        // This will be run just before webpack compiler starts
+    })
+  })
+
+  // Add hook for generate
+  this.nuxt.plugin('generate', async generator => {
+    // This Will be called when a nuxt generate starts
+  })
+}
+```
+
+<p class="Alert">
+  There are many many more hooks and possibilities for modules.
+  Please refer to [Nuxt Internals](/api/internals) to learn more about Nuxt internal API.
+</p>

--- a/fr/guide/plugins.md
+++ b/fr/guide/plugins.md
@@ -1,23 +1,23 @@
 ---
 title: Plugins
-description: Nuxt.js vous permet de définir les plugins js à exécuter avant d'instancier l'application vue.js racine, il peut s'agir d'utiliser votre propre bibliothèque ou des modules externes.
+description: Nuxt.js vous permet de définir les plugins JavaScript à exécuter avant d'instancier l'application Vue.js racine. Cela est particulièrement pratique quand vous utilisez vos propres bibliothèques ou modules externes.
 ---
 
-> Nuxt.js vous permet de définir les plugins js à exécuter avant d'instancier l'application vue.js racine, il peut s'agir d'utiliser votre propre bibliothèque ou des modules externes.
+> Nuxt.js vous permet de définir les plugins JavaScript à exécuter avant d'instancier l'application Vue.js racine. Cela est particulièrement pratique quand vous utilisez vos propres bibliothèques ou modules externes.
 
-<div class="Alert">Il est important de savoir que, dans le [cycle de vie d'une instance de Vue](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), les *hooks* `beforeCreate` et` created` sont appelés **à la fois côté client et du côté serveur**. Tous les autres *hooks* ne sont appelés que du client.</div>
+<div class="Alert">Il est important de savoir que, dans le [cycle de vie d'une instance de Vue](https://fr.vuejs.org/v2/guide/instance.html#Diagramme-du-cycle-de-vie), les hooks `beforeCreate` et `created` sont appelés **à la fois du côté client et du côté serveur**. Tous les autres *hooks* ne sont appelés que depuis le client.</div>
 
 ## Modules externes
 
-Nous souhaitons utiliser des packages/modules externes dans notre application, un excellent exemple est [axios](https://github.com/mzabriskie/axios) pour les requêtes HTTP pour le serveur et le client.
+Nous souhaitons utiliser des packages / modules externes dans notre application, un excellent exemple est [axios](https://github.com/mzabriskie/axios) pour les requêtes HTTP depuis le serveur et le client.
 
-Nous l'installons via npm:
+Nous l'installons via npm :
 
 ```bash
 npm install --save axios
 ```
 
-Puis, nous pouvons l'utiliser directement dans nos pages:
+Puis nous pouvons l'utiliser directement dans nos pages :
 
 ```html
 <template>
@@ -36,7 +36,7 @@ export default {
 </script>
 ```
 
-Mais il y a **un problème**, si nous importons axios dans une autre page, il sera à nouveau inclus dans le bundle de la page. Nous voulons inclure `axios` une seule fois dans notre application, pour cela, nous utilisons la clé `build.vendor` dans notre `nuxt.config.js`:
+Mais il y a **un problème**, si nous importons axios dans une autre page, il sera à nouveau inclus dans le paquetage de la page. Nous voulons inclure `axios` une seule fois dans notre application, pour cela, nous utilisons la clé `build.vendor` dans notre `nuxt.config.js` :
 
 ```js
 module.exports = {
@@ -46,13 +46,14 @@ module.exports = {
 }
 ```
 
-Ensuite, je peux importer `axios` partout sans avoir à m'inquiéter de l'importer plusieurs fois et de rendre le bundle plus lourd.
+Je peux ensuite importer `axios` partout sans avoir à m'inquiéter de l'importer plusieurs fois et de rendre le paquetage plus lourd.
 
 ## Plugins Vue
 
 Si nous voulons utiliser [vue-notifications](https://github.com/se-panfilov/vue-notifications) pour afficher des notifications dans notre application, nous devons configurer le plugin avant de lancer l'application.
 
-Dans `plugins/vue-notifications.js`:
+Dans `plugins/vue-notifications.js` :
+
 ```js
 import Vue from 'vue'
 import VueNotifications from 'vue-notifications'
@@ -60,43 +61,81 @@ import VueNotifications from 'vue-notifications'
 Vue.use(VueNotifications)
 ```
 
-Puis, nous ajoutons le fichier dans l'attribut `plugins` de `nuxt.config.js`:
+Puis nous ajoutons le fichier dans l'attribut `plugins` de `nuxt.config.js` :
+
 ```js
 module.exports = {
   plugins: ['~plugins/vue-notifications']
 }
 ```
 
-Pour en savoir plus sur l'attribut `plugins`, voir [plugins api](/api/configuration-plugins).
+Pour en savoir plus sur l'attribut `plugins`, consultez [La propriété `plugins`](/api/configuration-plugins) de l'API.
 
-Acutellement, `vue-notifications` sera inclu dans le bundle de l'application; mais comme il s'agit d'une librairie, nous voulons l'inclure dans le bundle `vendor` pour une meilleure mise en cache.
+Acutellement, `vue-notifications` sera inclus dans le paquetage de l'application. Mais comme il s'agit d'une bibliothèque, nous voulons l'inclure dans le paquetage `vendor` pour une meilleure mise en cache.
 
-Nous pouvons mettre à jour `nuxt.config.js` pour ajouter `vue-notifications` dans le bundle `vendor`:
+Nous pouvons mettre à jour `nuxt.config.js` pour ajouter `vue-notifications` dans le bundle `vendor` :
+
 ```js
 module.exports = {
   build: {
     vendor: ['vue-notifications']
   },
-  plugins: ['~plugins/vue-notifications']
+  plugins: ['~/plugins/vue-notifications']
 }
 ```
 
-## Côté client uniquement
+## Injection dans $root et context
 
-Certains plugins fonctionnent **uniquement côté navigateur**. Vous pouvez utiliser l'option `ssr: false` dans `plugins` pour exécuter le fichier uniquement côté client.
+Plusieurs plugins ont besoin d'être injectés à la racine de l'application pour être utilisés, comme [vue-18n](https://github.com/kazupon/vue-i18n). Nuxt.js vous donne la possibilité d'exporter une fonction dans votre plugin pour recevoir l'instance racine ainsi que le contexte.
 
-Exemple:
+`plugins/i18n.js`:
+
+```js
+import Vue from 'vue'
+import VueI18n from 'vue-i18n'
+
+Vue.use(VueI18n)
+
+export default ({ app, store }) => {
+  // Appliquer l'instance i18n  de l'application
+  // De cette façon nous pouvons l'utiliser en tant que middleware et pages asyncData & fetch
+  app.i18n = new VueI18n({
+    /*  options vue-i18n... */
+  })
+}
+```
 
 `nuxt.config.js`:
+
+```js
+module.exports = {
+  build: {
+    vendor: ['vue-i18n']
+  },
+  plugins: ['~/plugins/i18n.js']
+}
+```
+
+Pour voir comment utiliser ce plugin, consultez cet [exemple i18n](/examples/i18n).
+
+## Côté client uniquement
+
+Certains plugins fonctionnent **uniquement dans un navigateur**. Vous pouvez utiliser l'option `ssr: false` dans `plugins` pour exécuter le fichier uniquement côté client.
+
+Exemple :
+
+`nuxt.config.js`:
+
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/vue-notifications', ssr: false }
+    { src: '~/plugins/vue-notifications', ssr: false }
   ]
 }
 ```
 
 `plugins/vue-notifications.js`:
+
 ```js
 import Vue from 'vue'
 import VueNotifications from 'vue-notifications'
@@ -104,4 +143,6 @@ import VueNotifications from 'vue-notifications'
 Vue.use(VueNotifications)
 ```
 
-Dans le cas où vous devez importer certaines librairies uniquement pour le serveur, vous pouvez utiliser la variable `process.server` définie sur `true` lorsque le serveur web crée le fichier `server.bundle.js`.
+Dans le cas où vous devez importer certaines bibliothèques uniquement pour le serveur, vous pouvez utiliser la variable `process.server` définie sur `true` lorsque le serveur web crée le fichier `server.bundle.js`.
+
+Si vous avez besoin également de savoir si vous êtes dans une application générée (via `nuxt generate`), vous pouvez vérifier la propriété `process.static` mise à `true` pendant la génération et après. Pour connaitre dans quel état est une page qui est en train d'être rendue par `nuxt generate` avant d'être sauvée, vous pouvez utilisez `process.static && process.server`.

--- a/fr/guide/routing.md
+++ b/fr/guide/routing.md
@@ -1,13 +1,13 @@
 ---
 title: Routage
-description: Nuxt.js utilise le système de fichiers pour générer les routes de votre applications web.
+description: Nuxt.js utilise le système de fichiers pour générer les routes de votre application web.
 ---
 
 > Nuxt.js génère automatiquement la configuration pour [vue-router](https://github.com/vuejs/vue-router) en fonction de votre arborescence de fichiers Vue se trouvant au sein du répertoire `pages`.
 
 ## Routes basiques
 
-Cette arborescence:
+Cette arborescence :
 
 ```bash
 pages/
@@ -17,7 +17,7 @@ pages/
 --| index.vue
 ```
 
-génère automatiquement:
+génèrera automatiquement :
 
 ```js
 router: {
@@ -43,9 +43,9 @@ router: {
 
 ## Routes dynamiques
 
-Pour définir une route dynmaique à l'aide d'un paramètre, vous devez définir un fichier `.vue` OU un répertoire **préfixé par un souligner (`_`).
+Pour définir une route dynamique à l'aide d'un paramètre, vous devez définir un fichier `.vue` OU un répertoire **préfixé par un souligné (`_`)**.
 
-Cette arborescence:
+Cette arborescence :
 
 ```bash
 pages/
@@ -57,7 +57,7 @@ pages/
 --| index.vue
 ```
 
-génère automatiquement:
+génèrera automatiquement :
 
 ```js
 router: {
@@ -86,18 +86,20 @@ router: {
 }
 ```
 
-Comme vous pouvez le voir, la route nommée `users-id` contient le chemin `:id?` ce qui le rend optionnel; si vous voulez le rendre obligatoire, créez un fichier `index.vue` dans le dossier `users/_id`.
+Comme vous pouvez le voir, la route nommée `users-id` contient le chemin `:id?` ce qui le rend optionnel. Si vous voulez le rendre obligatoire, créez un fichier `index.vue` dans le dossier `users/_id`.
 
-### Validation des paramètres de routes
+<p class="Alert Alert--info"><b>Attention :</b> les routes dynamiques sont ignorées par la commande `generate`, consultez la configuration de l'API à propos de [La propriété `generate`](/api/configuration-generate#routes)</p>
+
+### Validation des paramètres de route
 
 Nuxt.js vous permet de définir une méthode de validation dans votre composant de routage dynamique.
 
-Par exemple: `pages/users/_id.vue`
+Par exemple : `pages/users/_id.vue`
 
 ```js
 export default {
   validate ({ params }) {
-    // Must be a number
+    // Doit être un nombre
     return /^\d+$/.test(params.id)
   }
 }
@@ -105,17 +107,17 @@ export default {
 
 Si la méthode de validation ne renvoie pas `true`, Nuxt.js chargera automatiquement la page d'erreur 404.
 
-Plus d'informations à propos de la méthode de validation: [API Pages validate](/api/pages-validate)
+Pour plus d'informations à propos de la méthode de validation, consultez [la partie Pages de l'API pour La méthode `validate`](/api/pages-validate)
 
 ## Routes imbriquées
 
-Nuxt.js vous permets de créer des routes imbriquées en utilisant les routes enfants de vue-router.
+Nuxt.js vous permet de créer des routes imbriquées en utilisant les routes enfants de vue-router.
 
-Pour définir le composant parent d'un route imbriquée, vous devez créer un fichier Vue avec le **même nom que le répertoire** qui contient les vues enfants.
+Pour définir le composant parent d'une route imbriquée, vous devez créer un fichier Vue avec le **même nom que le répertoire** qui contient les vues enfants.
 
-<p class="Alert Alert--info">N'oubliez pas d'écrire `<nuxt-child/>` au sein du composant parent (fichier `.vue`).</p>
+<p class="Alert Alert--info"><b>Attention :</b> n'oubliez pas d'écrire `<nuxt-child/>` au sein du composant parent (fichier <code>.vue</code>).</p>
 
-Cette arborescence:
+Cette arborescence :
 
 ```bash
 pages/
@@ -125,7 +127,7 @@ pages/
 --| users.vue
 ```
 
-génère automatiquement:
+génèrera automatiquement :
 
 ```js
 router: {
@@ -152,9 +154,9 @@ router: {
 
 ## Routes dynamiques imbriquées
 
-Il est possible avec Nuxt.js d'avoir des routes dynamiques imbriquées dans des routes dynamiques; bien que ce scénario ne devrait pas être monnaie courante.
+Ce scénario ne devrait pas arriver souvent, mais il est possible avec Nuxt.js d'avoir des routes dynamiques enfants dans des routes dynamiques parentes.
 
-Cette arborescence:
+Cette arborescence :
 
 ```bash
 pages/
@@ -168,7 +170,7 @@ pages/
 --| index.vue
 ```
 
-génère automatiquement:
+génèrera automatiquement :
 
 ```js
 router: {
@@ -211,15 +213,16 @@ router: {
 
 ## Transitions
 
-Nuxt.js utilise le composant [&lt;transition&gt;](http://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) afin de vous permettre de créer des transitions/animations époustouflantes entre vos routes.
+Nuxt.js utilise le composant [`<transition>`](http://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) afin de vous permettre de créer de superbes transitions / animations entre vos routes.
 
 ### Paramètres globaux
 
-<p class="Alert Alert--info">Dans Nuxt.js, le nom de la transition par défaut est `"page"`.</p>
+<p class="Alert Alert--nuxt-green"><b>Info :</b> dans Nuxt.js, le nom de la transition par défaut est `"page"`.</p>
 
 Pour ajouter une transition de fondu à chaque page de votre application, nous avons besoin d'un fichier CSS qui est partagé sur toutes nos routes. Commençons par créer un fichier dans le dossier `assets`.
 
-Notre CSS global dans `assets/main.css`:
+Notre CSS global dans `assets/main.css` :
+
 ```css
 .page-enter-active, .page-leave-active {
   transition: opacity .5s;
@@ -229,7 +232,8 @@ Notre CSS global dans `assets/main.css`:
 }
 ```
 
-Nous ajoutons son chemin dans notre config `nuxt.config.js`:
+Nous ajoutons son chemin dans notre fichier de configuration `nuxt.config.js` :
+
 ```js
 module.exports = {
   css: [
@@ -238,13 +242,14 @@ module.exports = {
 }
 ```
 
-Plus d'informations à propos des transitions: [API Configuration transition](/api/pages-transition)
+Pour plus d'informations à propos des transitions, consultez [la partie Configuration de l'API pour La propriété `transition`](/api/pages-transition)
 
 ### Paramètres des pages
 
 Vous êtes également libre de définir une transition personnalisée pour une seule page à l'aide de la propriété `transition`.
 
-Nous ajoutons une nouvelle classe dans notre CSS global `assets/main.css`:
+Nous ajoutons une nouvelle classe dans notre CSS global `assets/main.css` :
+
 ```css
 .test-enter-active, .test-leave-active {
   transition: opacity .5s;
@@ -254,14 +259,15 @@ Nous ajoutons une nouvelle classe dans notre CSS global `assets/main.css`:
 }
 ```
 
-puis, nous utilions la propriété transition pour définir le nom de la classe à utiliser pour cette transition de page:
+puis, nous utilisons la propriété transition pour définir le nom de la classe à utiliser pour cette transition de page :
+
 ```js
 export default {
   transition: 'test'
 }
 ```
 
-Plus d'informations à propos de la propriété transition: [API Pages transition](/api/pages-transition)
+Pour plus d'informations à propos de la propriété transition, consultez [la partie Configuration de l'API pour La propriété `transition`](/api/pages-transition)
 
 ## Middleware
 
@@ -269,7 +275,7 @@ Plus d'informations à propos de la propriété transition: [API Pages transitio
 
 **Tous les middlewares devraient être placés dans le répertoire `middleware/`.** Le nom du fichier étant le nom du middleware (`middleware/auth.js` deviendra le middleware `auth`).
 
-Un middleware reçoit le [contexte](/api#context) comme premier argument:
+Un middleware reçoit [le contexte](/api#context) comme premier argument :
 
 ```js
 export default function (context) {
@@ -277,14 +283,16 @@ export default function (context) {
 }
 ```
 
-Le middleware sont exécuté en séries dans l'ordre suivant:
+Le middleware sera exécuté en série dans l'ordre suivant :
+
 1. `nuxt.config.js`
-2. Layouts correspondants
+2. Mises en page correspondantes
 3. Pages correspondantes
 
-Un middleware peut être asynchrone, retourner une `Promise` ou utiliser le `callback` (2ème arguement):
+Un middleware peut être asynchrone, retourner une `Promise` ou utiliser une fonction de rappel en second argument :
 
 `middleware/stats.js`
+
 ```js
 import axios from 'axios'
 
@@ -295,9 +303,10 @@ export default function ({ route }) {
 }
 ```
 
-Puis, dans `nuxt.config.js`, un layout ou une page, utilisez le mot clef `middleware`:
+Puis, dans `nuxt.config.js`, pour une mise en page ou une page, utilisez le mot-clé `middleware` :
 
 `nuxt.config.js`
+
 ```js
 module.exports = {
   router: {
@@ -306,6 +315,6 @@ module.exports = {
 }
 ```
 
-Dans cet exemple, le middleware `stats` sera appelé à chaque changement de routes.
+Le middleware `stats` sera appelé à chaque changement de routes.
 
-Pour voir un exemple "réel" utilisant les middlewares, jeter un oeil à [example-auth0](https://github.com/nuxt/example-auth0) sur GitHub.
+Pour voir un exemple d'usage utilisant les middlewares, consultez [example-auth0](https://github.com/nuxt/example-auth0) sur GitHub.

--- a/fr/guide/views.md
+++ b/fr/guide/views.md
@@ -1,19 +1,19 @@
 ---
 title: Vues
-description: La section Vues décrit tout ce dont vous avez besoin pour configurer les données et les vues pour une route spécifique dans votre application Nuxt.js. (Document, Layouts, Pages et HTML Head)
+description: La section des vues décrit tout ce dont vous avez besoin pour configurer les données et les vues pour une route spécifique dans votre application Nuxt.js (document, mises en page, pages et entête HTML).
 ---
 
-> La section Vues décrit tout ce dont vous avez besoin pour configurer les données et les vues pour une route spécifique dans votre application Nuxt.js. (Document, Layouts, Pages et HTML Head)
+> La section des vues décrit tout ce dont vous avez besoin pour configurer les données et les vues pour une route spécifique dans votre application Nuxt.js (document, mises en page, pages et entête HTML).
 
 ![nuxt-views-schema](/nuxt-views-schema.png)
 
 ## Document
 
-> Vous pouvez personnaliser le document principal avec nuxt.js
+> Vous pouvez personnaliser le document principal avec Nuxt.js.
 
-Pour étendre le modèle html, créez un fichier `app.html` à la racine de votre projet.
+Pour étendre le modèle HTML, créez un fichier `app.html` à la racine de votre projet.
 
-Le modèle par défaut est le suivant:
+Le modèle par défaut est le suivant :
 
 ```html
 <!DOCTYPE html>
@@ -27,11 +27,11 @@ Le modèle par défaut est le suivant:
 </html>
 ```
 
-Un exemple pour ajouter des classes CSS conditionnelles pour IE:
+Un exemple pour ajouter des classes CSS conditionnelles pour IE :
 
 ```html
 <!DOCTYPE html>
-<!--[if IE 9]><html lang="en-US" class="lt-ie9 ie9" {{ HTML_ATTRS }}><![endif]-->
+<!--[if IE 9]><html lang="fr-FR" class="lt-ie9 ie9" {{ HTML_ATTRS }}><![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--><html {{ HTML_ATTRS }}><!--<![endif]-->
   <head>
     {{ HEAD }}
@@ -42,7 +42,7 @@ Un exemple pour ajouter des classes CSS conditionnelles pour IE:
 </html>
 ```
 
-## Mise en page
+## Mises en page
 
 Nuxt.js vous permet d'étendre la mise en page principale ou de créer des mises en page personnalisées en les ajoutant dans le répertoire `layouts`.
 
@@ -52,7 +52,8 @@ Vous pouvez étendre la mise en page principale en ajoutant un fichier `layouts/
 
 *Assurez-vous d'ajouter le composant `<nuxt/>` lors de la création d'une mise en page afin d'afficher le composant de la page.*
 
-Le code source de mise en page par défaut est:
+Le code source de mise en page par défaut est :
+
 ```html
 <template>
   <nuxt/>
@@ -67,7 +68,8 @@ Cette mise en page est spéciale car vous ne devez pas inclure `<nuxt />` dans s
 
 Le code source de la page d'erreur par défaut est [disponible sur GitHub](https://github.com/nuxt/nuxt.js/blob/master/lib/app/components/nuxt-error.vue).
 
-Exemple d'une page d'erreur personalisée à l'aide de `layouts/error.vue`:
+Exemple d'une page d'erreur personnalisée à l'aide de `layouts/error.vue`:
+
 ```html
 <template>
   <div class="container">
@@ -80,18 +82,18 @@ Exemple d'une page d'erreur personalisée à l'aide de `layouts/error.vue`:
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // vous pouvez définir une mise en page personalisée pour la page d'erreur
+  layout: 'blog' // vous pouvez définir une mise en page personnalisée pour la page d'erreur
 }
 </script>
 ```
 
-### Mise en page personalisée
+### Mise en page personnalisée
 
 Chaque fichier (*premier niveau*) dans le répertoire `layouts` créera une mise en page personnalisée accessible via la propriété `layout` dans le composant de la page.
 
 *Assurez-vous d'ajouter le composant `<nuxt/>` lors de la création d'une mise en page afin d'afficher le composant de la page.*
 
-Exemple avec `layouts/blog.vue`:
+Exemple avec `layouts/blog.vue` :
 ```html
 <template>
   <div>
@@ -101,7 +103,8 @@ Exemple avec `layouts/blog.vue`:
 </template>
 ```
 
-Puis dans `pages/posts.vue`, vous pouvez spécifier à Nuxt.js d'utiliser votre mise en page personalisée:
+Puis dans `pages/posts.vue`, vous pouvez spécifier à Nuxt.js d'utiliser votre mise en page personnalisée :
+
 ```html
 <script>
 export default {
@@ -110,30 +113,30 @@ export default {
 </script>
 ```
 
-Plus d'informations à propos de la propriété des mises en pages: [API Pages layout](/api/pages-layout)
+Pour plus d'informations, consultez la configuration de l'API à propos de [La propriété `layout`](/api/pages-layout).
 
 Regardez la [vidéo de démonstration](https://www.youtube.com/watch?v=YOKnSTp7d38) pour la voir en action (EN).
 
 ## Pages
 
-Chaque composant Page est un composant Vue, mais Nuxt.js ajoute des clés spéciales pour rendre le développement de votre application universelle la plus simple possible.
+Chaque composant de page est un composant Vue, mais Nuxt.js ajoute des clés spéciales pour rendre le développement de votre application universelle le plus simple possible.
 
 ```html
 <template>
-  <h1 class="red">Hello {{ nom }}!</h1>
+  <h1 class="red">Hello {{ name }} !</h1>
 </template>
 
 <script>
 export default {
   asyncData (context) {
-    // appellé avant le "loading" du composant
-    return { nom: 'World' }
+    // appelé avant le chargement du composant
+    return { name: 'World' }
   },
   fetch () {
-    // La méthode "fetch" est utilisé pour peupler le "store" avant d'effectuer le rendu de la page
+    // La méthode `fetch` est utilisée pour peupler le store avant d'effectuer le rendu de la page
   },
   head () {
-    // Définit les meta tags pour cette page
+    // Définit les balises meta pour cette page
   },
   // et plus de fonctionnalités à découvrir
   ...
@@ -147,39 +150,39 @@ export default {
 </style>
 ```
 
-
 | Attribut | Description |
 |-----------|-------------|
-| asyncData | L'attribut le plus important. Il peut être asynchrone et reçoit le contexte comme argument, lisez la [documentation sur asyncData](/guide/async-data) pour savoir comment il fonctionne. |
-| fetch | Utilisé pour peupler le "store" avant de faire le rendu de la page, équivalent à la méthode "data" sauf qu'il ne peuple pas le composant "data". Voir [API Pages fetch](/api/pages-fetch). |
-| head | Définissez des Meta tags spécifiques pour la page en cours, voir [API Pages head](/api/pages-head). |
-| layout | Spécifie une mise en page existantes dans le répertoire `layouts`, voir [API Pages layouts](/api/pages-layout). |
-| transition | Défini une transition spécifique pour une page, voir [API Pages transition](/api/pages-transition). |
-| scrollToTop | Booléen, par défaut: `false`. Indiquez si vous souhaitez que la position se déplace vers le haut avant d'afficher la page, est utilisé pour les [routes imbriquées](/guide/routing#nested-routes). |
-| validate | Fonction de validation pour une [route dynamique](/guide/routing#dynamic-routes). |
-| middleware | Définissez un middleware pour cette page, ce middleware sera exécuté avant d'effectuer le rendu de la page, voir [routes middleware](/guide/routing#middleware). |
+| asyncData | L'attribut le plus important. Il peut être asynchrone et reçoit le contexte comme argument, lisez la documentation sur les [Données asynchrones](/guide/async-data) pour savoir comment il fonctionne. |
+| fetch | Utilisé pour peupler le store avant de faire le rendu de la page, équivalent à la méthode `data` sauf qu'il ne peuple pas le composant `data`. Voir [la partie Pages de l'API sur `fetch`](/api/pages-fetch). |
+| head | Défini des balises meta spécifiques pour la page en cours, voir [la partie Pages de l'API sur `head`](/api/pages-head). |
+| layout | Défini une mise en page existantes dans le répertoire `layouts`, voir [la partie Pages de l'API sur `layout`](/api/pages-layout). |
+| transition | Défini une transition spécifique pour une page, voir [la partie Pages de l'API sur `transition`](/api/pages-transition). |
+| scrollToTop | Booléen, par défaut: `false`. Indiquez si vous souhaitez que la position se déplace vers le haut avant d'afficher la page, est utilisé pour les [Routes imbriquées](/guide/routing#routes-imbriqu-es). |
+| validate | Fonction de validation pour les [Routes dynamiques](/guide/routing#routes-dynamiques). |
+| middleware | Défini un middleware pour cette page, ce middleware sera exécuté avant d'effectuer le rendu de la page, voir le [Middleware dans le Routage](/guide/routing#middleware). |
 
-Plus d'informations à propos de l'utilisation des attributs des pages: [API Pages](/api)
+Pour plus d'informations à propos de l'utilisation des attributs de pages, consultez [la partie Pages de l'API](/api)
 
-## HTML Head
+## Entête HTML
 
 Nuxt.js utilise [vue-meta](https://github.com/declandewet/vue-meta) pour mettre à jour les `headers` et les `html attributes` de votre application.
 
-Nuxt.js configure `vue-meta` avec les options suivantes:
+Nuxt.js configure `vue-meta` avec les options suivantes :
 ```js
 {
-  keyName: 'head', // le nom de l'option où vue-meta va chercher les infos.
-  attribute: 'data-n-head', // l'attribut que vue-meta ajoute aux tags observés
-  ssrAttribute: 'data-n-head-ssr', // le nom de l'attribut qui permet à vue-meta de savoir que la méta-information a déjà été générée par le serveur
-  tagIDKeyName: 'hid' // Le nom de la propriété que vue-meta utilise pour déterminer s'il faut écraser ou ajouter un tag
+  keyName: 'head', // le nom de l'option où vue-meta va chercher les informations.
+  attribute: 'data-n-head', // l'attribut que vue-meta ajoute aux balises observées
+  ssrAttribute: 'data-n-head-ssr', // le nom de l'attribut qui permet à vue-meta de savoir que la meta information a déjà été générée par le serveur
+  tagIDKeyName: 'hid' // Le nom de la propriété que vue-meta utilise pour déterminer s'il faut écraser ou ajouter une balise
 }
 ```
 
-### Meta tags par défaut
+### Balises meta par défaut
 
-Nuxt.js vous permet de définir tous les meta par défaut de votre application dans `nuxt.config.js`, en utilisant la propriété `head`:
+Nuxt.js vous permet de définir tous les meta par défaut de votre application dans `nuxt.config.js`, en utilisant la même propriété `head` :
 
-Exemple d'un viewport spécifique et d'une police Google:
+Exemple d'un viewport spécifique et d'une police Google personnalisée :
+
 ```js
 head: {
   meta: [
@@ -192,12 +195,12 @@ head: {
 }
 ```
 
-Pour connaitre la liste des options que vous pouvez donner à `head`, jeter un oeil à la [documentation vue-meta](https://github.com/declandewet/vue-meta#recognized-metainfo-properties).
+Pour connaitre la liste des options que vous pouvez donner à `head`, jeter un œil à la [documentation vue-meta](https://github.com/declandewet/vue-meta#recognized-metainfo-properties).
 
-Plus d'informations à propos de la méthode head: [API Configuration head](/api/configuration-head)
+More information about the `head` method: [API Configuration `head`](/api/configuration-head).
 
-### Meta tags personalisé pour une page
+### Balises meta personnalisées pour une page
 
-Plus d'informations à propos de la méthode head: [API Pages head](/api/pages-head)
+Plus d'informations à propos de la méthode `head` dans [la partie Configuration de l'API sur `head`](/api/pages-head).
 
-<p class="Alert">Afin d'éviter toutes duplications lors de l'utilisation d'un composant enfant, donnez un identifiant unique à l'aide de l'attribut `hid`; [en lire plus à ce propos.](https://github.com/declandewet/vue-meta#lists-of-tags)</p>
+<p class="Alert">Afin d'éviter toutes duplications lors de l'utilisation d'un composant enfant, donnez un identifiant unique à l'aide de l'attribut `hid`. Pour [en savoir plus](https://github.com/declandewet/vue-meta#lists-of-tags).</p>

--- a/fr/guide/vuex-store.md
+++ b/fr/guide/vuex-store.md
@@ -1,46 +1,49 @@
 ---
-title: Vuex Store
-description: L'utilisation d'un store pour gérer l'état est important pour toutes les applications de taille importante, c'est pourquoi nuxt.js met en œuvre Vuex dans son cœur.
+title: Store Vuex
+description: L'utilisation d'un store pour gérer l'état est important pour toutes les applications de taille importante, c'est pourquoi Vuex est implémenté au cœur de Nuxt.js.
 ---
 
-> L'utilisation d'un store pour gérer l'état est important pour toutes les applications de taille importante, c'est pourquoi nuxt.js met en œuvre [vuex](https://github.com/vuejs/vuex) dans son cœur.
+> L'utilisation d'un store pour gérer l'état est important pour toutes les applications de taille importante, c'est pourquoi [Vuex](https://vuex.vuejs.org/fr/) est implémenté au cœur de Nuxt.js.
 
-## Activer le Store
+## Activer le store
 
-Nuxt.js recherchera le répertoire `store`; si il existe il:
+Nuxt.js recherchera le répertoire `store`. S'il existe, il :
 
-1. Importera Vuex
-2. Ajoutera le module `vuex` dans le vendors bundle
-3. Ajoutera l'option `store` à l'instance racine de `Vue`.
+1. importera Vuex,
+2. ajoutera le module `vuex` dans le paquetage vendors,
+3. ajoutera l'option `store` à l'instance racine de Vue.
 
-Nuxt.js vous laisse le choix entre **2 modes de store**, choisissez celui qui vous convient le mieux:
-- **Classique:** `store/index.js` retourne une instance
-- **Modules:** chaque fichier `.js` dans le répertoire `store` est transformé en tant que [module avec son propre espace de nom](http://vuex.vuejs.org/en/modules.html) (`index` étant le module racine)
+Nuxt.js vous laisse le choix entre **2 modes de store**, choisissez celui qui vous convient le mieux :
+
+- **Classique :** `store/index.js` retourne une instance de store.
+- **Modules :** chaque fichier `.js` dans le répertoire `store` est transformé en tant que [module avec son propre espace de nom](http://vuex.vuejs.org/fr/modules.html) (`index` étant le module racine)
 
 ## Mode classique
 
-Pour activer le store avec le mode classique, nous créons `store/index.js` dans lequel nous exportons l'instance du store:
+Pour activer le store avec le mode classique, nous créons `store/index.js` qui devrait exporter une méthode qui renvoie une instance Vuex :
 
 ```js
 import Vuex from 'vuex'
 
-const store = new Vuex.Store({
-  state: {
-    counter: 0
-  },
-  mutations: {
-    increment (state) {
-      state.counter++
+const createStore = () => {
+  return new Vuex.Store({
+    state: {
+      counter: 0
+    },
+    mutations: {
+      increment (state) {
+        state.counter++
+      }
     }
-  }
-})
+  })
+}
 
-export default store
+export default createStore
 ```
 
-> Pas besoin d'installer `vuex` étant livré avec nuxt.js
+> Pas besoin d'installer `vuex`, celui-ci étant livré avec Nuxt.js.
 
-Nous pouvons alors utiliser `this.$store` dans nos composants:
+Nous pouvons alors utiliser `this.$store` dans nos composants :
 
 ```html
 <template>
@@ -52,7 +55,7 @@ Nous pouvons alors utiliser `this.$store` dans nos composants:
 
 > Nuxt.js vous permet d'avoir un répertoire `store` dans lequel chaque fichier correspond à un module.
 
-Si vous voulez cette option, exportez le `state`, les mutations et les actions dans `store/index.js` au lieu de l'instance `store`:
+Si vous voulez cette option, exportez l'état, les mutations et les actions dans `store/index.js` au lieu de l'instance `store` :
 
 ```js
 export const state = () => ({
@@ -66,7 +69,8 @@ export const mutations = {
 }
 ```
 
-Puis, vous pouvez avoir `store/todos.js`:
+Puis, vous pouvez avoir `store/todos.js` :
+
 ```js
 export const state = () => ({
   list: []
@@ -79,7 +83,7 @@ export const mutations = {
       done: false
     })
   },
-  delete (state, { todo }) {
+  remove (state, { todo }) {
     state.list.splice(state.list.indexOf(todo), 1)
   },
   toggle (state, todo) {
@@ -88,7 +92,8 @@ export const mutations = {
 }
 ```
 
-Le store sera comme suit:
+Le store sera comme suit :
+
 ```js
 new Vuex.Store({
   state: { counter: 0 },
@@ -109,7 +114,7 @@ new Vuex.Store({
             done: false
           })
         },
-        delete (state, { todo }) {
+        remove (state, { todo }) {
           state.list.splice(state.list.indexOf(todo), 1)
         },
         toggle (state, { todo }) {
@@ -121,7 +126,7 @@ new Vuex.Store({
 })
 ```
 
-Et dans votre `pages/todos.vue`, utiliser le module `todos`:
+Et dans votre `pages/todos.vue`, utiliser le module `todos` :
 
 ```html
 <template>
@@ -130,7 +135,7 @@ Et dans votre `pages/todos.vue`, utiliser le module `todos`:
       <input type="checkbox" :checked="todo.done" @change="toggle(todo)">
       <span :class="{ done: todo.done }">{{ todo.text }}</span>
     </li>
-    <li><input placeholder="What needs to be done?" @keyup.enter="addTodo"></li>
+    <li><input placeholder="Qu'est-ce qui doit être fait ?" @keyup.enter="addTodo"></li>
   </ul>
 </template>
 
@@ -160,19 +165,41 @@ export default {
 </style>
 ```
 
-<div class="Alert">Vous pouvez également avoir des modules en exportant une instance store; vous devrez les ajouter manuellement sur votre store.
+<div class="Alert">Vous pouvez également avoir des modules en exportant une instance de store vous devrez les ajouter manuellement sur votre store.</div>
+
+### Plugins
+
+Vous pouvez ajouter des plugins additionnels au store (en mode modules) en les ajoutant dans le fichier `store/index.js` :
+
+```js
+import myPlugin from 'myPlugin'
+
+export const plugins = [ myPlugin ]
+
+export const state = () => ({
+  counter: 0
+})
+
+export const mutations = {
+  increment (state) {
+    state.counter++
+  }
+}
+```
+
+Pour plus d'informations à propos des plugins, consultez la [documentation Vuex](https://vuex.vuejs.org/fr/plugins.html).
 
 ## La méthode fetch
 
-> La méthode fetch est utilisée pour remplir le store avant de faire le rendu de la page, c'est comme la méthode data sauf qu'elle ne définit pas les données du composant.
+> La méthode `fetch` est utilisée pour remplir le store avant de faire le rendu de la page, c'est comme la méthode `data` sauf qu'elle ne définit pas les données du composant.
 
-Plus d'informations à propos de la méthode fetch: [API Pages fetch](/api/pages-fetch)
+Plus d'informations à propos de la méthode `fetch` dans [la partie Pages de l'API pour `fetch`](/api/pages-fetch).
 
 ## L'action nuxtServerInit
 
-Si l'action `nuxtServerInit` est définie dans le store, nuxt.js l'appellera avec le contexte (uniquement côté serveur). C'est utile lorsque nous disposons de données sur le serveur que nous voulons donner directement au client.
+Si l'action `nuxtServerInit` est définie dans le store, Nuxt.js l'appellera avec le contexte (uniquement côté serveur). C'est utile lorsque nous disposons de données sur le serveur que nous voulons donner directement au client.
 
-Par exemple, disons que nous avons des sessions côté serveur et nous pouvons accéder à l'utilisateur connecté grâce à `req.session.user`. Pour donner l'utilisateur authentifié à notre store, nous mettons à jour notre `store/index.js` comme suit:
+Par exemple, disons que nous avons des sessions côté serveur et nous pouvons accéder à l'utilisateur connecté grâce à `req.session.user`. Pour fournir l'utilisateur authentifié à notre store, nous mettons à jour notre `store/index.js` comme suit :
 
 ```js
 actions: {
@@ -186,4 +213,6 @@ actions: {
 
 > Si vous utilisez le mode _Modules_ du store Vuex, seul le module principal (dans `store/index.js`) recevra cette action. Vous devrez chainer vos actions de module à partir de là.
 
-Le contexte est fourni par `nuxtServerInit` comme 2ème argument. C'est le même que pour les méthodes `data` et `fetch` excepté que `context.redirect()` et `context.error()` sont omis.
+Le contexte est fourni par `nuxtServerInit` comme deuxième argument. C'est le même que pour les méthodes `data` et `fetch` excepté que `context.redirect()` et `context.error()` sont omis.
+
+> Note : Les actions `nuxtServerInit` asynchrones doivent retourner une promesse pour permettre au serveur `nuxt` de les attendre.

--- a/fr/lang.json
+++ b/fr/lang.json
@@ -1,5 +1,6 @@
 {
   "iso": "fr",
+  "docVersion": "1.0.0-rc10",
   "links": {
     "api": "API",
     "blog": "Blog",
@@ -9,23 +10,23 @@
     "examples": "Exemples",
     "ecosystem": "Écosystème",
     "faq": "FAQ",
-    "get_started": "Démarrer",
+    "get_started": "Commencer",
     "github": "GitHub",
     "guide": "Guide",
     "homepage": "Accueil",
-    "live_demo": "Démo",
-    "live_edit": "Expérimenter",
+    "live_demo": "Voir en ligne",
+    "live_edit": "Éditer en ligne",
     "twitter": "Twitter",
     "vuejs": "Vue.js",
     "vue_jobs": "Vue Jobs"
   },
   "text": {
-    "an_error_occurred": "Une erreur s'est produite",
+    "an_error_occured": "Une erreur s'est produite",
     "api_page_not_found": "La page API est introuvable",
     "example_file": "Fichiers d'exemples",
-    "please_wait": "Patienter...",
-    "please_define_title": "Merci de définir un titre dans le \"front matter\"",
-    "please_define_description": "Merci de définir une description dans le \"front matter\"",
+    "please_wait": "Patientez...",
+    "please_define_title": "Merci de définir un titre",
+    "please_define_description": "Merci de définir une description",
     "search": "Rechercher",
     "version": "Version"
   },
@@ -33,16 +34,16 @@
     "title": "Applications Vue.js universelles",
     "meta": {
       "title": "Nuxt.js - Applications Vue.js universelles",
-      "description": "Nuxt.js est un framework minimal pour créer des applications Vue.js avec du rendu côté serveur (\"server side rendering\"), \"code-splitting\", \"hot-reloading\", génération de sites statiques et plus!"
+      "description": "Nuxt.js est un framework minimal pour créer des applications Vue.js avec du rendu côté serveur, de la scission de code, du rechargement à chaud, de la génération de sites statiques et plus encore !"
     }
   },
   "footer": {
     "authors": "Réalisé par les frères Chopin"
   },
   "guide": {
-    "release_notes": "Notes de versions",
-    "contribute": "Tu as vu une erreur ou tu veux contribuer à la documentation?",
-    "edit_on_github": "Édite cette page sur GitHub!"
+    "release_notes": "Notes de versions (en)",
+    "contribute": "Vous avez vu une erreur ou vous souhaitez contribuer à la documentation ?",
+    "edit_on_github": "Éditez cette page sur GitHub !"
   },
   "examples": {
     "source_code": "Code source"


### PR DESCRIPTION
Hi @Atinux!

This PR contains all french content ready to be online.

Currently, the part translated are :

— guide

the part not translated but with a message indicate pages is under translation is :

- api
- examples
- faq

The message is :

```HTML
<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>
```

It is tested to be mobile/desktop displayed to announce the current translation and to not change the number of line of each page. That allows us to continue translation with correct line-to-line matching.

Two options:

- To keep this PR and wait for more page to be translated.
  No content « not French » on the online French website will be accessible but already translated part will not be available online too.

- To merge this PR and offer this content to online french people
  That allows already translated page to be accessible and not already translated pages to be joined by people reading the french message « under translation ».

I let you decide but it was a great help for Vuejs-FR to have the website partially translated to let website to be adopted page by page and allows us to tweet the advancement to allows visibility to project.

In the case you keep this PR here a while, she will be updated each time a new page will be translated.

I think all website could be in French on December (maybe November if all continue as currently!).