### PR TITLE
feat: add advanced nginx example

### DIFF
--- a/en/faq/nginx-proxy.md
+++ b/en/faq/nginx-proxy.md
@@ -39,7 +39,7 @@ server {
 
 If you have a high volume website with regularly changing content, you might want to benefit from Nuxt generate capabilities and [nginx caching](https://www.nginx.com/blog/nginx-caching-guide).
 
-Below is an exampe configuration. Keep in mind that:
+Below is an example configuration. Keep in mind that:
 - root folder should be the same as set by [configuration generate.dir](/api/configuration-generate#dir)
 - expire headers set by Nuxt are stripped (due to the cache)
 - both Nuxt as nginx can set additional headers, it's advised to choose one (if in doubt, choose nginx)

--- a/en/faq/nginx-proxy.md
+++ b/en/faq/nginx-proxy.md
@@ -39,10 +39,20 @@ server {
 
 If you have a high volume website with regularly changing content, you might want to benefit from Nuxt generate capabilities and [nginx caching](https://www.nginx.com/blog/nginx-caching-guide).
 
-Below is an exampe configuration which you will most likely need to adapt to your needs.
+Below is an exampe configuration. Keep in mind that:
+- root folder should be the same as set by [configuration generate.dir](/api/configuration-generate#dir)
+- expire headers set by Nuxt are stripped (due to the cache)
+- both Nuxt as nginx can set additional headers, it's advised to choose one (if in doubt, choose nginx)
+- if your site is mostly static, increase the `proxy_cache_path inactive` and `proxy_cache_valid` numbers
+
+If you don't generate your routes but still wish to benefit from nginx cache:
+- remove the `root` entry
+- change `location @proxy {` to `location / {`
+- remove the other 2 `location` entries
+
 
 ```nginx
-proxy_cache_path  /PATH/TO/YOUR/CACHE levels=1:2 keys_zone=nuxt-cache:25m max_size=1g inactive=60m use_temp_path=off;
+proxy_cache_path  /data/nginx/cache levels=1:2 keys_zone=nuxt-cache:25m max_size=1g inactive=60m use_temp_path=off;
 
 map $sent_http_content_type $expires {
     "text/html"                 1h; # set this to your needs
@@ -60,7 +70,7 @@ server {
 
     charset utf-8;
 
-    root /var/www/YOUR_NUXT_DIST_FOLDER
+    root /var/www/NUXT_PROJECT_PATH/dist
 
     location ~* \.(?:ico|gif|jpe?g|png|woff2?|eot|otf|ttf|svg|js|css)$ {
         expires $expires;

--- a/en/faq/nginx-proxy.md
+++ b/en/faq/nginx-proxy.md
@@ -35,6 +35,80 @@ server {
 }
 ```
 
+# Using nginx with generated pages and a caching proxy as fallback
+
+If you have a high volume website with regularly changing content, you might want to benefit from Nuxt generate capabilities and [nginx caching](https://www.nginx.com/blog/nginx-caching-guide).
+
+Below is an exampe configuration which you will most likely need to adapt to your needs.
+
+```nginx
+proxy_cache_path  /PATH/TO/YOUR/CACHE levels=1:2 keys_zone=nuxt-cache:25m max_size=1g inactive=60m use_temp_path=off;
+
+map $sent_http_content_type $expires {
+    "text/html"                 1h; # set this to your needs
+    "text/html; charset=utf-8"  1h; # set this to your needs
+    default                     7d; # set this to your needs
+}
+
+server {
+    listen          80;             # the port nginx is listening on
+    server_name     your-domain;    # setup your domain here
+
+    gzip            on;
+    gzip_types      text/plain application/xml text/css application/javascript;
+    gzip_min_length 1000;
+
+    charset utf-8;
+
+    root /var/www/YOUR_NUXT_DIST_FOLDER
+
+    location ~* \.(?:ico|gif|jpe?g|png|woff2?|eot|otf|ttf|svg|js|css)$ {
+        expires $expires;
+        add_header Pragma public;
+        add_header Cache-Control "public";
+
+        try_files $uri $uri/ @proxy;
+    }
+
+    location / {
+        expires $expires;
+        add_header Content-Security-Policy "default-src 'self' 'unsafe-inline';";
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "SAMEORIGIN";
+
+        try_files $uri $uri/index.html @proxy; # for generate.subFolders: true
+        # try_files $uri $uri.html @proxy; # for generate.subFolders: false
+    }
+
+    location @proxy {
+        expires $expires;
+        add_header Content-Security-Policy "default-src 'self' 'unsafe-inline';";
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Cache-Status $upstream_cache_status;
+
+        proxy_redirect                      off;
+        proxy_set_header Host               $host;
+        proxy_set_header X-Real-IP          $remote_addr;
+        proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto  $scheme;
+        proxy_ignore_headers        Cache-Control;
+        proxy_http_version          1.1;
+        proxy_read_timeout          1m;
+        proxy_connect_timeout       1m;
+        proxy_pass                  http://127.0.0.1:3000; # set the adress of the Node.js instance here
+        proxy_cache                 nuxt-cache;
+        proxy_cache_bypass          $arg_nocache; # probably better to change this
+        proxy_cache_valid           200 302  60m; # set this to your needs
+        proxy_cache_valid           404      1m;  # set this to your needs
+        proxy_cache_lock            on;
+        proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+        proxy_cache_key             $uri$is_args$args;
+        proxy_cache_purge           PURGE from 127.0.0.1;
+    }
+}
+```
+
 # nginx configuration for Laravel Forge
 
 Change `YOUR_WEBSITE_FOLDER` to your web site folder and `YOUR_WEBSITE_DOMAIN` to your website URL. Laravel Forge will have filled out these values for you but be sure to double check.


### PR DESCRIPTION
Added an advanced nginx example for when you use Nuxt to generate all (dynamic) routes of your project so nginx can serve mostly static files. But I also added a caching proxy to a Nuxt server so if an url is not (yet) generated the Nuxt server will generate the page for that url and nginx will cache it until its invalidated or purged.

The example doesnt explain how everything works, its more to show what is possible and if you want to know exactly how and why then you should RTFM (of nginx mostly)