### PR TITLE
Fix plugins/i18n.js section

### DIFF
--- a/fr/guide/plugins.md
+++ b/fr/guide/plugins.md
@@ -100,7 +100,7 @@ import VueI18n from 'vue-i18n'
 
 Vue.use(VueI18n)
 
-export default ({ store }, inject) => {
+export default ({ app }) => {
   // Mettre l'instance `i18n` dans `app`
   // De cette manière nous pouvons l'utiliser comme middleware et `asyncData` / `fetch` pour les pages
   app.i18n = new VueI18n({


### PR DESCRIPTION
Replaces `store` by `app` in context params and removes useless `inject` argument