### PR TITLE
Fix ESLint anchor link to match link on page

### DIFF
--- a/en/guide/menu.json
+++ b/en/guide/menu.json
@@ -111,7 +111,7 @@
         "to": "/development-tools", "name": "Development Tools",
         "contents": [
           { "to": "#end-to-end-testing", "name": "End-to-End Testing" },
-          { "to": "#eslint", "name": "ESLint" }
+          { "to": "#eslint-amp-amp-prettier", "name": "ESLint" }
         ]
       }
     ]


### PR DESCRIPTION
The link in the menu pointing to the ESLint section in [Development tools](https://nuxtjs.org/guide/development-tools) was incorrect and broken. Changed it to match the `id` of the anchor in the [article](https://nuxtjs.org/guide/development-tools#eslint-amp-amp-prettier). 