### PR TITLE
Delete cached components example

### DIFF
--- a/en/examples/cached-components.md
+++ b/en/examples/cached-components.md
@@ -1,6 +1,0 @@
----
-title: Cached Components
-description: Cached Components example with Nuxt.js
-github: cached-components
-documentation: /api/configuration-cache
----


### PR DESCRIPTION
This feature was deprecated, and corresponding documentation, that this leads to, is gone.
This example is currently misleading and should be deleted.
It would probably be a great idea to provide a replacement entry in FAQ page. Leading to [@nuxtjs/component-cache](https://github.com/nuxt-community/modules/tree/master/packages/component-cache)