### PR TITLE
Fix relative github.com anchors

### DIFF
--- a/en/api/configuration-servermiddleware.md
+++ b/en/api/configuration-servermiddleware.md
@@ -11,8 +11,8 @@ description: Define server-side middleware.
 Nuxt internally creates a [connect](https://github.com/senchalabs/connect) instance,
 so we can register our middleware to it's stack and having chance
 to provide more routes like API **without need to an external server**.
-Because connect itself is a middleware, registered middleware will work with both `nuxt start` 
-and also when used as a middleware with programmatic usages like [express-template](github.com/nuxt-community/express-template).
+Because connect itself is a middleware, registered middleware will work with both `nuxt start`
+and also when used as a middleware with programmatic usages like [express-template](https://github.com/nuxt-community/express-template).
 Nuxt [Modules](/guide/modules) can also provide `serverMiddleware`
 using [this.addServerMiddleware()](/api/internals-module-container#addservermiddleware-middleware-)
 

--- a/fr/api/configuration-servermiddleware.md
+++ b/fr/api/configuration-servermiddleware.md
@@ -11,8 +11,8 @@ description: Define server-side middleware.
 <p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p><p>Nuxt internally creates a [connect](https://github.com/senchalabs/connect) instance,
 so we can register our middleware to it's stack and having chance
 to provide more routes like API **without need to an external server**.
-Because connect itself is a middleware, registered middleware will work with both `nuxt start` 
-and also when used as a middleware with programmatic usages like [express-template](github.com/nuxt-community/express-template).
+Because connect itself is a middleware, registered middleware will work with both `nuxt start`
+and also when used as a middleware with programmatic usages like [express-template](https://github.com/nuxt-community/express-template).
 Nuxt [Modules](/guide/modules) can also provide `serverMiddleware`
 using [this.addServerMiddleware()](/api/internals-module-container#addservermiddleware-middleware-)</p>
 


### PR DESCRIPTION
The github.com urls to the express-template in the server middleware documentation were relative.

Both En & Fr are fixed, other languages didn't seem affected with this issue or didn't have the documentation for server middleware configuration.