### PR TITLE
Fix the API menu to match content (en, de, fr, id, ja, pt-BR langs)

### DIFF
--- a/de/api/menu.json
+++ b/de/api/menu.json
@@ -93,13 +93,14 @@
         "name": "render",
         "to": "/configuration-render",
         "contents": [
-          { "name": "bundleRenderer", "to": "#bundleRenderer" },
+          { "name": "bundleRenderer", "to": "#bundlerenderer" },
           { "name": "etag", "to": "#etag" },
           { "name": "gzip", "to": "#gzip" },
           { "name": "http2", "to": "#http2" },
-          { "name": "resourceHints", "to": "#resourceHints" },
+          { "name": "resourceHints", "to": "#resourcehints" },
           { "name": "ssr", "to": "#ssr" },
-          { "name": "static", "to": "#static" }
+          { "name": "static", "to": "#static" },
+          { "name": "csp", "to": "#csp" }
         ]
       },
       { "name": "rootDir", "to": "/configuration-rootdir" },

--- a/en/api/menu.json
+++ b/en/api/menu.json
@@ -105,13 +105,15 @@
         "name": "render",
         "to": "/configuration-render",
         "contents": [
-          { "name": "bundleRenderer", "to": "#bundleRenderer" },
+          { "name": "bundleRenderer", "to": "#bundlerenderer" },
           { "name": "etag", "to": "#etag" },
-          { "name": "gzip", "to": "#gzip" },
+          { "name": "compressor", "to": "#compressor" },
           { "name": "http2", "to": "#http2" },
-          { "name": "resourceHints", "to": "#resourceHints" },
+          { "name": "resourceHints", "to": "#resourcehints" },
           { "name": "ssr", "to": "#ssr" },
-          { "name": "static", "to": "#static" }
+          { "name": "static", "to": "#static" },
+          { "name": "dist", "to": "#dist" },
+          { "name": "csp", "to": "#csp" }
         ]
       },
       { "name": "rootDir", "to": "/configuration-rootdir" },

--- a/fr/api/menu.json
+++ b/fr/api/menu.json
@@ -89,13 +89,14 @@
       {
         "name": "render (En)", "to": "/configuration-render",
         "contents": [
-          { "name": "bundleRenderer (En)", "to": "#bundleRenderer" },
+          { "name": "bundleRenderer (En)", "to": "#bundlerenderer" },
           { "name": "etag (En)", "to": "#etag" },
           { "name": "gzip (En)", "to": "#gzip" },
           { "name": "http2 (En)", "to": "#http2" },
-          { "name": "resourceHints (En)", "to": "#resourceHints" },
+          { "name": "resourceHints (En)", "to": "#resourcehints" },
           { "name": "ssr (En)", "to": "#ssr" },
-          { "name": "static (En)", "to": "#static" }
+          { "name": "static (En)", "to": "#static" },
+          { "name": "csp (En)", "to": "#csp" }
         ]
       },
       { "name": "rootDir (En)", "to": "/configuration-rootdir" },

--- a/id/api/menu.json
+++ b/id/api/menu.json
@@ -89,11 +89,11 @@
         "name": "render",
         "to": "/configuration-render",
         "contents": [
-          { "name": "bundleRenderer", "to": "#bundleRenderer" },
+          { "name": "bundleRenderer", "to": "#bundlerenderer" },
           { "name": "etag", "to": "#etag" },
           { "name": "gzip", "to": "#gzip" },
           { "name": "http2", "to": "#http2" },
-          { "name": "resourceHints", "to": "#resourceHints" },
+          { "name": "resourceHints", "to": "#resourcehints" },
           { "name": "ssr", "to": "#ssr" },
           { "name": "static", "to": "#static" }
         ]

--- a/ja/api/menu.json
+++ b/ja/api/menu.json
@@ -93,11 +93,11 @@
         "name": "render",
         "to": "/configuration-render",
         "contents": [
-          { "name": "bundleRenderer", "to": "#bundleRenderer" },
+          { "name": "bundleRenderer", "to": "#bundlerenderer" },
           { "name": "etag", "to": "#etag" },
           { "name": "gzip", "to": "#gzip" },
           { "name": "http2", "to": "#http2" },
-          { "name": "resourceHints", "to": "#resourceHints" },
+          { "name": "resourceHints", "to": "#resourcehints" },
           { "name": "ssr", "to": "#ssr" },
           { "name": "static", "to": "#static" }
         ]

--- a/pt-BR/api/menu.json
+++ b/pt-BR/api/menu.json
@@ -88,11 +88,11 @@
         "name": "render",
         "to": "/configuration-render",
         "contents": [
-          { "name": "bundleRenderer", "to": "#bundleRenderer" },
+          { "name": "bundleRenderer", "to": "#bundlerenderer" },
           { "name": "etag", "to": "#etag" },
           { "name": "gzip", "to": "#gzip" },
           { "name": "http2", "to": "#http2" },
-          { "name": "resourceHints", "to": "#resourceHints" },
+          { "name": "resourceHints", "to": "#resourcehints" },
           { "name": "ssr", "to": "#ssr" },
           { "name": "static", "to": "#static" }
         ]


### PR DESCRIPTION
API menu update for the `en` lang:
- Add `dist` to `configuration-render`
- Swtich `gzip` for `compressor` in `configuration-render`

API menu update for the `en`, `de`, and `fr` langs:
- Add `static` and `csp` to `configuration-render`

API menu update for the `en`, `de`, `fr`, `id`, `ja`, and `pt-BR` langs:
- Match the page's generated anchor for `bundleRenderer` and `resourceHints`