### PR TITLE
In the Japanese document, There is a misprint on the page of "LoadingIndicator property".

### DIFF
--- a/ja/api/configuration-loading-indicator.md
+++ b/ja/api/configuration-loading-indicator.md
@@ -45,4 +45,4 @@ Spinkit のデモページを見ることで、スピナーを試してみるこ
 もし独自の特別なインジケータを必要とする場合は、 String 値もしくは Name キーにインジケータのソースコードを HTML テンプレートへのパスとして設定することができます！
 その際、全てのオプションもテンプレートへと渡されます。
 
-ベースが必要な場合は、 Nuxt の組み込み[ソースコード](https://github.com/nuxt/nuxt.js/tree/dev/lib/app/views/loading)をベースとして使用できます。
+ベースが必要な場合は、 Nuxt の組み込み[ソースコード](https://github.com/nuxt/nuxt.js/tree/dev/packages/app/template/views/loading)をベースとして使用できます。

--- a/ja/api/configuration-loading-indicator.md
+++ b/ja/api/configuration-loading-indicator.md
@@ -45,4 +45,4 @@ Spinkit のデモページを見ることで、スピナーを試してみるこ
 もし独自の特別なインジケータを必要とする場合は、 String 値もしくは Name キーにインジケータのソースコードを HTML テンプレートへのパスとして設定することができます！
 その際、全てのオプションもテンプレートへと渡されます。
 
-ベースが必要な場合は、 Nuxt の組み込み[ソースコード]((https://github.com/nuxt/nuxt.js/tree/dev/lib/app/views/loading)をベースとして使用できます。
+ベースが必要な場合は、 Nuxt の組み込み[ソースコード](https://github.com/nuxt/nuxt.js/tree/dev/lib/app/views/loading)をベースとして使用できます。


### PR DESCRIPTION
Resolves #912 

> ### What problem does this feature solve?
> 
> The problem is on the following page!
> 
> https://ja.nuxtjs.org/api/configuration-loading-indicator/
> 
> #### 1. Currently, there is a typographical error in markdown notation, and the appropriate text is not linked.
> 
> If this problem is solved, the user can access the appropriate link.
> 
> #### 2. Currently, accessing the set link will return 404 error.
> 
> If this problem is solved, the user can access the appropriate link.
> 
> 
> ### What does the proposed changes look like?
> 
> Line 48, `/docs/ja/api/configuration-loading-indicator.md `
> 
> #### before
> 
> ```markdown
> 
> ベースが必要な場合は、 Nuxt の組み込み[ソースコード]((https://github.com/nuxt/nuxt.js/tree/dev/lib/app/views/loading)をベースとして使用できます。
> ```
> 
> #### after
> 
> ```markdown
> ベースが必要な場合は、 Nuxt の組み込み[ソースコード](https://github.com/nuxt/nuxt.js/tree/dev/packages/app/template/views/loading)をベースとして使用できます。
> ```
> 
> <!--cmty--><!--cmty_prevent_hook-->
> <div align="right"><sub><em>This feature request is available on <a href="https://cmty.app/nuxt">Nuxt</a> community (<a href="https://cmty.app/nuxt/docs/issues/c138">#c138</a>)</em></sub></div>