### PR TITLE
fix: (node:8482) UnhandledPromiseRejectionWarning: YAMLException on npm run dev

### DIFF
--- a/ja/api/pages-loading.md
+++ b/ja/api/pages-loading.md
@@ -1,6 +1,6 @@
 ---
 title: "API: loading プロパティ"
-description: `loading` プロパティは特定のページに対してデフォルトの loading プログレスバーを無効にするオプションを提供します。
+description: "`loading` プロパティは特定のページに対してデフォルトの loading プログレスバーを無効にするオプションを提供します。"
 ---
 
 # loading プロパティ

--- a/zh/api/pages-loading.md
+++ b/zh/api/pages-loading.md
@@ -1,6 +1,6 @@
 ---
 title: "API: loading 属性"
-description: `loading` 属性为您提供了禁用特定页面上的默认加载进度条的选项。
+description: "`loading` 属性为您提供了禁用特定页面上的默认加载进度条的选项。"
 ---
 
 # loading 属性


### PR DESCRIPTION
I have fixed the following error on `npm run dev`.

> (node:8482) UnhandledPromiseRejectionWarning: YAMLException: end of the stream or a document separator is expected at line 2, column 14:

```shell
[@GISELE.local ja.docs.nuxtjs]$ node -v
v10.15.2
[@GISELE.local ja.docs.nuxtjs]$ npm -v
6.4.1
```

<details>

```
[@GISELE.local ja.docs.nuxtjs]$ npm run dev

> nuxt-docs@1.0.0 dev /Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs
> nodemon --watch *.js --exec 'node api.js'

[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: api.js
[nodemon] starting `node api.js gh-hook.js`
ℹ info Building files...
(node:8482) UnhandledPromiseRejectionWarning: YAMLException: end of the stream or a document separator is expected at line 2, column 14:
    description: `loading` プロパティは特定のページに対してデフォルトの ...
                 ^
    at generateError (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:165:10)
    at throwError (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:171:9)
    at readDocument (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1512:5)
    at loadDocuments (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1548:5)
    at Object.load (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1569:19)
    at parse (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/front-matter/index.js:41:27)
    at extractor (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/front-matter/index.js:24:12)
    at getDocFile (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/api.js:113:10)
(node:8482) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:8482) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:8482) UnhandledPromiseRejectionWarning: YAMLException: end of the stream or a document separator is expected at line 2, column 14:
    description: `loading` プロパティは特定のページに対してデフォルトの ...
                 ^
    at generateError (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:165:10)
    at throwError (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:171:9)
    at readDocument (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1512:5)
    at loadDocuments (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1548:5)
    at Object.load (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1569:19)
    at parse (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/front-matter/index.js:41:27)
    at extractor (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/front-matter/index.js:24:12)
    at getDocFile (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/api.js:113:10)
(node:8482) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:8482) UnhandledPromiseRejectionWarning: YAMLException: end of the stream or a document separator is expected at line 2, column 14:
    description: `loading` 属性为您提供了禁用特定页面上的默认加载进度条的选项。
                 ^
    at generateError (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:165:10)
    at throwError (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:171:9)
    at readDocument (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1512:5)
    at loadDocuments (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1548:5)
    at Object.load (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/js-yaml/lib/js-yaml/loader.js:1569:19)
    at parse (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/front-matter/index.js:41:27)
    at extractor (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/node_modules/front-matter/index.js:24:12)
    at getDocFile (/Users/inouetakuya/src/github.com/inouetakuya/ja.docs.nuxtjs/api.js:113:10)
(node:8482) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
[nodemon] clean exit - waiting for changes before restart
```

</details>

