### PR TITLE
Update directory-structure.md

### DIFF
--- a/en/guide/directory-structure.md
+++ b/en/guide/directory-structure.md
@@ -15,7 +15,7 @@ The `assets` directory contains your un-compiled assets such as Stylus or Sass f
 
 ### The Components Directory
 
-The `components` directory contains your Vue.js Components. You can't use neither `asyncData` nor `fetch` in these components.
+The `components` directory contains your Vue.js Components. You can't use either `asyncData` or `fetch` in these components.
 
 ### The Layouts Directory
 


### PR DESCRIPTION
"can't use neither .. nor" is both a double-negative and, _likely_, doesn't mean what is intended. "can't use either ... or" or, slightly awkwardly, "can use neither ... nor" should be used. If the double-negative is intended, then "must use either ... or" would be a better substitute.