### PR TITLE
Translate config build

### DIFF
--- a/ja/api/configuration-build.md
+++ b/ja/api/configuration-build.md
@@ -415,11 +415,11 @@ postcss の設定が `Object` 型の場合、プラグインの順番の定義�
 export default {
   build: {
     postcss: {
-      // preset name
+      // プリセット名
       order: 'cssnanoLast',
-      // ordered plugin names
+      // 順序付けされたプラグイン名の配列
       order: ['postcss-import', 'postcss-preset-env', 'cssnano']
-      // Function to calculate plugin order
+      // プラグインの順番を算出するための関数
       order: (names, presets) => presets.cssnanoLast(names)
     }
   }

--- a/ja/api/configuration-build.md
+++ b/ja/api/configuration-build.md
@@ -404,12 +404,12 @@ export default {
 ```
 
 
-If the postcss configuration is an `Object`, `order` can be used for defining the plugin order:
+postcss の設定が `Object` 型の場合、プラグインの順番の定義に `order`を利用できます:
 
-- Type: `Array` (ordered plugin names), `String` (order preset name), `Function`
-- Default: `cssnanoLast` (put `cssnano` in last)
+- Type: `Array` (順序付けされたプラグイン名), `String` (順序付けされたプリセット名), `Function`
+- Default: `cssnanoLast` (最後に `cssnano` を配置する)
 
-Example (`nuxt.config.js`):
+例 (`nuxt.config.js`):
 
 ```js
 export default {

--- a/ja/api/configuration-build.md
+++ b/ja/api/configuration-build.md
@@ -95,7 +95,7 @@ extend メソッドは一度はサーバーのバンドルのため、一度は�
 
 <div class="Alert Alert--orange">
 
-  **Warning:**
+  **警告:**
   The `isClient` and `isServer` keys provided in are separate from the keys available in [`context`](/api/context).
   They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.
 
@@ -150,7 +150,7 @@ Using [`mini-extract-css-plugin`](https://github.com/webpack-contrib/mini-css-ex
 
 <div class="Alert Alert--teal">
 
-**Note:** There was a bug prior to Vue 2.5.18 that removed critical CSS imports when using this options.
+**注記:** Vue 2.5.18 以前では、このオプションを使用したときにクリティカルな CSS のインポートを削除するバグがありました。
 
 </div>
 
@@ -212,7 +212,7 @@ manifest の使い方をより理解するためには [webpack documentation](h
 }
 ```
 
-**Attention:** If you make changes to `html.minify`, they won't be merged with the defaults!
+**情報:** `html.minify`に変更を加えても、それらはデフォルトとマージされません！
 
 ビルドプロセス中に作成された HTML ファイルのミニファイに使われる [html-minifier](https://github.com/kangax/html-minifier) プラグインの設定（*全てのモード*に適用される）。
 
@@ -377,7 +377,7 @@ export default {
   }
   ```
 
-Your custom plugin settings will be merged with the default plugins (unless you are using an `Array` instead of an `Object`).
+カスタムプラグイン設定は、デフォルトのプラグイン設定とマージされます (`Object` のかわりに `Array` を使っている場合を除く).
 
 例（`nuxt.config.js`）:
 
@@ -490,7 +490,7 @@ export default {
 
 <div class="Alert Alert--orange">
 
-**Warning:** This property is deprecated. Please use the [style-resources-modules](https://github.com/nuxt-community/style-resources-module/) instead for improved performance and better DX!
+**警告** このプロパティは非推奨です。 パフォーマンスおよび開発体験の向上のために、代わりに [style-resources-modules](https://github.com/nuxt-community/style-resources-module/) を使用してください。
 
 </div>
 

--- a/ja/api/configuration-build.md
+++ b/ja/api/configuration-build.md
@@ -92,6 +92,16 @@ extend メソッドは一度はサーバーのバンドルのため、一度は�
 1. Webpack 設定オブジェクト
 2. 次のキーを持つオブジェクト（すべてブーリアン）: `isDev`, `isClient`, `isServer`, `loaders`
 
+
+<div class="Alert Alert--orange">
+
+  **Warning:**
+  The `isClient` and `isServer` keys provided in are separate from the keys available in [`context`](/api/context).
+  They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.
+
+</div>
+
+
 例（`nuxt.config.js`）:
 
 ```js
@@ -135,7 +145,15 @@ export default {
 - 型: `ブーリアン`
 - デフォルト: `false`
 
-`extract-text-webpack-plugin` を使ってメインチャンク内の CSS を個別の CSS ファイル（テンプレートに自動的に注入される）形式で抽出します。これにより、ファイルを個別にキャッシュさせることができます。これは共通して利用される CSS が多く存在するときに推奨されます。非同期コンポーネント内部の CSS は JavaScript の文字列としてインラインで保持され、vue-style-loader で取り扱われます。
+
+Using [`mini-extract-css-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) under the hood, all your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and Javascript separately and is worth a try in case you have a lot of global or shared CSS.
+
+<div class="Alert Alert--teal">
+
+**Note:** There was a bug prior to Vue 2.5.18 that removed critical CSS imports when using this options.
+
+</div>
+
 
 ## filenames
 
@@ -183,24 +201,18 @@ manifest の使い方をより理解するためには [webpack documentation](h
 ```js
 {
   collapseBooleanAttributes: true,
-  collapseWhitespace: false,
   decodeEntities: true,
   minifyCSS: true,
   minifyJS: true,
   processConditionalComments: true,
-  removeAttributeQuotes: false,
-  removeComments: false,
   removeEmptyAttributes: true,
-  removeOptionalTags: false,
   removeRedundantAttributes: true,
-  removeScriptTypeAttributes: false,
-  removeStyleLinkTypeAttributes: false,
-  removeTagWhitespace: false,
-  sortClassName: false,
   trimCustomFragments: true,
   useShortDoctype: true
 }
 ```
+
+**Attention:** If you make changes to `html.minify`, they won't be merged with the defaults!
 
 ビルドプロセス中に作成された HTML ファイルのミニファイに使われる [html-minifier](https://github.com/kangax/html-minifier) プラグインの設定（*全てのモード*に適用される）。
 
@@ -303,33 +315,6 @@ manifest の使い方をより理解するためには [webpack documentation](h
 
 [Webpack の最適化](https://webpack.js.org/configuration/optimization/)を参照してください。
 
-## terser
-
-- 型: `オブジェクト` または `ブーリアン`
-- デフォルト:
-
-```js
-{
-  parallel: true,
-  cache: false,
-  sourceMap: false,
-  extractComments: {
-    filename: 'LICENSES'
-  },
-  terserOptions: {
-    output: {
-      comments: /^\**!|@preserve|@license|@cc_on/
-    }
-  }
-}
-```
-
-Terser プラグインのオプションです。 `false` を設定するとこのプラグインは無効になります。
-
-`soruceMap` は webpack の `confing.devtool` が `source-?map` と一致した際に有効になります。
-
-[webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) を参照してください。
-
 ## optimizeCSS
 
 - 型: `オブジェクト` または `ブーリアン`
@@ -378,6 +363,7 @@ export default {
 - 型: `配列`、`オブジェクト`（推奨）、`関数` または `ブーリアン`
 
   **注意：**  Nuxt.js は [PostCSS Preset Env](https://github.com/csstools/postcss-preset-env) を適用しました。デフォルトでは、[Stage 2 features](https://cssdb.org/) と [Autoprefixer](https://github.com/postcss/autoprefixer) が有効になっています。`build.postcss.preset` を使うことで設定が出来ます。
+
 - デフォルト:
 
   ```js
@@ -390,6 +376,8 @@ export default {
     }
   }
   ```
+
+Your custom plugin settings will be merged with the default plugins (unless you are using an `Array` instead of an `Object`).
 
 例（`nuxt.config.js`）:
 
@@ -410,6 +398,29 @@ export default {
           grid: true
         }
       }
+    }
+  }
+}
+```
+
+
+If the postcss configuration is an `Object`, `order` can be used for defining the plugin order:
+
+- Type: `Array` (ordered plugin names), `String` (order preset name), `Function`
+- Default: `cssnanoLast` (put `cssnano` in last)
+
+Example (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    postcss: {
+      // preset name
+      order: 'cssnanoLast',
+      // ordered plugin names
+      order: ['postcss-import', 'postcss-preset-env', 'cssnano']
+      // Function to calculate plugin order
+      order: (names, presets) => presets.cssnanoLast(names)
     }
   }
 }
@@ -477,6 +488,12 @@ export default {
 - 型: `オブジェクト`
 - デフォルト: `{}`
 
+<div class="Alert Alert--orange">
+
+**Warning:** This property is deprecated. Please use the [style-resources-modules](https://github.com/nuxt-community/style-resources-module/) instead for improved performance and better DX!
+
+</div>
+
 毎回インポートせずに変数やミックスインをページに挿入する必要がある場合に便利です。
 
 Nuxt.js はこの動作を実現するために https://github.com/yenshih/style-resources-loader を使用します。
@@ -529,6 +546,34 @@ export default {
 ```
 
 テンプレートは [`lodash.template`](https://lodash.com/docs/#template) を使ってレンダリングされます。[こちら](https://github.com/learn-co-students/javascript-lodash-templates-v-000)でより詳細な使い方を知ることができます。
+
+## terser
+
+- 型: `オブジェクト` または `ブーリアン`
+- デフォルト:
+
+```js
+{
+  parallel: true,
+  cache: false,
+  sourceMap: false,
+  extractComments: {
+    filename: 'LICENSES'
+  },
+  terserOptions: {
+    output: {
+      comments: /^\**!|@preserve|@license|@cc_on/
+    }
+  }
+}
+```
+
+Terser プラグインのオプションです。 `false` を設定するとこのプラグインは無効になります。
+
+`soruceMap` は webpack の `confing.devtool` が `source-?map` と一致した際に有効になります。
+
+[webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) を参照してください。
+
 
 ## transpile
 

--- a/ja/api/configuration-build.md
+++ b/ja/api/configuration-build.md
@@ -96,8 +96,8 @@ extend メソッドは一度はサーバーのバンドルのため、一度は�
 <div class="Alert Alert--orange">
 
   **警告:**
-  The `isClient` and `isServer` keys provided in are separate from the keys available in [`context`](/api/context).
-  They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.
+  提供される `isClient` および `isServer` は [`context`](/api/context) で利用可能なキーとは別物です。
+  これらは非推奨 **ではありません**。ここでは `process.client` および `process.server` は undefined となるため使用しないでください。
 
 </div>
 

--- a/ja/api/configuration-build.md
+++ b/ja/api/configuration-build.md
@@ -146,7 +146,7 @@ export default {
 - デフォルト: `false`
 
 
-Using [`mini-extract-css-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) under the hood, all your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and Javascript separately and is worth a try in case you have a lot of global or shared CSS.
+hood の中で [`mini-extract-css-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) を使うと、, 全ての CSS は別々のファイルに、通常はコンポーネントごとに一つ抽出されます。これは CSS と JavaScript を別々にキャッシュすることを可能にし、多くのグローバルまたは共通 CSS が存在する場合には試してみる価値があります。
 
 <div class="Alert Alert--teal">
 


### PR DESCRIPTION
@inouetakuya @aytdm 
遅くなりましたが、引き継いだ https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/11 の翻訳が完了しました。
差分がある程度出ていたため、現時点の master 最終変更相当まで追従して翻訳しています。

original: https://github.com/nuxt/docs/blob/c34025c18f686d5bb1daede1aa0db7bf0c50721b/en/api/configuration-build.md

なお、今回の翻訳範囲の英語の原文はこちらで確認できます。

https://github.com/nuxt/docs/commit/28e91fa75f070e99343a9b7ff795a81dde8c5d1d