### PR TITLE
Update dokku deployment

### DIFF
--- a/en/faq/dokku-deployment.md
+++ b/en/faq/dokku-deployment.md
@@ -41,6 +41,12 @@ Then, we tell Dokku to launch `npm run build` via the `scripts.dokku.predeploy` 
 }
 ```
 
+To launch the application we run `npm run start` using the [Procfile](http://dokku.viewdocs.io/dokku/deployment/methods/dockerfiles/#procfiles-and-multiple-processes):
+
+```
+web: npm run start
+```
+
 Finally, we can push our app on Dokku with:
 
 ```bash


### PR DESCRIPTION
When following the guide on dokku deployment I missed the specification how to run the final process that launches the actual application. When this is not set it fails with a message similar to (depending on your current Procfile content):

```
Cannot find module '/app/dist'
```

This is solved by specifying which command should be run on the dokku deploy.