### PR TITLE
Added scss code snippet

### DIFF
--- a/en/faq/pre-processors.md
+++ b/en/faq/pre-processors.md
@@ -23,6 +23,12 @@ module.exports = data: ->
 .red
   color: red
 </style>
+
+<style lang="scss">
+.red {
+  color: red
+}
+</style>
 ```
 
 To be able to use these pre-processors, we need to install their webpack loaders:


### PR DESCRIPTION
At the first glance (for beginners), it's not clear if `lang="sass"` would work with scss as well and this throws css errors.

IMO, it makes sense to add a scss lang snippet, to reflect that it should work with scss syntax as well, if you set `lang`. Opinions?