### PR TITLE
ja: Translate api/components-nuxt-child.md

### DIFF
--- a/ja/api/components-nuxt-child.md
+++ b/ja/api/components-nuxt-child.md
@@ -66,3 +66,20 @@ description: 現在のページを表示します。
 > 子コンポーネントは、通常の Vue コンポーネントのようなプロパティも受け取ることができます。
 
 実際の例を見たいときは [ネストされたルートの例](/examples/nested-routes) を参照してください。
+
+## 名前付きビュー
+
+> Nuxt v2.4.0 で導入されました
+
+`<nuxt-child/>` は名前付きビューを描画するために `name` プロパティを受け入れます:
+
+```html
+<template>
+  <div>
+    <nuxt-child name="top" />
+    <nuxt-child />
+  </div>
+</template>
+```
+
+実際の例を見たいときは [名前付きビューの例](/examples/named-views) を参照してください。

--- a/ja/examples/menu.json
+++ b/ja/examples/menu.json
@@ -40,6 +40,10 @@
         "to": "/middleware"
       },
       {
+        "name": "名前付きビュー",
+        "to": "/named-views"
+      },
+      {
         "name": "ネストされたルート",
         "to": "/nested-routes"
       },

--- a/ja/examples/named-views.md
+++ b/ja/examples/named-views.md
@@ -3,5 +3,5 @@ title: 名前付きビュー
 description: 名前付きビューの例
 github: named-views
 livedemo: https://named-views.nuxtjs.org
-documentation: /guide/routing#named-views
+documentation: /guide/routing#名前付きビュー
 ---


### PR DESCRIPTION
@inouetakuya @potato4d @aytdm 

https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/81 を翻訳しましたのでご確認お願いします 🙏 

最新の en はこちらです。
https://github.com/nuxt/docs/blob/master/en/api/components-nuxt-child.md

`git diff b000302bd83a2bef8c00979c98ab1c2d62f2dcb0..e53272a68e3a4ac45373ec333b14009f45dbf29b en/api/components-nuxt-child.md` したところ、

以下の差分は https://github.com/nuxt/docs/commit/3d0d9895088db39dd5ee4ac2ef6fdd028d7d999b で翻訳されていたので、それ以外の差分を翻訳したのが本PRです。

```
+`<nuxt-child/>` accepts `keep-alive` and `keep-alive-props`:
+
+```html
+<template>
+  <div>
+    <nuxt-child keep-alive :keep-alive-props="{ exclude: ['modal'] }" />
+  </div>
+</template>
+
+<!-- will be converted into something like this -->
+<div>
+  <keep-alive :exclude="['modal']">
+    <router-view />
+  </keep-alive>
+</div>
+```
```