### PR TITLE
ja: Translate api/configuration-global-name.md

### DIFF
--- a/ja/api/configuration-global-name.md
+++ b/ja/api/configuration-global-name.md
@@ -1,16 +1,16 @@
 ---
-title: "API: The globalName Property"
-description: Nuxt.js lets you customize the global ID used in the main HTML template as well as the main Vue instance name and other options.
+title: "API: globalName プロパティ"
+description: Nuxt.js はメインの Vue インスタンスとその他のオプションだけでなく、メインの HTML テンプレート上でもグローバル ID をカスタマイズできます。
 ---
 
-# The globalName Property
+# globalName プロパティ
 
-> Nuxt.js lets you customize the global ID used in the main HTML template as well as the main Vue instance name and other options.
+> Nuxt.js はメインの Vue インスタンスとその他のオプションだけでなく、メインの HTML テンプレート上でもグローバル ID をカスタマイズできます。
 
-- Type: `String`
-- Default: `nuxt`
+- 型: `String`
+- デフォルト: `nuxt`
 
-Example:
+例:
 
 `nuxt.config.js`
 
@@ -20,14 +20,14 @@ Example:
 }
 ```
 
-It needs to be a valid JavaScript identifier.
+有効な JavaScript 識別子である必要があります。
 
-## The globals property
+## globals プロパティ
 
-> Customizes specific global names which are based on `globalName` by default.
+> デフォルトで `globalName` に基づく、特定のグローバル名をカスタマイズします。
 
-- Type: `Object`
-- Default:
+- 型: `Object`
+- デフォルト:
 
 ```js
 {


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm

vuejs-jp#91 の差分の翻訳が完了しました。
お手数ですが、ご確認お願いいたします。

enの差分はこちらです。
https://github.com/nuxt/docs/compare/b000302..e53272a#diff-c396a6219396b7678badf1b19ad3bb17
上記差分の英文の追加はすでに済んでいたため、日本語訳への修正のみ行っています。また型の表記に関しては、vuejs-jp#126 の方針に合わせています。