### PR TITLE
Fixed webpack-bundle-analyzer link

### DIFF
--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -9,7 +9,7 @@ description: Nuxt.js lets you customize the webpack configuration for building y
 
 ## analyze
 
-> Nuxt.js use [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyze) to let you visualize your bundles and how to optimize them.
+> Nuxt.js use [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to let you visualize your bundles and how to optimize them.
 
 - Type: `Boolean` or `Object`
 - Default: `false`


### PR DESCRIPTION
The link to the webpack-bundle-analyzer git was missing an **r** at the end.