### PR TITLE
ja: Remove menu of $nuxt from ja/api/menu.json

### DIFF
--- a/ja/api/menu.json
+++ b/ja/api/menu.json
@@ -37,12 +37,6 @@
     ]
   },
   {
-    "title": "Utils",
-    "links": [
-      { "name": "$nuxt", "to": "/$nuxt" }
-    ]
-  },
-  {
     "title": "設定",
     "links": [
       {


### PR DESCRIPTION
@inouetakuya @potato4d 先日の PR（#1174）で今回翻訳対象外の項目を追加していたので、削除 PR です:bow: