### PR TITLE
fix japanese modules markdown

### DIFF
--- a/ja/guide/modules.md
+++ b/ja/guide/modules.md
@@ -277,7 +277,7 @@ module.exports = function (moduleOptions) {
 
 ## 特定のフックでタスクを実行する
 
-単に Nuxt の初期化処理時だけではなく、特定の条件下でのみ、モジュールにある処理を実行させたいこともあるでしょう。強力な[Hookable]（https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/hookable.js）Nuxt.jsシステムを使用して特定のイベントでタスクを実行できます。フックが Promise を返すか `async` として定義されている場合は Nuxt は待機します。
+単に Nuxt の初期化処理時だけではなく、特定の条件下でのみ、モジュールにある処理を実行させたいこともあるでしょう。強力な[Hookable](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/hookable.js)Nuxt.jsシステムを使用して特定のイベントでタスクを実行できます。フックが Promise を返すか `async` として定義されている場合は Nuxt は待機します。
 
 ```js
 module.exports = function () {


### PR DESCRIPTION
## Summary
Fix Markdown.
https://ja.nuxtjs.org/guide/modules#%E7%89%B9%E5%AE%9A%E3%81%AE%E3%83%95%E3%83%83%E3%82%AF%E3%81%A7%E3%82%BF%E3%82%B9%E3%82%AF%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B