### PR TITLE
Add `eslint-plugin-import` & `eslint-plugin-node` to ESLint docs

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -124,7 +124,7 @@ jsdom has some limitations because it does not use a browser. However, it will c
 You can add [ESLint](http://eslint.org) pretty easily with nuxt.js, first, you need to add the npm dependencies:
 
 ```bash
-npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard
+npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard eslint-plugin-import eslint-plugin-node
 ```
 
 Then, you can configure ESLint via a `.eslintrc.js` file in your root project directory:

--- a/es/guide/development-tools.md
+++ b/es/guide/development-tools.md
@@ -120,7 +120,7 @@ jsdom has some limitations because it does not use a browser. However, it will c
 You can add [ESLint](http://eslint.org) pretty easily with nuxt.js, first, you need to add the npm dependencies:
 
 ```bash
-npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard
+npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard eslint-plugin-import eslint-plugin-node
 ```
 
 Then, you can configure ESLint via a `.eslintrc.js` file in your root project directory:

--- a/fr/guide/development-tools.md
+++ b/fr/guide/development-tools.md
@@ -124,7 +124,7 @@ jsdom a certaines limitations parce qu'il n'utilise pas de navigateur. Cependant
 Vous pouvez ajouter [ESLint](http://eslint.org) assez facilement avec Nuxt.js. Ajouter les dépendances npm :
 
 ```bash
-npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard
+npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard eslint-plugin-import eslint-plugin-node
 ```
 
 Puis, configurez ESLint via un fichier `.eslintrc.js` à la racine de votre projet :

--- a/ja/guide/development-tools.md
+++ b/ja/guide/development-tools.md
@@ -124,7 +124,7 @@ jsdom はブラウザを使っていないため制約がいくつかありま�
 とても簡単に [ESLint](http://eslint.org) を Nuxt.js と一緒に使うことができます。まず npm の依存パッケージを追加する必要があります:
 
 ```bash
-npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard
+npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard eslint-plugin-import eslint-plugin-node
 ```
 
 それから `.eslintrc.js` ファイルをプロジェクトのルートディレクトに置いて ESLint を設定できます:

--- a/ko/guide/development-tools.md
+++ b/ko/guide/development-tools.md
@@ -123,7 +123,7 @@ jsdom 은 브라우저를 사용하지 않기 때문에 제약점이 몇가지 �
 매우 간단하게 [ESLint](http://eslint.org) 를 Nuxt.js 와 같이 사용할 수 있습니다. 우선 npm 디펜던시를 추가해야 합니다:
 
 ```bash
-npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard
+npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard eslint-plugin-import eslint-plugin-node
 ```
 
 그리고 `.eslintrc.js` 파일을 프로젝트의 루트 디렉토리에 두고 ESLint를 설정합니다:

--- a/zh/guide/development-tools.md
+++ b/zh/guide/development-tools.md
@@ -124,7 +124,7 @@ npm test
 在 Nuxt.js 中集成 [ESLint](http://eslint.org) 是非常简单的，首先我们需要安装 ESLint 的一系列依赖包：
 
 ```bash
-npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard
+npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-html eslint-plugin-promise eslint-plugin-standard eslint-plugin-import eslint-plugin-node
 ```
 
 然后, 在项目根目录下创建 `.eslintrc.js` 文件用于配置 ESLint：


### PR DESCRIPTION
Following the instructions in the [documentation](https://github.com/nuxt/docs/blob/d48dadc3387b6a60b636faa060d9a0cad2d7a28c/en/guide/development-tools.md#eslint) to add ESLint I encountered the following errors:

```
Oops! Something went wrong! :(

ESLint: 4.15.0.
ESLint couldn't find the plugin "eslint-plugin-import". This can happen for a couple different reasons:

1. If ESLint is installed globally, then make sure eslint-plugin-import is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.

2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm i eslint-plugin-import@latest --save-dev

If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.
```

```
Oops! Something went wrong! :(

ESLint: 4.15.0.
ESLint couldn't find the plugin "eslint-plugin-node". This can happen for a couple different reasons:

1. If ESLint is installed globally, then make sure eslint-plugin-node is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.

2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm i eslint-plugin-node@latest --save-dev

If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.
```
After installing these two plugins ESLint runs as expected.

This pull request adds `eslint-plugin-import` and `eslint-plugin-node` to the list of packages to install for all languages in the docs ([except Russian](https://github.com/nuxt/docs/blob/d48dadc3387b6a60b636faa060d9a0cad2d7a28c/ru/guide/eslint.md)).