### PR TITLE
Change babel preset to `env`

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -28,7 +28,7 @@ Then add a test script to our `package.json` and configure AVA to compile files 
 },
 "babel": {
   "presets": [
-    "es2015"
+    "env"
   ]
 }
 ```


### PR DESCRIPTION
Since Nuxt is now using `env` babel preset, the configuration for testing should reflect this change