### PR TITLE
Fix external resources example code

### DIFF
--- a/en/faq/external-resources.md
+++ b/en/faq/external-resources.md
@@ -33,13 +33,15 @@ Include your resources in your `.vue` file inside the `pages/` directory:
 
 <script>
 export default {
-  head: {
-    script: [
-      { src: 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js' }
-    ],
-    link: [
-      { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Roboto' }
-    ]
+  head () {
+    return {
+      script: [
+        { src: 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js' }
+      ],
+      link: [
+        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Roboto' }
+      ]
+    } 
   }
 }
 </script>


### PR DESCRIPTION
I think it should use the `head` method.

```diff
- head: {
-   ...
- }
+ head () {
+   return {
+     ...
+  }
+ }
```