### PR TITLE
declare config.mode as universal.

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -81,6 +81,7 @@ test.before('Init Nuxt.js', async t => {
   try { config = require(resolve(rootDir, 'nuxt.config.js')) } catch (e) {}
   config.rootDir = rootDir // project folder
   config.dev = false // production build
+  config.mode = 'universal' // Isomorphic application
   nuxt = new Nuxt(config)
   await new Builder(nuxt).build()
   nuxt.listen(4000, 'localhost')


### PR DESCRIPTION
"End to End Testing" tutorial does't work When using spa mode because spa mode does't make page content.

To avoid that, set to universal mode in `test.before`.