### PR TITLE
zh: Update the open source contribution guide document

### DIFF
--- a/zh/guide/contribution-guide.md
+++ b/zh/guide/contribution-guide.md
@@ -7,15 +7,101 @@ description: 欢迎为 Nuxt.js 做出开源贡献！
 
 ## 提交问题
 
-开源贡献的其中一种方式是为项目提交问题的详细报告，以方便我们不断地迭代优化项目。
-我们欢迎并感谢大家提交有良好书写习惯且能够清晰描述问题的报告！遇到问题的时候，麻烦先详细阅读 Nuxt.js 的文档，并在 https://github.com/nuxt/nuxt.js/issues 上查找是否已有相同或类似的问题。
+我们使用[CMTY](https://cmty.nuxtjs.org/)使贡献者和维护者更容易的提交问题的详细报告。
+
+请确保包含一个复制代码仓库或[CodeSandBox](https://template.nuxtjs.org/)，以便可以更好地再现错误，我们开始修复它的速度越快！
 
 ## Pull Requests
 
 欢迎大家提 PR（ `源码拉取请求` ），即便是修复一个拼写错误。
-任何重要的问题修复或特性开发，在开始编码之前请先提 [GitHub issue](https://github.com/nuxt/nuxt.js/issues)，以便大家知悉，避免重复的功能开发或问题修复。
 
-### 惯例
+任何重大改进都应与现有[功能请求](https://feature.nuxtjs.org/)或[错误报告](https://bug.nuxtjs.org/)相关联。
 
-- 问题修复，分支命名为 `fix-XXX`，其中的 `XXX` 对应问题在 [GitHub issue](https://github.com/nuxt/nuxt.js/issues) 中的编号或名称。
-- 特性开发，分支命名为 `feature-XXX`，其中的 `XXX` 对应特性在 [GitHub issue](https://github.com/nuxt/nuxt.js/issues) 中的编号或名称。
+### 开始
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) 代码仓库到您自己的GitHub帐户，然后 [clone](https://help.github.com/articles/cloning-a-repository/) 到您的本地。
+2. 运行 `npm install` 或 `yarn install` 来安装依赖。
+
+> _请注意，**npm** 和 **yarn** 都被认为丢失依赖项。要解决此问题，您可以删除示例应用程序中的node_modules文件夹，然后重新安装或执行缺少的依赖项的本地安装。_
+
+> 如果要添加依赖项，请使用`yarn add`。`yarn.lock`文件是所有Nuxt依赖项的最新源。
+
+### 构建
+
+在运行任何测试之前，请确保满足所有依赖项并构建所有依赖项：
+
+ ```sh
+yarn
+yarn build
+```
+
+### 测试结构
+
+一个伟大而出色的PR，无论是包含错误修复还是新功能，都会包含测试。
+
+要编写出色的测试，让我们解释一下我们的测试结构：
+
+#### Fixtures
+
+这个 fixtures (在 `tests/fixtures` 目录下) 包含几个Nuxt应用程序。为了使构建时间尽可能短，我们不会为每个测试构建一个自己的Nuxt应用程序。相反，在运行实际的单元测试之前，构造了(`yarn test:fixtures`)。
+
+提交PR时，请确保 **更改** 或 **添加新fixture** 用来正确反映更改（如果适用）。
+此外，不要忘记在更改后通过使用`jest test/fixtures/my-fixture/my-fixture.test.js`运行相应的测试来重新构建fixtures。
+
+#### Unit tests(单元测试)
+
+单元测试可以在`tests/unit`中找到，并将在构建fixtures后执行。每次测试，将使用新的Nuxt服务器以便不存在共享状态（除了构建步骤的初始状态）。
+
+添加单元测试后，您可以直接运行它们：
+
+```sh
+jest test/unit/test.js
+```
+
+或者您可以运行整个单元测试：
+
+```sh
+yarn test:unit
+```
+
+请再次注意，您可能需要重新构建您的fixture！
+
+### 测试您的更改
+
+在处理PR时，您可能需要检查fixture是否设置正确或调试当前的更改。
+为此，您可以使用Nuxt脚本本身来启动例如您的fixture或示例应用：
+
+```sh
+yarn nuxt examples/your-app
+yarn nuxt test/fixtures/your-fixture-app
+```
+
+> `npm link`也可以（并且在某种程度上）可以为此工作，但有时它会出现一些问题。这就是为什么我们建议直接调用`yarn nuxt`来运行示例。
+
+### 例子
+
+如果您正在开发更大的功能，请在 `examples/` 中设置一个示例应用程序。
+这将有助于理解变更，并帮助Nuxt用户深入了解您提交构建的功能。
+
+### Linting
+
+您可能已经注意到，我们正在使用 ESLint 来强制检查代码标准。请在提交之前运行`yarn lint`您的更改以检查代码样式是否标准。
+如果没有，你可以使用 `yarn lint --fix` 或 `npm run lint -- --fix` (没有拼错！)来修复大部分的样式风格变化。如果仍有错误，则必须手动更正。
+
+### 文档
+
+如果您要添加新功能，请进行重构或以任何其他方式更改Nuxt的行为，您可能会这样做
+想要记录变化。 Please do so with a PR to the [docs](https://github.com/nuxt/docs/pulls) repository.
+请提交PR到 [docs](https://github.com/nuxt/docs/pulls) 代码仓库。您不必立即编写文档（但请在PR足够严谨及检查后提交）。
+
+### 提交过程
+
+提交PR时，您需要填写一个简单的模板。
+
+请勾选清单中的所有对应 "answers"。
+
+#### 在macOS上调试测试
+
+搜索`getPort()`将显示它用于在测试期间启动新的Nuxt进程。使用macOS它有时会停止，并且可能需要您手动设置端口进行测试。
+
+另一个常见问题是Nuxt进程在运行fixture测试时可能会挂起内存。过程通常会阻止后续测试工作。运行`ps aux | grep -i node`如果您对发生这种情况不解，则检查任何挂起的测试过程。

--- a/zh/guide/contribution-guide.md
+++ b/zh/guide/contribution-guide.md
@@ -7,9 +7,9 @@ description: 欢迎为 Nuxt.js 做出开源贡献！
 
 ## 提交问题
 
-我们使用[CMTY](https://cmty.nuxtjs.org/)使贡献者和维护者更容易的提交问题的详细报告。
+我们使用[CMTY](https://cmty.nuxtjs.org/)使贡献者和维护者更容易的提交问题和新功能改进。
 
-请确保包含一个复制代码仓库或[CodeSandBox](https://template.nuxtjs.org/)，以便可以更好地再现错误，我们开始修复它的速度越快！
+请确保包含一个克隆仓库或[CodeSandBox](https://template.nuxtjs.org/)，以便可以更好地再现错误，我们开始修复它的速度越快！
 
 ## Pull Requests
 


### PR DESCRIPTION
## Fixed :speech_balloon:
* Update the open source contribution guide document to synchronize with the English document in 2.4.X version