### PR TITLE
feat: add github-like anchors to headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 
 # logs
 npm-debug.log
+yarn-error.log
 .DS_Store
 .vscode
 .idea

--- a/api.js
+++ b/api.js
@@ -7,6 +7,7 @@ const marked = require('marked')
 const highlightjs = require('highlight.js')
 const fm = require('front-matter')
 const { resolve } = require('path')
+const octicon = require('octicons')
 const githubHook = require('./gh-hook')
 const readFile = pify(fs.readFile)
 const send = micro.send
@@ -28,7 +29,10 @@ renderer.heading = (text, level) => {
   } else {
     link = text.toLowerCase().replace(/[^\wА-яіІїЇєЄ\u4e00-\u9eff一-龠ぁ-ゔァ-ヴー々〆〤\u3130-\u318F\uAC00-\uD7AF]+/gi, '-')
   }
-  return '<h' + level + ' id="' + link + '">' + text + '</h' + level + '>'
+  return '<h' + level + '>' +
+    '<a id="' + link + '" class="anchor" aria-hidden="true" href="#' + link + '">' +
+      octicon.link.toSVG() +
+    '</a>' + text + '</h' + level + '>'
 }
 marked.setOptions({ renderer })
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "highlight.js": "^9.12.0",
     "marked": "^0.3.6",
     "micro": "^8.0.2",
+    "octicons": "^8.1.0",
     "pify": "^3.0.0",
     "rimraf": "^2.6.1",
     "uuid": "^3.1.0"


### PR DESCRIPTION
fix: add yarn-error to gitignore

This will make it much easier to link to a certain section of the docs. See also https://github.com/nuxt/nuxtjs.org/pull/159 for the required styles.

--edit--
Forgot to say, the anchor links dont work on `h1` because they have an `overflow: hidden`.