### PR TITLE
Documented Fetch Use With Vuex

### DIFF
--- a/en/api/pages-fetch.md
+++ b/en/api/pages-fetch.md
@@ -48,3 +48,24 @@ export default {
 }
 </script>
 ```
+
+## Using Vuex
+
+If using `dispatch` inside of Nuxt component `fetch`, make sure to use `async`/`await` in the component file *and* the action function. If this is not done, then `fetch` will not trigger on page refresh.
+
+```html
+<script>
+export default {
+  async fetch ({ store, params }) {
+    await store.dispatch('GET_STARS');
+  }
+}
+</script>
+```
+
+```js
+export async function GET_STARS({ commit }) {
+  const { data } = await axios.get('http://my-api/stars');
+  store.commit('SET_STARS', data);
+}
+```

--- a/en/api/pages-fetch.md
+++ b/en/api/pages-fetch.md
@@ -49,9 +49,9 @@ export default {
 </script>
 ```
 
-## Using Vuex
+## Vuex
 
-If using `dispatch` inside of Nuxt component `fetch`, make sure to use `async`/`await` in the component file *and* the action function. If this is not done, then `fetch` will not trigger on page refresh.
+If you want to call a store action, use `store.dispatch` inside `fetch`, make sure to wait for the end of the action by using `async`/`await` inside:
 
 ```html
 <script>
@@ -63,9 +63,13 @@ export default {
 </script>
 ```
 
+`store/index.js`
 ```js
-export async function GET_STARS({ commit }) {
-  const { data } = await axios.get('http://my-api/stars');
-  store.commit('SET_STARS', data);
+// ...
+export const actions = {
+  async function GET_STARS({ commit }) {
+    const { data } = await axios.get('http://my-api/stars');
+    store.commit('SET_STARS', data);
+  }
 }
 ```


### PR DESCRIPTION
Added missing edge case to `fetch` usage with Vuex `dispatch`. If this is not done when using Vuex with Nuxt, then the Component `fetch` method will not trigger on page refresh.

If I am in any way incorrect, please correct me in possible alternatives. In my own experience, using `fetch` will not work otherwise.

Is this intentional functionality? If so it should be documented. Otherwise, if this is not intentional, then there is something much deeper that needs to be fixed.

This was also discussed previously: https://github.com/nuxt/nuxt.js/issues/1852
  
  