### PR TITLE
ja: Translate /api/components-nuxt-link.md

### DIFF
--- a/ja/api/components-nuxt-link.md
+++ b/ja/api/components-nuxt-link.md
@@ -5,19 +5,34 @@ description: ページ間を nuxt-link を使ってリンクさせます。
 
 # <nuxt-link> コンポーネント
 
-> ページ間を nuxt-link を使ってリンクさせます。
+> このコンポーネントは、ページコンポーネント間のナビゲーションを提供し、賢い prefetching（先読み）でパフォーマンスを高めるのに使用します。
 
-現時点では、`<nuxt-link>` は [`<router-link>`](https://router.vuejs.org/ja/api/#router-link) と同じです。そのため、[Vue Router のドキュメント](https://router.vuejs.org/ja/api/#router-link) でこのコンポーネントの使い方を確認することをお勧めします。
+`<nuxt-link>` は Nuxt の重要な要素です。あなたのアプリケーションを**遷移するのに使われるべきコンポーネント**で、従来の Vue アプリケーションにおける `<router-link>` と似ています。実際に、`<nuxt-link>` は [`<router-link>`](https://router.vuejs.org/api/#router-link) を拡張しています。つまり、同じプロパティを取り、同じように使うことができるということです。詳しくは、[Vue Router のドキュメント](https://router.vuejs.org/api/#router-link) を参照してください。
 
 例（`pages/index.vue`）:
 
 ```html
 <template>
   <div>
-    <h1>ホーム</h1>
-    <nuxt-link to="/about">このサイトについて</nuxt-link>
+    <h1>ホームページ</h1>
+    <nuxt-link to="/about">このサイトについて（Nuxt アプリケーション内部リンク）</nuxt-link>
+    <a href="https://nuxtjs.org">別のページへの外部リンク</a>
   </div>
 </template>
 ```
 
-将来的には、Nuxt.js アプリケーションの応答性を改善するためにバックグラウンドでプリフェッチするような機能を `<nuxt-link>` コンポーネントに追加する予定です。
+**エイリアス:** `<n-link>`, `<NuxtLink>`, `<NLink>`
+
+> この機能は Nuxt.js v2.4.0 で追加されました
+
+Nuxt.js アプリケーションの応答性を高めるため、viewport（ブラウザの表示領域）内にリンクが表示されたとき、Nuxt.js は*コード分割された*ページを自動的に先読みします。この機能は Google Chrome Labs の [quicklink.js](https://github.com/GoogleChromeLabs/quicklink) にインスパイアされています。
+
+リンク先ページの先読みを無効化するために、`no-prefetch` プロパティを使うことができます:
+
+```html
+<n-link to="/about" no-prefetch>（先読みしない）このサイトについて</n-link>
+```
+
+[router.prefetchLinks](/api/configuration-router#prefetchlinks) を使って、この挙動をグローバルに設定することができます。
+
+また、コード分割されたページの先読みが完了したとき付与される class をカスタマイズするため、 `prefetched-class` プロパティを使用することもできます。この機能は [router.linkPrefetchedClass](/api/configuration-router#linkprefetchedclass) でグローバルに設定できることを必ず確認してください。


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm

https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/82

翻訳対象にあたる b000302..e53272a 間のDiffと翻訳時点のmaster(2d360beb)の内容に差分があったため、masterの内容（下記）を訳しています。

https://github.com/nuxt/docs/blob/2d360beb89988d415a711c7059cf95943f24e352/en/api/components-nuxt-link.md

よろしくお願いいたします。