### PR TITLE
增加严谨性

### DIFF
--- a/zh/guide/plugins.md
+++ b/zh/guide/plugins.md
@@ -63,7 +63,7 @@ Vue.use(VueNotifications)
 然后, 在 `nuxt.config.js` 内配置 `plugins` 如下：
 ```js
 module.exports = {
-  plugins: ['~plugins/vue-notifications']
+  plugins: ['~/plugins/vue-notifications']
 }
 ```
 
@@ -75,9 +75,9 @@ module.exports = {
 ```js
 module.exports = {
   build: {
-    vendor: ['vue-notifications']
+    vendor: ['~/plugins/vue-notifications']
   },
-  plugins: ['~plugins/vue-notifications']
+  plugins: ['~/plugins/vue-notifications']
 }
 ```
 
@@ -91,7 +91,7 @@ module.exports = {
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/vue-notifications', ssr: false }
+    { src: '~/plugins/vue-notifications', ssr: false }
   ]
 }
 ```


### PR DESCRIPTION
1. 把~plugins改成~/plugins. 保持风格一致性
2. vendor 补全路径：  ['~/plugins/vue-notifications']。这样做的原因是，当我使用element-ui时， 在plugins目录新建新element.js, 代码如下:

```js
import Vue from 'vue'
import ElementUI from 'element-ui'

Vue.use(ElementUI)
```
**然后不修改任何vue文件**， 在`nuxt.config.js`里配置

```js
  build: {
    vendor: ['axios', 'element']
  },
 plugins: [
		{src: '~/plugins/axios'}, {src: '~/plugins/element', ssr: false}
  ],
```
然后执行`npm run build`， 最终会报错:

```sh
ERROR in multi vue vue-router vue-meta vuex axios element
Module not found: Error: Can't resolve 'element' in '/Users/levy/repo/vue/nuxt'
 @ multi vue vue-router vue-meta vuex axios element
```
在venor中， 补全路径时，才成功编译

我是参考[Nuxt.js + Vuetify.js project](https://github.com/vuetifyjs/nuxt)的