### PR TITLE
Fix small issue with the generate:routeCreated signature.

### DIFF
--- a/en/api/internals-generator.md
+++ b/en/api/internals-generator.md
@@ -17,7 +17,7 @@ Hook                    | Arguments                   | When
 `generate:distRemoved`  | (nuxt)                      | Hook on  destination folder  cleaned
 `generate:distCopied`   | (nuxt)                      | Hook on copy static and built files
 `generate:page`         | ({route, path, html})       | Hook to let user update the path & html
-`generate:routeCreated` | (route, path, errors)       | Hook on saving generated page success
+`generate:routeCreated` | ({route, path, errors})       | Hook on saving generated page success
 `generate:extendRoutes` | (routes)                    | Hook to let user update the routes to generate
 `generate:routeFailed`  | (route, errors)             | Hook on saving generated page failure
 `generate:done`         | (nuxt, errors)              | Hook on generation finished


### PR DESCRIPTION
`generate:routeCreated` signature in the docs is `route, path, errors` but in reality, it's `{route, path, errors}`