### PR TITLE
Add <no-ssr> component document (Only /en)

### DIFF
--- a/en/api/components-no-ssr.md
+++ b/en/api/components-no-ssr.md
@@ -1,0 +1,23 @@
+---
+title: "API: The <no-ssr> Component"
+description: Skip component rendering on server side rendering, and rendering placeholder text.
+---
+
+# The &lt;no-ssr&gt; Component
+
+> This component is used to purposely remove the component from the subject of server side rendering.
+
+**Props**:
+- placeholder: `string`
+  - This prop will be use to component innner `div`, it's displayed as text only on server side rendering.
+
+```html
+<template>
+  <div>
+    <ssrfrendly-component />
+    <no-ssr>
+      <not-ssrfrendly />
+    </no-ssr>
+  </div>
+</template>
+```

--- a/en/api/components-no-ssr.md
+++ b/en/api/components-no-ssr.md
@@ -1,6 +1,6 @@
 ---
 title: "API: The <no-ssr> Component"
-description: Skip component rendering on server side rendering, and rendering placeholder text.
+description: Skip component rendering on server side(rendering), and display placeholder text.
 ---
 
 # The &lt;no-ssr&gt; Component
@@ -9,7 +9,7 @@ description: Skip component rendering on server side rendering, and rendering pl
 
 **Props**:
 - placeholder: `String`
-  - This prop will be use to component innner `div`, it's displayed as text only on server side rendering.
+  - This prop will be used as a content of inner `div` and displayed as text only on server side rendering.
 
 ```html
 <template>

--- a/en/api/components-no-ssr.md
+++ b/en/api/components-no-ssr.md
@@ -21,3 +21,6 @@ description: Skip component rendering on server side(rendering), and display pla
   </div>
 </template>
 ```
+
+This component is a clone of [egoist/vue-no-ssr](https://github.com/egoist/vue-no-ssr).
+Thanks [@egoist](https://github.com/egoist)!

--- a/en/api/components-no-ssr.md
+++ b/en/api/components-no-ssr.md
@@ -8,7 +8,7 @@ description: Skip component rendering on server side rendering, and rendering pl
 > This component is used to purposely remove the component from the subject of server side rendering.
 
 **Props**:
-- placeholder: `string`
+- placeholder: `String`
   - This prop will be use to component innner `div`, it's displayed as text only on server side rendering.
 
 ```html

--- a/en/api/menu.json
+++ b/en/api/menu.json
@@ -30,7 +30,8 @@
     "links": [
       { "name": "nuxt", "to": "/components-nuxt" },
       { "name": "nuxt-child", "to": "/components-nuxt-child" },
-      { "name": "nuxt-link", "to": "/components-nuxt-link" }
+      { "name": "nuxt-link", "to": "/components-nuxt-link" },
+      { "name": "no-ssr", "to": "/components-no-ssr" }
     ]
   },
   {


### PR DESCRIPTION
## About

Nuxt include a `<no-ssr>` component, but documentation about it does not exist.
So, I added to documentation it.

## Remarks

The quoting source for `<no-ssr>` seems to be `egoist/vue-no-ssr`.
Should I add reference to it? Just like `<nuxt-link>` 's document.