### PR TITLE
en: link to dir configuration in Configuration page and API menu 

### DIFF
--- a/en/api/menu.json
+++ b/en/api/menu.json
@@ -138,6 +138,7 @@
       { "name": "server", "to": "/configuration-server" },
       { "name": "serverMiddleware", "to": "/configuration-servermiddleware" },
       { "name": "srcDir", "to": "/configuration-srcdir" },
+      { "name": "dir", "to": "/configuration-dir" },
       { "name": "transition", "to": "/configuration-transition" },
       { "name": "vue.config", "to": "/configuration-vue-config" },
       { "name": "watch", "to": "/configuration-watch" },

--- a/en/guide/configuration.md
+++ b/en/guide/configuration.md
@@ -90,6 +90,12 @@ This option lets you define the source directory of your Nuxt.js Application.
 
 [Documentation about `srcDir` integration](/api/configuration-srcdir)
 
+### dir
+
+This option lets you define the custom directories for your Nuxt.js application
+
+[Documentation about `dir` integration](/api/configuration-dir)
+
 ### transition
 
 This option lets you define the default properties of the page transitions.


### PR DESCRIPTION
The documentation for the dir configuration (https://github.com/nuxt/nuxt.js/pull/2748) existed but nothing linked to it. The modifications here include a link in the sidebar and a link and description in the Configuration page of the Guide.

Resolves #870 