### PR TITLE
misguiding info about implementation for `script` into head

### DIFF
--- a/en/api/pages-head.md
+++ b/en/api/pages-head.md
@@ -5,7 +5,7 @@ description: Nuxt.js uses vue-meta to update the headers and HTML attributes of 
 
 # The head Method
 
-> Nuxt.js uses [vue-meta](https://github.com/declandewet/vue-meta) to update the `headers` and `html attributes` of your application.
+> Nuxt.js uses [vue-meta](https://github.com/declandewet/vue-meta) to update the `headers` and `html attributes` of your application. Except for `script` it has [a different implementation method](https://nuxtjs.org/faq/).
 
 - **Type:** `Object` or `Function`
 


### PR DESCRIPTION
I spent a few hours trying to debug as I thought I had to refer to the vue-meta implementation method of `script` which is very different from the Nuxt way.