### PR TITLE
Add warning note about isClient and isServer

### DIFF
--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -88,6 +88,8 @@ The extend is called twice, one time for the server bundle, and one time for the
 1. webpack config object,
 2. object with the following keys (all boolean): `isDev`, `isClient`, `isServer`, `loaders`.
 
+*note: The `isClient` and `isServer` keys in extend are separate from the keys available in context. `process.client` and `process.server` are undefined at this point and cannot be used.*
+
 Example (`nuxt.config.js`):
 
 ```js

--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -91,6 +91,7 @@ The extend is called twice, one time for the server bundle, and one time for the
 <p class="Alert Alert--orange">
   <b>Warning:</b>
   The `isClient` and `isServer` keys in extend are separate from the keys available in [`context`](/api/context).  
+
   They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.  
 </p>
 

--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -88,12 +88,13 @@ The extend is called twice, one time for the server bundle, and one time for the
 1. webpack config object,
 2. object with the following keys (all boolean): `isDev`, `isClient`, `isServer`, `loaders`.
 
+
 <p class="Alert Alert--orange">
   <b>Warning:</b>
   The `isClient` and `isServer` keys in extend are separate from the keys available in [`context`](/api/context).  
-
-  They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.  
+  They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.
 </p>
+
 
 Example (`nuxt.config.js`):
 

--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -88,7 +88,11 @@ The extend is called twice, one time for the server bundle, and one time for the
 1. webpack config object,
 2. object with the following keys (all boolean): `isDev`, `isClient`, `isServer`, `loaders`.
 
-*note: The `isClient` and `isServer` keys in extend are separate from the keys available in context. `process.client` and `process.server` are undefined at this point and cannot be used.*
+<p class="Alert Alert--danger">
+  <b>HEADS UP!</b>
+  The `isClient` and `isServer` keys in extend are separate from the keys available in [context](/api/context).  
+  They are <b>not</b> deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.  
+</p>
 
 Example (`nuxt.config.js`):
 

--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -89,11 +89,13 @@ The extend is called twice, one time for the server bundle, and one time for the
 2. object with the following keys (all boolean): `isDev`, `isClient`, `isServer`, `loaders`.
 
 
-<p class="Alert Alert--orange">
-  <b>Warning:</b>
-  The `isClient` and `isServer` keys in extend are separate from the keys available in [`context`](/api/context).  
+<div class="Alert Alert--orange">
+  
+  **Warning:**
+  The `isClient` and `isServer` keys provided in are separate from the keys available in [`context`](/api/context).  
   They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.
-</p>
+
+</div>
 
 
 Example (`nuxt.config.js`):

--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -88,10 +88,10 @@ The extend is called twice, one time for the server bundle, and one time for the
 1. webpack config object,
 2. object with the following keys (all boolean): `isDev`, `isClient`, `isServer`, `loaders`.
 
-<p class="Alert Alert--danger">
-  <b>HEADS UP!</b>
-  The `isClient` and `isServer` keys in extend are separate from the keys available in [context](/api/context).  
-  They are <b>not</b> deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.  
+<p class="Alert Alert--orange">
+  <b>Warning:</b>
+  The `isClient` and `isServer` keys in extend are separate from the keys available in [`context`](/api/context).  
+  They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.  
 </p>
 
 Example (`nuxt.config.js`):

--- a/en/api/context.md
+++ b/en/api/context.md
@@ -26,3 +26,10 @@ List of all the available keys in `context`:
 | `error`                | `Function`                                                                         | Client & Server | Use this method to show the error page: `error(params)`. The `params` should have the properties `statusCode` and `message`.                                                                                                                                                                |
 | `nuxtState`            | `Object`                                                                           | Client          | Nuxt state, useful for plugins which uses `beforeNuxtRender` to get the nuxt state on client-side before hydration. **Available only in `universal` mode**.                                                                                                                                 |
 | `beforeNuxtRender(fn)` | `Function`                                                                         | Server          | Use this method to update `__NUXT__` variable rendered on client-side, the `fn` (can be asynchronous) is called with `{ Components, nuxtState }`, see [example](https://github.com/nuxt/nuxt.js/blob/cf6b0df45f678c5ac35535d49710c606ab34787d/test/fixtures/basic/pages/special-state.vue). |
+
+
+<div class="Alert Alert--teal">
+  
+  **Note:** This is **not** the context passed into the `build.extend` function.
+
+</div>


### PR DESCRIPTION
Add short warning note about `isClient`/`isServer` in build extend to deter developers from thinking it is deprecated and should be replaced with `process.client`/`process.server`, which would return undefined and therefore cannot be used.

There appearrs to be a large amount of misinformation about this property, leading to a lot of incorrect configurations that *appear* to be correct because replacing `isClient` with `process.client` will disable linting, making it appear as if there are no errors, when the reality is they have just disabled linting.