### PR TITLE
Doc Update: Added hint as to why arrow functions don't have there own 'this'

### DIFF
--- a/en/guide/vuex-store.md
+++ b/en/guide/vuex-store.md
@@ -195,6 +195,8 @@ export default {
 
 You can optionally break down a module file into separate files: `state.js`, `actions.js`, `mutations.js` and `getters.js`. If you maintain an `index.js` file with state, getters and mutations while having a single separate file for actions, that will also still be properly recognized.
 
+> Note: Whilst using split-file modules, you must remember that using arrow functions, ```this``` is only lexically available. Lexical scoping simply means that the ```this``` always references the owner of the arrow function. If the arrow function is not contained then ```this``` would be undefined. The solution is to use a "normal" function which produces its own scope and thus has ```this``` available.
+
 ### Plugins
 
 You can add additional plugin to the store (in Modules Mode) putting it into the `store/index.js` file:


### PR DESCRIPTION
Tried to keep the hint as short as possible let me know if you want me to remove a few lines! I placed is under Module Files sections as I felt it would be at this point that most people would run into issues with not having access to ```this``` because of using arrow functions.

Resolves #849 