### PR TITLE
Update components-nuxt.md

### DIFF
--- a/zh/api/components-nuxt.md
+++ b/zh/api/components-nuxt.md
@@ -5,7 +5,7 @@ description: 该组件用于在布局中显示页面组件（即非布局内容�
 
 # &lt;nuxt&gt; 组件
 
-> 该组件只适用于在[布局]((/guide/views#布局))中显示页面组件（即非布局内容）。
+> 该组件只适用于在[布局](/guide/views#布局)中显示页面组件（即非布局内容）。
 
 例如 (`layouts/default.vue`)：
 


### PR DESCRIPTION
修改链接: https://zh.nuxtjs.org/api/components-nuxt 上的"该组件只适用于在布局)中显示页面组件（即非布局内容）。"文字链接编辑, 文字链接为"布局", 链接为"/guide/views#布局", 多了一对小括号, 导致链接不能够访问; 此pr删除了多余的一对小括号