### PR TITLE
ja: Update ja/api/internal-builder.md

### DIFF
--- a/ja/api/internals-builder.md
+++ b/ja/api/internals-builder.md
@@ -1,31 +1,29 @@
 ---
-title: "API: The Builder Class"
-description: Nuxt `Builder` Class
+title: "API: The Builder クラス"
+description: Nuxt `Builder` クラス
 ---
 
-# Builder Class
+# Builder クラス
 
-- Source: **[builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/builder.js)**
+- ソース: **[builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/builder.js)**
 
 
-## Tapable plugins
+## フック
 
-We can register hooks on certain life cycle events.
+特定のライフサイクルイベントでのフックを登録できます。
 
 ```js
-nuxt.plugin('build', builder => {
-    builder.plugin('extendRoutes', async ({routes}) =>  {
-        // ...
-    })
+// ビルドのためのフックを追加
+this.nuxt.hook('build:done', (builder) => {
+  ...
 })
 ```
 
-Plugin         | Arguments                               | When
----------------|-----------------------------------------|--------------------------------------------------------------------------------
-`build`        | builder                                 | First build started
-`built`        | builder                                 | First build finished
-`extendRoutes` | {routes, templateVars, r}               | Generating routes
-`generate`     | {builder, templatesFiles, templateVars} | Generating `.nuxt` template files
-`done`         | {builder, stats}                        | webpack build was done
-`compile`      | {builder, compiler}                     | Before webpack compile (compiler is a `MultiCompiler` instance)
-`compiled`     | builder                                 | webpack build finished
+フック               | 引数                                       | タイミング
+---------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------
+`build:before`       | (nuxt, buildOptions)                       | Nuxtのビルドが始まる前
+`build:templates`    | ({ templateFiles, templateVars, resolve }) | `.nuxt` テンプレートファイルを生成する時
+`build:extendRoutes` | (routes, resolve)                          | ルーティングを生成する時
+`build:compile`      | ({ name, compiler })                       | webpackのコンパイルを実行する前 (compilerはwebpackの `Compiler` インスタンス) 。もしユニバーサルモードであれば、 `'client'` と `'server'` という名前で二回呼び出されます。
+`build:compiled`     | ({ name, compiler, stats })                | webpackのビルドが終了した時
+`build:done`         | (nuxt)                                     | Nuxtのビルドが終了した時

--- a/ja/api/internals-builder.md
+++ b/ja/api/internals-builder.md
@@ -21,9 +21,9 @@ this.nuxt.hook('build:done', (builder) => {
 
 フック               | 引数                                       | タイミング
 ---------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------
-`build:before`       | (nuxt, buildOptions)                       | Nuxtのビルドが始まる前
+`build:before`       | (nuxt, buildOptions)                       | Nuxt のビルドが始まる前
 `build:templates`    | ({ templateFiles, templateVars, resolve }) | `.nuxt` テンプレートファイルを生成する時
 `build:extendRoutes` | (routes, resolve)                          | ルーティングを生成する時
-`build:compile`      | ({ name, compiler })                       | webpackのコンパイルを実行する前 (compilerはwebpackの `Compiler` インスタンス) 。もしユニバーサルモードであれば、 `'client'` と `'server'` という名前で二回呼び出されます。
-`build:compiled`     | ({ name, compiler, stats })                | webpackのビルドが終了した時
-`build:done`         | (nuxt)                                     | Nuxtのビルドが終了した時
+`build:compile`      | ({ name, compiler })                       | webpack のコンパイルを実行する前 ( compiler は webpack の `Compiler` インスタンス) 。もしユニバーサルモードであれば、 `'client'` と `'server'` という名前で二回呼び出されます。
+`build:compiled`     | ({ name, compiler, stats })                | webpack のビルドが終了した時
+`build:done`         | (nuxt)                                     | Nuxt のビルドが終了した時


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm

遅くなってすみません。
ja/api/internals-builder.md を翻訳しました。
レビューよろしくお願いします！ 🙏

en: https://github.com/resessh/nuxt-docs/blob/master/en/api/internals-builder.md
master の更新分を取り込んでます。