### PR TITLE
Adding GitHub Pages base router documentation

### DIFF
--- a/en/faq/github-pages.md
+++ b/en/faq/github-pages.md
@@ -17,6 +17,63 @@ It will create a `dist` folder with everything inside ready to be deployed on Gi
 
 <p class="Alert Alert--nuxt-green"><b>Info:</b> If you use a custom domain for your GitHub Pages and put `CNAME` file, it is recommended that CNAME file is put in the `static` directory. [More documentation](/guide/assets#static) about it.</p>
 
+## Deploying to GitHub Pages for repository
+
+If you are creating GitHub Pages for one specific repository, and you don't have any custom domain, the URL of the page will be in this format: `http://<username>.github.io/<repository-name>`.
+
+If you deployed `dist` folder without adding [router base](https://nuxtjs.org/api/configuration-router/#base), when you visit the deployed site you will find that the site is not working due to missing assets. This is because we assume that the website root will be `/`, but in this case it is `/<repository-name>`.
+
+To fix the issue we need to add [router base](https://nuxtjs.org/api/configuration-router/#base) configuration in `nuxt.config.js`:
+
+```js
+module.exports = {
+  router: {
+    base: '/<repository-name>/'
+  }
+}
+```
+
+This way, all generated path asset will be prefixed with `/<repository-name>/`, and the next time you deploy the code to repository GitHub Pages, the site should be working properly.
+
+There is a downside adding `router.base` as the default setting in `nuxt.config.js` though, when you are running `npm run dev`, it won't be working properly since the base path changes. To fix this issue, we want to create a conditional for `router.base` whether to include `<repository-name>`:
+
+```js
+/* nuxt.config.js */
+// only add router.base = '/<repository-name>/' if DEPLOY_ENV is GH_PAGES
+const routerBase = process.env.DEPLOY_ENV === 'GH_PAGES' ? {
+    router: { 
+      base: '/<repository-name>/'
+    }
+  } : {}
+
+module.exports = {
+  ...routerBase
+}
+```
+
+and now we just need to set `DEPLOY_ENV='GH_PAGES'` to build the site for GitHub Pages:
+
+```js
+/* package.json */
+"scripts": {
+  "build:gh-pages": "DEPLOY_ENV=GH_PAGES nuxt build",
+  "generate:gh-pages": "DEPLOY_ENV=GH_PAGES nuxt generate",
+},
+```
+
+For Windows user, you might want to install [cross-env](https://github.com/kentcdodds/cross-env) if you are not using `bash`
+
+```sh
+npm install cross-env --save-dev
+```
+
+then use it this way:
+
+```js
+  "build:gh-pages": "cross-env DEPLOY_ENV=GH_PAGES nuxt build",
+  "generate:gh-pages": "cross-env DEPLOY_ENV=GH_PAGES nuxt generate",
+```
+
 ## Command line deployment
 
 You can also use [push-dir package](https://github.com/L33T-KR3W/push-dir):

--- a/en/guide/commands.md
+++ b/en/guide/commands.md
@@ -110,3 +110,5 @@ So, for an SPA deployment, you must do the following:
 Another possible deployment method is to use Nuxt as a middleware in frameworks while in `spa` mode. This helps reduce server load and uses Nuxt in projects where SSR is not possible.
 
 <div class="Alert">See [How to deploy on Heroku?](/faq/heroku-deployment) for examples of deployment to popular hosts.</div>
+
+<div class="Alert">See [How to deploy on GitHub Pages?](/faq/github-pages) for more details on how to deploy to GitHub Pages.</div>

--- a/en/guide/index.md
+++ b/en/guide/index.md
@@ -111,3 +111,5 @@ We don't want to manually generate the application every time we update the [doc
 We now have a **Serverless Static Generated Web Application** :)
 
 We can go further by thinking of an e-commerce web application made with `nuxt generate` and hosted on a CDN. Everytime a product is out of stock or back in stock, we regenerate the web app. But if the user navigates through the web app in the meantime, it will be up to date thanks to the API calls made to the e-commerce API. No need to have multiple instances of a server + a cache anymore!
+
+<div class="Alert">See [How to deploy on GitHub Pages?](/faq/github-pages) for more details on how to deploy to GitHub Pages.</div>


### PR DESCRIPTION
Raised from issue https://github.com/nuxt/nuxtjs.org/issues/92

Documentation for deploying to GitHub Pages for repository site, to make sure users can deploy correctly