### PR TITLE
Fix link to end-to-end testing section

### DIFF
--- a/en/api/nuxt-render-and-get-window.md
+++ b/en/api/nuxt-render-and-get-window.md
@@ -15,7 +15,7 @@ description: Get the `window` from a given URL of a Nuxt.js Application.
 
 > Get the window from a given url of a nuxt.js application.
 
-<p class="Alert Alert--info">This method is made for [test purposes](guide/development-tools#end-to-end-testing).</p>
+<p class="Alert Alert--info">This method is made for [test purposes](/guide/development-tools#end-to-end-testing).</p>
 
 To use this function, you have to install `jsdom`:
 


### PR DESCRIPTION
Currently on the site, when you click on the 'test purposes' link, it takes you to a page that doesn't exist, as the path is relative. This fixes the link by making it absolute, like the link found on the nuxt.renderRoute page. (https://nuxtjs.org/api/nuxt-render-route)