### PR TITLE
Update Chinese document (introduction) to synchronize with nuxt2.0 English document

### DIFF
--- a/zh/guide/index.md
+++ b/zh/guide/index.md
@@ -31,7 +31,7 @@ Nuxt.js 集成了以下组件/框架，用于开发完整而强大的 Web 应用
 - [Vuex](https://github.com/vuejs/vuex) (当配置了 [Vuex 状态树配置项](/guide/vuex-store) 时才会引入)
 - [Vue-Meta](https://github.com/declandewet/vue-meta)
 
-压缩并 gzip 后，总代码大小为：**28kb** （如果使用了 Vuex 特性的话为 31kb）。
+压缩并 gzip 后，总代码大小为：**57kb** （如果使用了 Vuex 特性的话为 60kb）。
 
 另外，Nuxt.js 使用 [Webpack](https://github.com/webpack/webpack) 和 [vue-loader](https://github.com/vuejs/vue-loader) 、 [babel-loader](https://github.com/babel/babel-loader) 来处理代码的自动化构建工作（如打包、代码分层、压缩等等）。
 
@@ -48,6 +48,7 @@ Nuxt.js 集成了以下组件/框架，用于开发完整而强大的 Web 应用
 - 本地开发支持热加载
 - 集成ESLint
 - 支持各种样式预处理器： SASS、LESS、 Stylus等等
+- 支持HTTP/2 推送
 
 ## 流程图
 
@@ -63,15 +64,22 @@ Nuxt.js 集成了以下组件/框架，用于开发完整而强大的 Web 应用
 
 可以查看 Nuxt.js 提供的各种 [命令](/guide/commands) 以了解更多的信息。
 
+### 单页应用程序 (SPA)
+
+如果您不想使用服务器端渲染或需要应用程序提供静态托管，则可以使用`nuxt --spa`命令即可使用`SPA`模式。
+它为您提供了强大的SPA部署机制，无需使用`Node.js`来运行应用程序或任何特殊的服务器端处理。
+
+可以查看Nuxt.js提供的各种[命令](/guide/commands)来了解更多相关使用信息。
+
 如果你的项目有自己的Web服务器（例如用 Express.js 启动的Web服务），你仍然可以将 Nuxt.js 当作是中间件来使用，负责UI渲染部分的功能。在开发通用的Web应用过程中，Nuxt.js 是可插拔的，没有太多的限制，可通过 [开发编码中使用Nuxt.js](/api/nuxt) 了解更多的信息。
 
-## 静态化
+## 静态化 (预渲染)
 
 支持 Vue.js 应用的静态化算是 Nuxt.js 的一个创新点，通过 `nuxt generate` 命令实现。
 
 该命令依据应用的路由配置将每一个路由静态化成为对应的HTML文件。
 
-例子：
+例如，以下文件结构：
 
 ```bash
 -| pages/
@@ -89,18 +97,17 @@ Nuxt.js 集成了以下组件/框架，用于开发完整而强大的 Web 应用
 
 静态化可以让你在任何一个静态站点服务商托管你的Web应用。
 
-Nuxt.js 的官网就是一个绝佳的例子, 它静态化后托管于GitHub Pages：
-- [源码](https://github.com/nuxt/nuxtjs.org)
-- [静态化后的文件](https://github.com/nuxt/nuxtjs.org/tree/gh-pages)
+Nuxt.js 的官网就是一个绝佳的例子, 它静态化后托管在 [Netlify](https://www.netlify.com)上，也可以参考我们的[源代码](https://github.com/nuxt/nuxtjs.org)
 
-在每次更新[文档代码](https://github.com/nuxt/docs)的时候，为了避免手工执行 `nuxt generate` 命令生成静态文件，我们可以在每次提交代码的时候调用一个AWS Lambda函数来做以下的事情：
-1. 拷贝 [nuxtjs.org 源码](https://github.com/nuxt/nuxtjs.org)
+我们不希望每次更新部署[docs仓库](https://github.com/nuxt/docs)的时候都要手工执行 `nuxt generate` 命令生成静态文件，它会触发`Netlify`的钩子应用：
+
+1. 克隆 [nuxtjs.org repository](https://github.com/nuxt/nuxtjs.org)
 2. 使用 `npm install` 命令安装依赖
-3. 运行 `nuxt generate`
-4. 将生成的 `dist` 目录提交至 `gh-pages` 分支
+3. 运行 `npm run generate`
+4. 生成 `dist` 目录
 
 我们现在就有了一个 **无服务端的自动静态化的Web应用** :)
 
 我们进一步考虑下电商应用的场景，利用 `nuxt generate`，是不是可以将应用静态化后部署在CDN服务器，每当一个商品的库存发生变化时，就重新静态化下，更新下商品的库存。但是如果用户访问的时候恰巧更新了呢？我们可以通过调用电商的API，保证用户访问的是最新的数据。这样相对于传统的电商应用来说，这种静态化的方案可以大大节省服务器的资源。
- 
-> 译者注：因为CDN节点目前只能缓存静态文件，像动态脚本PHP是CDN节点无法运行。也就是只能存html,css，js这样的前端页面到CDN节点。所以通过CDN缓存静态页面，进行全球CDN节点布局。相对传统的动态网站，分散了对服务器的请求，降低了服务器压力。从而降低了运维成本。提升了用户体验。简单而言就是，页面静态文件CDN，数据通过API。前后端分离。
+
+<div class="Alert">查看 [如何在Netlify上部署？](/faq/netlify-deployment) 来获取更多相关信息。。</div>

--- a/zh/guide/index.md
+++ b/zh/guide/index.md
@@ -110,4 +110,4 @@ Nuxt.js 的官网就是一个绝佳的例子, 它静态化后托管在 [Netlify]
 
 我们进一步考虑下电商应用的场景，利用 `nuxt generate`，是不是可以将应用静态化后部署在CDN服务器，每当一个商品的库存发生变化时，就重新静态化下，更新下商品的库存。但是如果用户访问的时候恰巧更新了呢？我们可以通过调用电商的API，保证用户访问的是最新的数据。这样相对于传统的电商应用来说，这种静态化的方案可以大大节省服务器的资源。
 
-<div class="Alert">查看 [如何在Netlify上部署？](/faq/netlify-deployment) 来获取更多相关信息。。</div>
+<div class="Alert">查看 [如何在Netlify上部署？](/faq/netlify-deployment) 来获取更多相关信息。</div>

--- a/zh/lang.json
+++ b/zh/lang.json
@@ -1,6 +1,6 @@
 {
   "iso": "zh",
-  "docVersion": "0.10.7",
+  "docVersion": "2.0.0",
   "links": {
     "api": "API",
     "blog": "博客",


### PR DESCRIPTION
I am very pleased that nuxt.js has released version 2.0, which makes nuxt.js better optimized and experienced in its use.
There are more and more Chinese developers using nuxt.js. They are troubled by the lack of Chinese documents, so I translated some Chinese documents and translated them with the nuxt.js2.0 English documents. If I can approve these, I will use the remaining time to continue. Translation, as a contributor to nuxt.js, I feel very honored, thank you!