### PR TITLE
ja: Fix some broken md formt on JP guide.

### DIFF
--- a/ja/guide/commands.md
+++ b/ja/guide/commands.md
@@ -65,9 +65,9 @@ nuxt build
 nuxt start
 ```
 
-Nuxt.js を HTTPS モードで提供することを選択した場合、 [`https.createServer`]（https://nodejs.org/api/https.html）に渡されるオプションと同じオプションを使って` nuxt.config.js`に `server.https`を設定することもできます。 
-`nuxt.config.js`に `server.socket` オプションを設定（または [CLI](https://ja.nuxtjs.org/guide/commands/#%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E4%B8%80%E8%A6%A7 の `-n` 引数を使用）すると、 Unix ソケットも利用できます。
-[Unix ソケット]（https://en.wikipedia.org/wiki/Berkeley_sockets）を利用する場合は、 `host` パラメータと ` port` パラメータを設定しないでください。設定した場合、 `socket` パラメータは無視されます。
+Nuxt.js を HTTPS モードで提供することを選択した場合、 [`https.createServer`](https://nodejs.org/api/https.html) に渡されるオプションと同じオプションを使って`nuxt.config.js`に `server.https`を設定することもできます。 
+`nuxt.config.js`に `server.socket` オプションを設定（または [CLI](https://ja.nuxtjs.org/guide/commands/#%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E4%B8%80%E8%A6%A7) の `-n` 引数を使用すると、 Unix ソケットも利用できます。
+[Unix ソケット](https://en.wikipedia.org/wiki/Berkeley_sockets)を利用する場合は、 `host` パラメータと ` port` パラメータを設定しないでください。設定した場合、 `socket` パラメータは無視されます。
 
 `package.json` では下記のように記述することが推奨されています:
 


### PR DESCRIPTION
Hi!

I found some broken markdown layout on `ja/guide/commands.md` file, so I fixed it correctly.
