### PR TITLE
ja: "docVersion": "2.6.X"

### DIFF
--- a/ja/lang.json
+++ b/ja/lang.json
@@ -1,6 +1,6 @@
 {
   "iso": "ja",
-  "docVersion": "2.4.X",
+  "docVersion": "2.6.X",
   "links": {
     "api": "API",
     "blog": "ブログ",


### PR DESCRIPTION
resolve: [[doc] chore(version): Set version to 2.5.X for english · Issue #128 · vuejs-jp/ja.docs.nuxtjs](https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/128)
