### PR TITLE
Update build.babel block

### DIFF
--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -38,18 +38,18 @@ export default {
 
 ## babel
 
-> Customize Babel configuration for JavaScript and Vue files.
+> Customize Babel configuration for JavaScript and Vue files. `.babelrc` is ignored by default.
 
 - Type: `Object`
 - Default:
 
   ```js
   {
+    babelrc: false,
+    cacheDirectory: undefined,
     presets: ['@nuxt/babel-preset-app']
   }
   ```
-
-Example (`nuxt.config.js`):
 
 ```js
 export default {


### PR DESCRIPTION
Babelrc usage is turned off by default. No info about it in documentations and that is very confusing.
Update docs according to code here: https://github.com/nuxt/nuxt.js/blob/2.x/packages/config/src/config/build.js#L68