### PR TITLE
Fix text layout: en/api/configuration-modulesdir.md

### DIFF
--- a/en/api/configuration-modulesdir.md
+++ b/en/api/configuration-modulesdir.md
@@ -7,12 +7,16 @@ description: Define the modules directory for your Nuxt.js application
 
 - Type: `Array`
 - Default: `['node_modules']`
- > Used to set the modules directories for path resolving, for example: webpack resolveLoading, nodeExternal and postcss. Configuration path is relative to [options.rootDir](/api/configuration-rootdir) (default: `process.cwd()`).
- Example (`nuxt.config.js`):
- ```js
+
+> Used to set the modules directories for path resolving, for example: webpack resolveLoading, nodeExternal and postcss. Configuration path is relative to [options.rootDir](/api/configuration-rootdir) (default: `process.cwd()`).
+
+Example (`nuxt.config.js`):
+
+```js
 module.exports = {
   modulesDir: ['../../node_modules']
 }
 ```
+
 Setting this field may be necessary if your project is organized as a Yarn workspace-styled mono-repository.
 


### PR DESCRIPTION
Hi. nuxt/docs authors.

I found a page with a slightly broken layout so I fixed it.
Display of "Example:" etc. is different from other pages.

<img width="760" alt="broken_document" src="https://user-images.githubusercontent.com/26263/46200733-60478c80-c34d-11e8-8807-088fe7223de9.png">

via. https://nuxtjs.org/api/configuration-modulesdir

Please feel free to review it.
Thanks :)
