### PR TITLE
Fix globalName property type error

### DIFF
--- a/en/api/configuration-global-name.md
+++ b/en/api/configuration-global-name.md
@@ -7,7 +7,7 @@ description: Nuxt.js lets you customize the global ID used in the main HTML temp
 
 > Nuxt.js lets you customize the global ID used in the main HTML template as well as the main Vue instance name and other options.
 
-- Type: `Object`
+- Type: `String`
 - Default: `nuxt`
 
 Example:

--- a/ja/api/configuration-global-name.md
+++ b/ja/api/configuration-global-name.md
@@ -7,7 +7,7 @@ description: Nuxt.js lets you customize the global ID used in the main HTML temp
 
 > Nuxt.js lets you customize the global ID used in the main HTML template as well as the main Vue instance name and other options.
 
-- Type: `Object`
+- Type: `String`
 - Default: `nuxt`
 
 Example:

--- a/zh/api/configuration-global-name.md
+++ b/zh/api/configuration-global-name.md
@@ -7,7 +7,7 @@ description: Nuxt.js允许您自定义主HTML模板中使用的全局ID以及主
 
 > Nuxt.js允许您自定义主HTML模板中使用的全局ID以及主Vue实例名称和其他选项。
 
-- 类型: `Object`
+- 类型: `String`
 - 默认: `nuxt`
 
 例子:


### PR DESCRIPTION
Modify property `globalName`'s type from `Object` to `String`