### PR TITLE
Include information for context

### DIFF
--- a/en/api/context.md
+++ b/en/api/context.md
@@ -2,11 +2,12 @@
 title: "API: The Context"
 description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`.
 ---
+
 # The Context
 
-> The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`.
+> The `context` provides additional objects/params from Nuxt to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `fetch`, `plugins`, 'middleware', 'modules', and 'nuxtServerInit`.
 
-## Context
+## Available keys
 
 <div class="Alert Alert--teal">
   

--- a/en/api/context.md
+++ b/en/api/context.md
@@ -2,6 +2,9 @@
 title: "API: The Context"
 description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`.
 ---
+# The Context
+
+> The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`.
 
 ## Context
 


### PR DESCRIPTION
Copied hidden information in the same file to be presented on the site docs.
Following the same style as https://github.com/nuxt/docs/blob/master/en/api/index.md

Looks to partially fix https://github.com/nuxt/docs/issues/932

---
I was trying to find where `this.$route` for example is defined in the documentation. I couldn't find it, and I know this doesn't fix that issue, hence suggesting this is a partial fix. I don't feel I'd know how to best explain this.