### PR TITLE
Add comma at the end of element in postcss array

### DIFF
--- a/en/faq/postcss-plugins.md
+++ b/en/faq/postcss-plugins.md
@@ -16,8 +16,8 @@ import postcssHexrgba from 'postcss-hexrgba',
 export default {
   build: {
     postcss: [
-      postcssNested()
-      postcssResponsiveType()
+      postcssNested(),
+      postcssResponsiveType(),
       postcssHexrgba()
     ]
   }


### PR DESCRIPTION
I've seen that there have no comma at the end of elements in postcss array.
So, I add in docs on Faq page.