### PR TITLE
ja: Translate api/pages-scrolltotop

### DIFF
--- a/ja/api/pages-scrolltotop.md
+++ b/ja/api/pages-scrolltotop.md
@@ -9,7 +9,7 @@ description: scrollToTop プロパティで、ページをレンダリングす�
 
 - **型:** `ブーリアン`（デフォルト: `false`）
 
-別のページへ遷移する際にトップまでスクロールしますが、子ルートがあるときはスクロール位置をキープする、というのが Nuxt.js のデフォルトの挙動です。子ルートをレンダリングするときにトップまでスクロールさせたいときは `scrollToTop: true` と設定してください:
+別のページへ遷移する際にトップまでスクロールしますが、子ルートがあるときはスクロール位置をキープする、というのが Nuxt.js のデフォルトの挙動です。子ルートをレンダリングするときにトップまでスクロールさせたいときは `scrollToTop` to `true` と設定してください:
 
 ```html
 <template>
@@ -22,5 +22,7 @@ export default {
 }
 </script>
 ```
+
+Conversely, you can manually set `scrollToTop` to `false` on parent routes as well.
 
 スクロールについて Nuxt.js のデフォルトの挙動を上書きしたいときは [scrollBehavior オプション](/api/configuration-router#scrollBehavior) を参照してください。

--- a/ja/api/pages-scrolltotop.md
+++ b/ja/api/pages-scrolltotop.md
@@ -24,6 +24,6 @@ export default {
 ```
 
 
-親ルートでも `scrollToTop` を `false` に設定することができます。
+逆に、親ルートでは `scrollToTop` を手動で `false` に設定することができます。
 
 スクロールについて Nuxt.js のデフォルトの挙動を上書きしたいときは [scrollBehavior オプション](/api/configuration-router#scrollBehavior) を参照してください。

--- a/ja/api/pages-scrolltotop.md
+++ b/ja/api/pages-scrolltotop.md
@@ -9,7 +9,7 @@ description: scrollToTop プロパティで、ページをレンダリングす�
 
 - **型:** `ブーリアン`（デフォルト: `false`）
 
-別のページへ遷移する際にトップまでスクロールしますが、子ルートがあるときはスクロール位置をキープする、というのが Nuxt.js のデフォルトの挙動です。子ルートをレンダリングするときにトップまでスクロールさせたいときは `scrollToTop` to `true` と設定してください:
+別のページへ遷移する際にトップまでスクロールしますが、子ルートがあるときはスクロール位置をキープする、というのが Nuxt.js のデフォルトの挙動です。子ルートをレンダリングするときにトップまでスクロールさせたいときは `scrollToTop` を `true` と設定してください:
 
 ```html
 <template>
@@ -23,6 +23,7 @@ export default {
 </script>
 ```
 
-Conversely, you can manually set `scrollToTop` to `false` on parent routes as well.
+
+親ルートでも `scrollToTop` を `false` に設定することができます。
 
 スクロールについて Nuxt.js のデフォルトの挙動を上書きしたいときは [scrollBehavior オプション](/api/configuration-router#scrollBehavior) を参照してください。


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm 

vuejs-jp#123 の差分を翻訳しましたのでご確認お願します。

`en/api/pages-scrolltotop.md` の差分はこちらです。
https://github.com/nuxt/docs/compare/b000302..e53272a#diff-1abb9acd20b50ae9c339b3c6ecede8a8