### PR TITLE
Correct pug dependency

### DIFF
--- a/en/faq/pre-processors.md
+++ b/en/faq/pre-processors.md
@@ -34,5 +34,5 @@ module.exports = data: ->
 To be able to use these pre-processors, we need to install their webpack loaders:
 
 ```bash
-npm install --save-dev pug@2.0.0-beta6 pug-loader coffeescript coffee-loader node-sass sass-loader
+npm install --save-dev pug@2.0.3 pug-plain-loader coffeescript coffee-loader node-sass sass-loader
 ```


### PR DESCRIPTION
vue-loader v15+ uses pug-plain-loader instead of pug-loader.
https://github.com/yyx990803/pug-plain-loader