### PR TITLE
ja: Fix a destination of link on "routing/#ミドルウェア"

### DIFF
--- a/ja/guide/routing.md
+++ b/ja/guide/routing.md
@@ -405,7 +405,7 @@ export default {
 
 **ミドルウェアは `middleware/` ディレクトリに入れます。** ファイル名はミドルウェアの名前となります（`middleware/auth.js` は `auth` ミドルウェアになります）
 
-ミドルウェアは第一引数として [コンテキスト](/api#%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88) を受け取ります:
+ミドルウェアは第一引数として [コンテキスト](/api/context) を受け取ります:
 
 ```js
 export default function (context) {


### PR DESCRIPTION
## What is this PR
I fixed a destination of link on the `routing/#ミドルウェア` page in Japanese since the destination wasn't correct.

## Description
Current destination(which leads to `/api/` ) :  https://ja.nuxtjs.org/api#%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88
Fixed destination:
https://ja.nuxtjs.org/api/context

## このPRは何か
「ミドルウェア」の項目で「コンテキスト」ページへの向き先が異なっていたので修正しました。

## 詳細
現在のリンク先( `/api/` に遷移します ): https://ja.nuxtjs.org/api#%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88
修正後のリンク先: 
https://ja.nuxtjs.org/api/context