### PR TITLE
fix header level in docs internal

### DIFF
--- a/en/api/internals.md
+++ b/en/api/internals.md
@@ -34,7 +34,7 @@ These classes are the hearth of Nuxt and should exist on both runtime and build 
 
 These classes are only needed for build or dev mode.
 
-### Builder
+#### Builder
 
 - [`Builder` Class](/api/internals-builder)
 - Source: [builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/builder.js)


### PR DESCRIPTION
Builder, a module , was marked with a level 3 header making it seem like a category, fixed to a level 4 header like the other exportable modules