### PR TITLE
Warn usage of transpile scoped package on Windows

### DIFF
--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -542,6 +542,9 @@ See [webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/t
 
 If you want to transpile specific dependencies with Babel, you can add them in `build.transpile`. Item in transpile can be string or regex object for matching dependencies file name.
 
+### Note:  
+For Windows user, the filepath will be `\\` instead of `/`. Thus, for scoped package, please use `/@scoped[/\\]package/` instead of `"@scoped/package"`.
+
 ## vueLoader
 
 > Note: This config has been removed since Nuxt 2.0, please use [`build.loaders.vue`](#loaders)instead.


### PR DESCRIPTION
On Windows, the filepath that received by JavaScript uses backslash `\`.

At first it might be tempting to use
```js
build: {
  transpile: [
    '@scoped/packageA',
    '@scoped/packageB',
  ],
},
```

However, this will fail on Windows.

Related code:
```js
!modulesToTranspile.some(module => module.test(file))
```
https://github.com/nuxt/nuxt.js/blob/3702dfe5dcb5c4fdeb03fcd3025f5a5ae39232be/packages/webpack/src/config/base.js#L176

Which translate to:
```js
/@scoped\/packageA/.test('C:\\projects\\node_modules\\@scoped\\packageA\\src\\index.js')
```

and evaluated to: `false`

## Workaround:

### Option 1 (this PR)
Ask user to to use regex which cater for Windows filepath, i.e.
```js
build: {
  transpile: [
    /@scoped[\\/]packageA/,
    /@scoped[\\/]packageB/,
  ],
},
```

### Option 2
Convert filepath for user before testing, so that user can continue using one forward slash for scoped package.

```
const normalizePathForRegex = module => path.join(module).replace(/\\/, '\\\\')
```
```
  options.build.transpile = [].concat(options.build.transpile || [])
    .map(module => module instanceof RegExp ? module : new RegExp(normalizePathForRegex(module)));
)
```