### PR TITLE
Update plugins.md adding notes on ES6 plugins.

### DIFF
--- a/en/guide/plugins.md
+++ b/en/guide/plugins.md
@@ -63,6 +63,19 @@ export default {
 
 To learn more about the `plugins` configuration key, check out the [plugins api](/api/configuration-plugins).
 
+### ES6 plugins
+
+If the plugin is located in `node_modules` and exports an ES6 module, you may need to add it to the `transpile` build option:
+
+```js
+module.exports = {
+  build: {
+    transpile: ['vue-notifications']
+  }
+}
+```
+You can refer to the [configuration build](/api/configuration-build/#transpile) docs for more build options.
+
 ## Inject in $root & context
 
 Sometimes you want to make functions or values available across the app.


### PR DESCRIPTION
If you try to `import` and `Vue.use()` a plugin that exports an ES6 module, the build will fail throwing `Unexpected identifier`, `Unexpected token import` or similar error messages, and the traces wont give any useful information.

This happens because babel wont transpile modules inside `node_modules`, so the build process won't understand the code and will fail to build.

Since using vue plugins is a common practice and there are many that export ES6 modules,  I suggest adding advice on the matter to the docs to prevent new users from having this problem.