### PR TITLE
Add 0.0.0.0 usage clarification

### DIFF
--- a/en/faq/host-port.md
+++ b/en/faq/host-port.md
@@ -5,6 +5,10 @@ description: How to edit host and port with Nuxt.js?
 
 # How to edit host and port?
 
+By default, Nuxt development server host is `localhost` (only accessible from within the host machine).
+
+Host `0.0.0.0` is designated to tell Nuxt to resolve a host address, which is accessible to connections _outside_ of the host machine (e.g. LAN).
+
 You can configure the connection variables in different ways.  They are listed **from highest to lowest priority**.
 
 > **Note:** If `port` is assigned the string value of `'0'` (not `0`, which is falsy), a random port will be assigned to your Nuxt application.


### PR DESCRIPTION
Host `0.0.0.0` have different meanings between different contexts.

I added a clarification to what host `0.0.0.0` is designated to in this specific context.