### PR TITLE
ja: Translate faq/jsx.md

### DIFF
--- a/ja/faq/jsx.md
+++ b/ja/faq/jsx.md
@@ -5,7 +5,7 @@ description: Nuxt.js で JSX を使うには？
 
 # JSX を使うには？
 
-Nuxt.js は babel のデフォルトの設定のために公式の [babel-preset-vue-app](https://github.com/vuejs/babel-preset-vue-app) を使用しています。そのため、コンポーネントに JSX を使うことができます。
+Nuxt.js は babel のデフォルトの設定用の公式の [@vue/babel-preset-app](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app) に基づいた [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app) を使用しています。そのため、コンポーネントに JSX を使うことができます。
 
 コンポーネントの `render` メソッド内で JSX が使えます:
 


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm 

https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/64 を翻訳しましたので、ご確認お願いいたします 🙏 

最新の en はこちらです。
https://github.com/nuxt/docs/blob/master/en/faq/jsx.md

`git diff b000302bd83a2bef8c00979c98ab1c2d62f2dcb0..e53272a68e3a4ac45373ec333b14009f45dbf29b en/faq/jsx.md` したところ、以下の差分は既に翻訳済みだったので、それ以外の差分を翻訳したのが本PRです。


```
-<p class="Alert Alert--info">Aliasing `createElement` to `h` is a common convention you’ll see in the Vue ecosystem but is actually optional for JSX since it [automatically injects](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` in any method and getter (not functions or arrow functions) declared in ES2015 syntax that has JSX so you can drop the (h) parameter.</p>
+<div class="Alert Alert--orange">
+
+Aliasing `createElement` to `h` is a common convention you’ll see in the Vue ecosystem but is actually optional for JSX since it [automatically injects](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` in any method and getter (not functions or arrow functions) declared in ES2015 syntax that has JSX so you can drop the (h) parameter.
+
+</div>
```