### PR TITLE
Fix hotMiddleware menu link

### DIFF
--- a/en/api/menu.json
+++ b/en/api/menu.json
@@ -47,7 +47,7 @@
           { "name": "extend", "to": "#extend" },
           { "name": "extractCSS", "to": "#extractcss" },
           { "name": "filenames", "to": "#filenames" },
-          { "name": "hotMiddleware", "to": "#hot-middleware" },
+          { "name": "hotMiddleware", "to": "#hotmiddleware" },
           { "name": "plugins", "to": "#plugins" },
           { "name": "postcss", "to": "#postcss" },
           { "name": "publicPath", "to": "#publicpath" },

--- a/fr/api/menu.json
+++ b/fr/api/menu.json
@@ -46,7 +46,7 @@
           { "name": "extend (En)", "to": "#extend" },
           { "name": "extractCSS (En)", "to": "#extractcss" },
           { "name": "filenames (En)", "to": "#filenames" },
-          { "name": "hotMiddleware (En)", "to": "#hot-middleware" },
+          { "name": "hotMiddleware (En)", "to": "#hotmiddleware" },
           { "name": "plugins (En)", "to": "#plugins" },
           { "name": "postcss (En)", "to": "#postcss" },
           { "name": "publicPath (En)", "to": "#publicpath" },


### PR DESCRIPTION
The _hotMiddleware_ link in the API menu does not point to the right anchor in EN and FR.