### PR TITLE
Remove  --project <project-id>

### DIFF
--- a/en/faq/appengine-deployment.md
+++ b/en/faq/appengine-deployment.md
@@ -48,7 +48,7 @@ Now build your app with `npm run build`.
 At this point, your app is ready to be uploaded to Google App Engine. Now just run the following command:
 
 ```
-gcloud app deploy app.yaml --project <project-id>
+gcloud app deploy app.yaml
 ```
 
 Voilà! Your Nuxt.js application is now hosted on Google App Engine!

--- a/en/faq/appengine-deployment.md
+++ b/en/faq/appengine-deployment.md
@@ -56,4 +56,3 @@ Voilà! Your Nuxt.js application is now hosted on Google App Engine!
 ## Further Information
 
 - The `instance_class` attribute in your app.yaml file sets the class of your app instance. Instance F2 is not completely free, but has the minimum memory needed to run a Nuxt application.
-- Make sure to put the project-id and not the project-name in the deploy command. These are two different things - but easy to mix up.

--- a/en/faq/appengine-deployment.md
+++ b/en/faq/appengine-deployment.md
@@ -48,7 +48,7 @@ Now build your app with `npm run build`.
 At this point, your app is ready to be uploaded to Google App Engine. Now just run the following command:
 
 ```
-gcloud app deploy app.yaml
+gcloud app deploy app.yaml --project [project-id]
 ```
 
 Voilà! Your Nuxt.js application is now hosted on Google App Engine!
@@ -56,3 +56,5 @@ Voilà! Your Nuxt.js application is now hosted on Google App Engine!
 ## Further Information
 
 - The `instance_class` attribute in your app.yaml file sets the class of your app instance. Instance F2 is not completely free, but has the minimum memory needed to run a Nuxt application.
+
+Make sure to put the `project-id` and not the `project-name` in the deploy command. These are two different things but easy to mix up.


### PR DESCRIPTION
The flag `--project` seems not to be supported [any more]. Run `gcloud help app deploy` for more details.

This change in the deployment command is tested on my personal project.