### PR TITLE
ja: docs(ts): fix missing `interface` keyword in snippet

### DIFF
--- a/ja/guide/typescript.md
+++ b/ja/guide/typescript.md
@@ -66,7 +66,7 @@ Here is a basic example mixing a `page` and a reusable `component` to display da
 
 ```ts
 /* models/Post.ts */
-export default Post {
+export default interface Post {
   id: number
   title: string
   description: string


### PR DESCRIPTION
resolve: [[doc] docs(ts): fix missing `interface` keyword in snippet · Issue #138 · vuejs-jp/ja.docs.nuxtjs](https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/138)
