### PR TITLE
ja: Fix broken link

### DIFF
--- a/ja/guide/menu.json
+++ b/ja/guide/menu.json
@@ -111,7 +111,7 @@
         "to": "/development-tools", "name": "開発ツール",
         "contents": [
           { "to": "#エンドツーエンドテスト", "name": "エンドツーエンドテスト" },
-          { "to": "#eslint", "name": "ESLint" }
+          { "to": "#eslint-と-prettier", "name": "ESLint と Prettier" }
         ]
       }
     ]


### PR DESCRIPTION
https://github.com/nuxt/docs/commit/549a7c296eae7db14b4db59b8b28a1f8d95a5e9a
でリンク先が変わっているので、リンク切れになっていました。

nuxt/docsのPRの作法として間違ってたら申し訳ないです 🙇 