### PR TITLE
Fix/use webpack in lower case letters

### DIFF
--- a/en/api/internals-builder.md
+++ b/en/api/internals-builder.md
@@ -24,6 +24,6 @@ Plugin         | Arguments                               | When
 `build:before`           | (nuxt, buildOptions) | Before Nuxt build started
 `build:templates`        | ({ templateFiles, templateVars, resolve })  | Generating `.nuxt` template files    
 `build:extendRoutes`     | (routes, resolve) | Generating routes
-`build:compile`          | ({ name, compiler }) | Before webpack compile (compiler is a Webpack `Compiler` instance), if universal mode, called twice with name `'client'` and `'server'`
-`build:compiled`         | ({ name, compiler, stats }) | Webpack build finished 
+`build:compile`          | ({ name, compiler }) | Before webpack compile (compiler is a webpack `Compiler` instance), if universal mode, called twice with name `'client'` and `'server'`
+`build:compiled`         | ({ name, compiler, stats }) | webpack build finished 
 `build:done`             | (nuxt) | Nuxt build finished

--- a/en/faq/css-flash.md
+++ b/en/faq/css-flash.md
@@ -7,6 +7,6 @@ description: Why a CSS Flash appears with Nuxt.js?
 
 ![cssflash](/flash_css.gif)
 
-This is because the CSS is in the JavaScript build in **development mode** to allow hot-reloading via Webpack. This flash is called [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content).
+This is because the CSS is in the JavaScript build in **development mode** to allow hot-reloading via webpack. This flash is called [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content).
 
 Don't worry in **production mode**, the CSS is separated and put in the header so this flash of unstyled content does not appear anymore.


### PR DESCRIPTION
> webpack should always be written in lower-case letters, even at the beginning of a sentence.

https://webpack.js.org/branding/