### PR TITLE
ja: Translate api/configuration-render.md

### DIFF
--- a/ja/api/configuration-render.md
+++ b/ja/api/configuration-render.md
@@ -45,11 +45,31 @@ Nuxt.js は既に最高の SSR のデフォルト設定を提供していて、�
 
 独自の圧縮ミドルウェアを使用したい場合は、直接参照することができます。(f.ex. `otherComp({ myOptions: 'example' })`)
 
+## fallback
+- 型 `オブジェクト`
+  - デフォルト: `{ dist: {}, static: { skipUnknown: true } }`
+
+[serve-placeholder](https://github.com/nuxt/serve-placeholder) ミドルウェアのオプションです.
+
+ もしこれらのうち一つか両方を無効にする場合は、偽となる値を渡すことができます。
+
 ## http2
 - 型 `オブジェクト`
-  - デフォルト: `{ push: false }`
+  - デフォルト: `{ push: false, pushAssets: null }`
 
 HTTP2 プッシュヘッダーを有効にします。
+
+`pushAssets` 関数でプッシュされるリンクをコントロールすることができます。 例えば:
+```js
+pushAssets: (req, res, publicPath, preloadFiles) => preloadFiles
+  .filter(f => f.asType === 'script' && f.file === 'runtime.js')
+  .map(f => `<${publicPath}${f.file}>; rel=preload; as=${f.asType}`)
+```
+
+ 配列と同様に自分のアセットを追加することができます。
+`req` と `res` を使うことで、例えばアプリケーションバージョンを持ったクッキーを使うといったように、リクエストヘッダを元にどのリンクをプッシュするか決めることができます。
+
+ それらのアセットは `, ` を区切り文字として合成され、一つの `Link` ヘッダに渡されます。
 
 ## resourceHints
 - 型: `ブーリアン`
@@ -104,8 +124,15 @@ export default {
   render: {
     csp: {
       hashAlgorithm: 'sha256',
-      allowedSources: undefined,
-      policies: undefined
+      policies: {
+        'script-src': [
+          'https://www.google-analytics.com',
+          'https://name.example.com'
+        ],
+        'report-uri': [
+          'https://report.example.com/report-csp-violations'
+        ]
+      }
     }
   }
 }

--- a/ja/api/configuration-render.md
+++ b/ja/api/configuration-render.md
@@ -8,7 +8,7 @@ description: Nuxt.js はページレンダリングの実行時オプション�
 > Nuxt.js はページレンダリングの実行時オプションをカスタマイズできます。
 
 ## bundleRenderer
-- 型: `オブジェクト`
+- 型: `Object`
 
 > このオプションを使用して Vue SSR のバンドルレンダラのカスタマイズします。このオプションは SPA モードではスキップされます。
 
@@ -30,7 +30,7 @@ export default {
 Nuxt.js は既に最高の SSR のデフォルト設定を提供していて、誤った設定が SSR の問題を引き起こす可能性があるため、このオプションを使用しないことをお勧めします。
 
 ## etag
-- 型: `オブジェクト`
+- 型: `Object`
   - デフォルト: `{ weak: true }`
 
 ページの etag を無効にするためには `etag: false` をセットしてください。
@@ -38,15 +38,15 @@ Nuxt.js は既に最高の SSR のデフォルト設定を提供していて、�
 利用可能なオプションは [etag](https://www.npmjs.com/package/etag) を参照してください。
 
 ## compressor
-- 型 `オブジェクト`
+- 型 `Object`
   - デフォルト: `{ threshold: 0 }`
 
-オブジェクト（または偽の値）を提供する場合、[compression](https://www.npmjs.com/package/compression) ミドルウェアが利用されます（それぞれのオプションがあります）。
+Object（または偽の値）を提供する場合、[compression](https://www.npmjs.com/package/compression) ミドルウェアが利用されます（それぞれのオプションがあります）。
 
 独自の圧縮ミドルウェアを使用したい場合は、直接参照することができます。(f.ex. `otherComp({ myOptions: 'example' })`)
 
 ## fallback
-- 型 `オブジェクト`
+- 型 `Object`
   - デフォルト: `{ dist: {}, static: { skipUnknown: true } }`
 
 [serve-placeholder](https://github.com/nuxt/serve-placeholder) ミドルウェアのオプションです.
@@ -54,7 +54,7 @@ Nuxt.js は既に最高の SSR のデフォルト設定を提供していて、�
  もしこれらのうち一つか両方を無効にする場合は、偽となる値を渡すことができます。
 
 ## http2
-- 型 `オブジェクト`
+- 型 `Object`
   - デフォルト: `{ push: false, pushAssets: null }`
 
 HTTP2 プッシュヘッダーを有効にします。
@@ -72,7 +72,7 @@ pushAssets: (req, res, publicPath, preloadFiles) => preloadFiles
  それらのアセットは `, ` を区切り文字として合成され、一つの `Link` ヘッダに渡されます。
 
 ## resourceHints
-- 型: `ブーリアン`
+- 型: `Boolean`
   - デフォルト: `true`
 
 > 初期ページの読み込み時間をより早くするために、 `prefetch` と `preload` のリンクを追加しました。
@@ -80,7 +80,7 @@ pushAssets: (req, res, publicPath, preloadFiles) => preloadFiles
 多くのページとルートがある場合に、このオプションのみを無効にすることができます。
 
 ## ssr
-- 型: `ブーリアン`
+- 型: `Boolean`
   - デフォルト: ユニバーサルモードでは `true` SPA モードでは `false`
 
 > SSR レンダリングを有効にする
@@ -89,13 +89,13 @@ pushAssets: (req, res, publicPath, preloadFiles) => preloadFiles
 これは（例えば Docker で）イメージビルド後にランタイムで SSR を動的に有効/無効にするのに便利です。
 
 ## static
-- 型: `オブジェクト`
+- 型: `Object`
   - デフォルト: `{}`
 
 利用可能なオプションは  [serve-static](https://www.npmjs.com/package/serve-static) を参照してください。
 
 ## dist
-- 型: `オブジェクト`
+- 型: `Object`
   - デフォルト: `{ maxAge: '1y', index: false }`
 
 配布ファイルの配信に使用されるオプションです。本番でのみ適用されます。
@@ -106,7 +106,7 @@ pushAssets: (req, res, publicPath, preloadFiles) => preloadFiles
 
 > これは Content-Security-Policy で適用された外部リソースを読み込む設定をするために使用します。
 
-- 型: `ブーリアン` または `オブジェクト`
+- 型: `Boolean` または `Object`
   - デフォルト: `false`
 
 例 (`nuxt.config.js`)

--- a/ja/api/configuration-render.md
+++ b/ja/api/configuration-render.md
@@ -51,7 +51,7 @@ Object（または偽の値）を提供する場合、[compression](https://www.
 
 [serve-placeholder](https://github.com/nuxt/serve-placeholder) ミドルウェアのオプションです.
 
- もしこれらのうち一つか両方を無効にする場合は、偽となる値を渡すことができます。
+もしこれらのうち一つか両方を無効にする場合は、偽となる値を渡すことができます。
 
 ## http2
 - 型 `Object`
@@ -66,10 +66,10 @@ pushAssets: (req, res, publicPath, preloadFiles) => preloadFiles
   .map(f => `<${publicPath}${f.file}>; rel=preload; as=${f.asType}`)
 ```
 
- 配列と同様に自分のアセットを追加することができます。
+配列と同様に自分のアセットを追加することができます。
 `req` と `res` を使うことで、例えばアプリケーションバージョンを持ったクッキーを使うといったように、リクエストヘッダを元にどのリンクをプッシュするか決めることができます。
 
- それらのアセットは `, ` を区切り文字として合成され、一つの `Link` ヘッダに渡されます。
+それらのアセットは `,` を区切り文字として合成され、一つの `Link` ヘッダに渡されます。
 
 ## resourceHints
 - 型: `Boolean`


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm

https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/101 の翻訳しましたので、
確認お願いします 🙏 

対応するenは、 https://github.com/vuejs-jp/ja.docs.nuxtjs/blob/e53272a68e3a4ac45373ec333b14009f45dbf29b/en/api/configuration-render.md になります。


https://github.com/nuxt/docs/pull/1215/commits/21201006fcf2ec72203adcb2f078f7d78969527e のコミットで https://vuejs-jp.slack.com/archives/C1P227P7V/p1552140090015800 の対応をこのページだけで行っています