### PR TITLE
Info on modulesDir configuration option missing from documentation

### DIFF
--- a/en/api/configuration-modulesdir.md
+++ b/en/api/configuration-modulesdir.md
@@ -5,7 +5,14 @@ description: Define the modules directory for your Nuxt.js application
 
 # The modulesDir Property
 
-> Used to set the modules directories for path resolving, for example: webpack resolveLoading, nodeExternal and postcss. Configuration path is relative to options.rootDir.
+- Type: `Array`
+- Default: `['node_modules']`
+ > Used to set the modules directories for path resolving, for example: webpack resolveLoading, nodeExternal and postcss. Configuration path is relative to [options.rootDir](/api/configuration-rootdir) (default: `process.cwd()`).
+ Example (`nuxt.config.js`):
+ ```js
+module.exports = {
+  modulesDir: ['../../node_modules']
+}
+```
+Setting this field may be necessary if your project is organized as a Yarn workspace-styled mono-repository.
 
-Type: `Array`
-Default: `['node_modules']`

--- a/en/guide/configuration.md
+++ b/en/guide/configuration.md
@@ -53,6 +53,13 @@ This option lets you add Nuxt modules to your project.
 
 [Documentation about `modules` integration](/api/configuration-modules)
 
+### modulesDir
+
+This option lets you define the node_modules folder of your Nuxt.js Application.
+ 
+[Documentation about `modulesDir` integration](/api/configuration-modulesdir)
+
+
 ### plugins
 
 This option lets you define JavaScript plugins to be run before instantiating the root Vue.js Application.


### PR DESCRIPTION
Issue: #702

Changes:
- Section added to `en/guide/configuration.md`, including link to API section
- `en/api/configuration-modulesdir.md` reformatted to be consistent with other API sections and include an example