### PR TITLE
ZEIT Now deployment configuration update

### DIFF
--- a/en/faq/now-deployment.md
+++ b/en/faq/now-deployment.md
@@ -5,22 +5,32 @@ description: How to deploy Nuxt.js app with Now?
 
 # How to deploy with Now?
 
-To deploy with [now.sh](https://zeit.co/now) a `package.json` like follows is recommended:
+To deploy with [ZEIT Now](https://zeit.co/now) you need to customize `package.json` add create a `now.json` config.
 
-```json
-{
-  "name": "my-app",
-  "dependencies": {
-    "nuxt": "latest"
-  },
-  "scripts": {
-    "dev": "nuxt",
-    "build": "nuxt build",
-    "start": "nuxt start"
+* Add `now-build` script command to `package.json`:
+  * For SPA (without SSR):
+    ```js
+    "scripts": {
+       ...
+       "now-build": "nuxt build --spa"
+    }
+    ```
+  * For Static Generated (Pre Rendering):
+    ```js
+    "scripts": {
+       ...
+       "now-build": "nuxt generate"
+    }
+    ```
+* Create `now.json` and define `builds`
+  ```json
+  {
+    "version": 2,
+    "builds": [
+      { "src": "package.json", "use": "@now/static-build" }
+    ]
   }
-}
-```
-
-Then run `now` and enjoy!
+  ```
+* Run `now` and enjoy!
 
 Note: we recommend putting `.nuxt` in `.npmignore` or `.gitignore`.

--- a/en/faq/now-deployment.md
+++ b/en/faq/now-deployment.md
@@ -5,6 +5,8 @@ description: How to deploy Nuxt.js app with Now?
 
 # How to deploy with Now?
 
+## Now V2
+
 To deploy with [ZEIT Now](https://zeit.co/now) you need to customize `package.json` add create a `now.json` config.
 
 * Add `now-build` script command to `package.json`:
@@ -32,5 +34,25 @@ To deploy with [ZEIT Now](https://zeit.co/now) you need to customize `package.js
   }
   ```
 * Run `now` and enjoy!
+
+## Now V1 (legacy)
+
+To deploy with [now.sh](https://zeit.co/now) a `package.json` like follows is recommended:
+
+```json
+{
+  "name": "my-app",
+  "dependencies": {
+    "nuxt": "latest"
+  },
+  "scripts": {
+    "dev": "nuxt",
+    "build": "nuxt build",
+    "start": "nuxt start"
+  }
+}
+```
+
+Then run `now` and enjoy!
 
 Note: we recommend putting `.nuxt` in `.npmignore` or `.gitignore`.


### PR DESCRIPTION
Current docs are describing how to setup deployment for Now V1, while it's already a legacy version and it doesn't work anymore on Now V2.

For now, I omitted the part of setting up the deployment of a universal app with SSR, because still need to figure out how to do it.