### PR TITLE
Fix typo in directory-structure.md (supplement missing slash in path)

### DIFF
--- a/ja/guide/directory-structure.md
+++ b/ja/guide/directory-structure.md
@@ -88,6 +88,6 @@ _このファイル名は変更できません。_
 
 <div class="Alert Alert--nuxt-green">
 
-<b>情報:</b> `vue` テンプレート内で `assets` または `static` ディレクトリへのリンクが必要なときは `~assets/your_image.png` や `~static/your_image.png` などを使ってください。
+<b>情報:</b> `vue` テンプレート内で `assets` または `static` ディレクトリへのリンクが必要なときは `~/assets/your_image.png` や `~/static/your_image.png` などを使ってください。
 
 </div>


### PR DESCRIPTION
Supplement missing slash in path.