### PR TITLE
Update Vuex Classic mode example to working condition

### DIFF
--- a/en/guide/vuex-store.md
+++ b/en/guide/vuex-store.md
@@ -30,6 +30,9 @@ const createStore = () => {
     state: {
       counter: 0
     },
+    getters: {
+      counter: state => state.counter
+    },
     mutations: {
       increment (state) {
         state.counter++
@@ -47,7 +50,7 @@ We can now use `this.$store` inside our components:
 
 ```html
 <template>
-  <button @click="$store.commit('increment')">{{ $store.state.counter }}</button>
+  <button @click="$store.commit('increment')">{{ $store.getters.counter }}</button>
 </template>
 ```
 


### PR DESCRIPTION
The Classic mode example for using Vuex with Nuxt does not work above unless modified as shown. 

'this.$store.state' is not accessible unless accessed by a getter method.