### PR TITLE
ja: Translate faq/google-analytics.md

### DIFF
--- a/ja/faq/google-analytics.md
+++ b/ja/faq/google-analytics.md
@@ -48,7 +48,7 @@ export default ({ app }) => {
 `nuxt.config.js`
 
 ```js
-module.exports = {
+export default {
   plugins: [
     { src: '~plugins/ga.js', ssr: false }
   ]


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm

vuejs-jp#69 の差分の翻訳が完了しました。ソースコードのみの差分でした。
お手数ですが、ご確認お願いいたします。

enの差分はこちらです。
https://github.com/nuxt/docs/compare/b000302..e53272a#diff-76303847b8263a974984b25370aaed5c