### PR TITLE
Add FAQ about loading audio files with Webpack

### DIFF
--- a/en/faq/webpack-audio-files
+++ b/en/faq/webpack-audio-files
@@ -5,7 +5,7 @@ description: How to extend Webpack config to load audio files
 
 #  How to extend Webpack config to load audio files
 
-Audio files should be processed by `file-loader`. This loader is already includes in the default Webpack config, but it is not set to handle audio files. You need to extend its default config in `nuxt.config.js`:
+Audio files should be processed by `file-loader`. This loader is already included in the default Webpack configuration, but it is not set up to handle audio files. You need to extend its default configuration in `nuxt.config.js`:
 
 ```js
 export default {
@@ -23,7 +23,7 @@ export default {
 }
 ```
 
-You can now import audio file like this `<audio :src="require('@/assets/water.mp3')" controls></audio>`.
+You can now import audio files like this `<audio :src="require('@/assets/water.mp3')" controls></audio>`.
 
 If you only want to write: `<audio src="@/assets/water.mp3" controls></audio>`, you need to tell `vue-loader` to automatically require your audio files when you reference them with the `src` attribute:
 

--- a/en/faq/webpack-audio-files
+++ b/en/faq/webpack-audio-files
@@ -1,0 +1,52 @@
+---
+title: Loading audio files from assets directory
+description: How to extend Webpack config to load audio files
+---
+
+#  How to extend Webpack config to load audio files
+
+Audio files should be processed by `file-loader`. This loader is already includes in the default Webpack config, but it is not set to handle audio files. You need to extend its default config in `nuxt.config.js`:
+
+```js
+export default {
+  build: {
+    extend(config, ctx) {
+      config.module.rules.push({
+        test: /\.(ogg|mp3|wav|mpe?g)$/i,
+        loader: 'file-loader',
+        options: {
+          name: '[path][name].[ext]',
+        },
+      })
+    },
+  }
+}
+```
+
+You can now import audio file like this `<audio :src="require('@/assets/water.mp3')" controls></audio>`.
+
+If you only want to write: `<audio src="@/assets/water.mp3" controls></audio>`, you need to tell `vue-loader` to automatically require your audio files when you reference them with the `src` attribute:
+
+```js
+export default {
+   build: {
+    loaders: {
+      vue: {
+        transformAssetUrls: {
+          audio: 'src',
+        },
+      },
+    },
+
+    extend(config, ctx) {
+      config.module.rules.push({
+        test: /\.(ogg|mp3|wav|mpe?g)$/i,
+        loader: 'file-loader',
+        options: {
+          name: '[path][name].[ext]',
+        },
+      })
+    },
+  },
+}
+```


### PR DESCRIPTION
I hard a hard time finding how to achieve this in Nuxt 2.
Please correct me if this is not the optimal way 🙇‍♂️

I tried setting `transformAssetUrls` in the extend function. It did update the config, but I still couldn't import audio file with the `src` attribute.

```js
export default {
  build: {
    extend (config, { isClient, loaders: { vue } }) {

      // This doesn't work for me.
      vue.transformAssetUrls.audio= 'src'

      config.module.rules.push({
        test: /\.(ogg|mp3|wav|mpe?g)$/i,
        loader: 'file-loader',
        options: {
          name: '[path][name].[ext]',
        },
      })
  
    }
  }
}
```