### PR TITLE
ja: fix guide/modules.md

### DIFF
--- a/ja/guide/modules.md
+++ b/ja/guide/modules.md
@@ -308,5 +308,8 @@ module.exports = function () {
 }
 ```
 
-<p class="Alert">モジュールには他にも多くのフックがあり、また他にももっとできることがあります。Nuxt の内部 API については [Nuxt Internals](/api/internals) を参照してください。
-</p>
+<div class="Alert">
+
+モジュールには他にも多くのフックがあり、また他にももっとできることがあります。Nuxt の内部 API については [Nuxt Internals](/api/internals) を参照してください。
+
+</div>


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm

guide/modules.md の Alert 内の `[Nuxt Internals]` リンクが外れていたので Alertクラスのタグと改行を修正し正しくリンクされるようにしました。

