### PR TITLE
Update loader configuration reference in assets.md

### DIFF
--- a/en/guide/assets.md
+++ b/en/guide/assets.md
@@ -53,7 +53,7 @@ The benefits of these loaders are:
 For those two loaders, the default configuration is:
 
 ```js
-// https://github.com/nuxt/nuxt.js/blob/dev/packages/builder/src/webpack/base.js#L204-L229
+// https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/base.js#L297-L316
 [
   {
     test: /\.(png|jpe?g|gif|svg|webp)$/,


### PR DESCRIPTION
The original reference URL is not accessible, look like https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/base.js#L297-L316 is the right place.