### PR TITLE
fix: describe about render.compressor

### DIFF
--- a/en/api/configuration-render.md
+++ b/en/api/configuration-render.md
@@ -41,7 +41,7 @@ See [etag](https://www.npmjs.com/package/etag) docs for possible options.
 - Type `Object`
   - Default: `{ threshold: 0 }`
 
-When providing an object (or a falsy value), the [compression](https://www.npmjs.com/package/compression) middleware
+When providing an object, the [compression](https://www.npmjs.com/package/compression) middleware
 will be used (with respective options).
 
 If you want to use your own compression middleware, you can reference it

--- a/ja/api/configuration-render.md
+++ b/ja/api/configuration-render.md
@@ -41,7 +41,7 @@ Nuxt.js は既に最高の SSR のデフォルト設定を提供していて、�
 - 型 `Object`
   - デフォルト: `{ threshold: 0 }`
 
-Object（または偽の値）を提供する場合、[compression](https://www.npmjs.com/package/compression) ミドルウェアが利用されます（それぞれのオプションがあります）。
+Object を設定する場合、[compression](https://www.npmjs.com/package/compression) がミドルウェアとして利用され、そのオプションとして参照されます。
 
 独自の圧縮ミドルウェアを使用したい場合は、直接参照することができます。(f.ex. `otherComp({ myOptions: 'example' })`)
 


### PR DESCRIPTION
- remove `(or a falsy value)` because [falsy value will disable compressor option](https://github.com/nuxt/nuxt.js/blob/ef41e205e6787b784ab5907d99652b9d74891c6c/packages/server/src/server.js#L78-L86)
- tweak Japanese translation