### PR TITLE
Add ignorePrefix to API menu

### DIFF
--- a/en/api/configuration-ignore.md
+++ b/en/api/configuration-ignore.md
@@ -6,17 +6,16 @@ description: Define the ignore files for your Nuxt.js application
 # The ignorePrefix Property
 
 - Type: `String`
+- Default: `'-'`
 
-> All the files in pages/ layout/ middleware/ store/ will be ignored if they start with this prefix configured by `ignorePrefix`.
+> Any file in pages/ layout/ middleware/ or store/ will be ignored during building if its filename starts with the prefix specified by `ignorePrefix`.
 
-Default: `'-'`
-
-By default all files which are started with `-` will be ignored, such as: `store/-foo.js` and `pages/-bar.vue`
+By default all files which start with `-` will be ignored, such as `store/-foo.js` and `pages/-bar.vue`. This allows for co-locating tests, utilities, and components with their callers without themselves being converted into routes, stores, etc.
 
 # The ignore Property
 
 - Type: `Array`
+- Default: `['**/*.test.*']`
 
-> Support more customizable ignore patterns like *.test files, files match the glob patterns configured inside `ignore` will be ignored in building.
+> More customizable than `ignorePrefix`: all files matching glob patterns specified inside `ignore` will be ignored in building.
 
-Default: `['**/*.test.*']`

--- a/en/api/configuration-modules.md
+++ b/en/api/configuration-modules.md
@@ -3,7 +3,7 @@ title: "API: The modules Property"
 description: Modules are Nuxt.js extensions which can extend it's core functionality and add endless integrations.
 ---
 
-# The *modules* Property
+# The modules Property
 
 - Type: `Array`
 

--- a/en/api/menu.json
+++ b/en/api/menu.json
@@ -74,6 +74,7 @@
         ]
       },
       { "name": "head", "to": "/configuration-head" },
+      { "name": "ignore", "to": "/configuration-ignore" },
       {
         "name": "loading",
         "to": "/configuration-loading",


### PR DESCRIPTION
Fixes https://github.com/nuxt/nuxt.js/issues/3631

- Added link to `/configuration-ignore` to API menu
- Rewrote text for clarity and consistency with other pages.
- Removed inconsistent emphasis in title of modules page.