### PR TITLE
docs(ts): fix missing `interface` keyword in snippet

### DIFF
--- a/en/guide/typescript.md
+++ b/en/guide/typescript.md
@@ -72,7 +72,7 @@ Here is a basic example mixing a `page` and a reusable `component` to display da
 
 ```ts
 /* models/Post.ts */
-export default Post {
+export default interface Post {
   id: number
   title: string
   description: string


### PR DESCRIPTION
Contributes to fixing #1323. Specifically the missing interface keyword.