### PR TITLE
layout/view.vue now ignores the layout attribute

### DIFF
--- a/en/guide/views.md
+++ b/en/guide/views.md
@@ -86,7 +86,7 @@ export default {
 </script>
 ```
 
-The `layouts/error.vue` does not allow composing with other layouts (they `layouts` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
+The `layouts/error.vue` does not allow composing with other layouts (the `layout` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
 
 ### Custom Layout
 

--- a/en/guide/views.md
+++ b/en/guide/views.md
@@ -82,10 +82,11 @@ Example of a custom error page in `layouts/error.vue`:
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // you can set a custom layout for the error page
 }
 </script>
 ```
+
+The `layouts/error.vue` does not allow composing with other layouts (they `layouts` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
 
 ### Custom Layout
 

--- a/es/guide/views.md
+++ b/es/guide/views.md
@@ -80,10 +80,11 @@ Example of a custom error page in `layouts/error.vue`:
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // you can set a custom layout for the error page
 }
 </script>
 ```
+
+The `layouts/error.vue` does not allow composing with other layouts (they `layouts` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
 
 ### Custom Layout
 

--- a/fr/guide/views.md
+++ b/fr/guide/views.md
@@ -82,10 +82,11 @@ Exemple d'une page d'erreur personnalisée à l'aide de `layouts/error.vue`:
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // vous pouvez définir une mise en page personnalisée pour la page d'erreur
 }
 </script>
 ```
+
+The `layouts/error.vue` does not allow composing with other layouts (they `layouts` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
 
 ### Mise en page personnalisée
 

--- a/ja/guide/views.md
+++ b/ja/guide/views.md
@@ -81,10 +81,11 @@ Nuxt.js ではメインレイアウトを拡張したり、カスタムレイア
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // エラーページ用のカスタムレイアウトを指定できます
 }
 </script>
 ```
+
+The `layouts/error.vue` does not allow composing with other layouts (they `layouts` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
 
 ### カスタムレイアウト
 

--- a/ko/guide/views.md
+++ b/ko/guide/views.md
@@ -80,10 +80,11 @@ Nuxt.js를 사용하면 `layouts` 폴더에 레이아웃을 추가함으로써 �
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // you can set a custom layout for the error page
 }
 </script>
 ```
+
+The `layouts/error.vue` does not allow composing with other layouts (they `layouts` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
 
 ### 사용자 정의 레이아웃
 

--- a/zh/guide/views.md
+++ b/zh/guide/views.md
@@ -78,10 +78,11 @@ Nuxt.js 允许你扩展默认的布局，或在 `layout` 目录下创建自定�
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // 你可以为错误页面指定自定义的布局
 }
 </script>
 ```
+
+The `layouts/error.vue` does not allow composing with other layouts (they `layouts` attribute is ignored) due to conflicts (especially with css).  Instead, you should add your own header components, etc directly to `layouts/error.vue`.
 
 ### 个性化布局
 


### PR DESCRIPTION
Per https://github.com/nuxt/nuxt.js/issues/1566 it seems layout/view.vue
is now a standalone page that cannot be composed with other layouts due
to conflicts.

I wasn't sure exactly how to handle the translations, so changed the source code
and inserted the comment in English so it doesn't get lost.