### PR TITLE
ja: Translate /api/configuration-head.md

### DIFF
--- a/ja/api/configuration-head.md
+++ b/ja/api/configuration-head.md
@@ -5,17 +5,20 @@ description: Nuxt.js では nuxt.config.js 内にアプリケーションのデ�
 
 # head プロパティ
 
-> Nuxt.js では `nuxt.config.js` 内にアプリケーションのデフォルトのメタ情報を定義できます。それには `head` プロパティを使います:
+> Nuxt.js では `nuxt.config.js` 内にアプリケーションのデフォルトのメタ情報を定義できます。それには `head` プロパティを使います
 
 - 型: `オブジェクト`
 
+An example `nuxt.config.js`:
 ```js
-module.exports = {
+export default {
   head: {
     titleTemplate: '%s - Nuxt.js',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+
+      // hidは一意の識別子として使用されます。`vmid` は動作しないので使わないでください
       { hid: 'description', name: 'description', content: 'Meta description' }
     ]
   }
@@ -24,8 +27,10 @@ module.exports = {
 
 `head` に設定できるオプション一覧は [vue-meta のドキュメント](https://github.com/declandewet/vue-meta#recognized-metainfo-properties) を参照してください。
 
+ページのコンポーネントでも `head` を使うことができ、`this` を経由してコンポーネントのデータにアクセスできます。詳しくは [コンポーネントの head プロパティ](/api/pages-head) を参照してください。
+
 <div class="Alert Alert--teal">
 
-<b>情報:</b> ページのコンポーネントでも `head` を使うことができ、`this` を経由してコンポーネントのデータにアクセスできます。詳しくは [コンポーネントの head プロパティ](/api/pages-head) を参照してください。
+<b>情報:</b> 子コンポーネントでメタタグが重複しないようにするには、メタ要素に `hid` を使って一意の識別子を設定します。詳しくは[こちら](https://github.com/declandewet/vue-meta#lists-of-tags)を参照してください。
 
 </div>


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm

vuejs-jp#92 の差分を翻訳しましたのでご確認お願します。

en/api/configuration-head.md の差分はこちらです。
https://github.com/nuxt/docs/compare/b000302..e53272a#diff-421f31192304e75988dab0da181e7389