### PR TITLE
Chinese Doc has a character mistake

### DIFF
--- a/zh/guide/modules.md
+++ b/zh/guide/modules.md
@@ -71,7 +71,7 @@ export default {
 }
 ```
 
-然后，我们告诉Nuxt为项目加载一些特定模块，并将可选参数作为选项。 请参考 [莫模块配置](/api/configuration-modules) 文档来查看更多!
+然后，我们告诉Nuxt为项目加载一些特定模块，并将可选参数作为选项。 请参考 [模块配置](/api/configuration-modules) 文档来查看更多!
 
 ## 异步模块
 


### PR DESCRIPTION
[mistake page](https://zh.nuxtjs.org/guide/modules)
参考 莫模块配置 文档来查看更多”  这里有个错别字

莫模块配置 错别字