### PR TITLE
Update configuration-render.md

### DIFF
--- a/en/api/configuration-render.md
+++ b/en/api/configuration-render.md
@@ -47,7 +47,7 @@ will be used (with respective options).
 If you want to use your own compression middleware, you can reference it
 directly (f.ex. `otherComp({ myOptions: 'example' })`).
 
-To disable compression, pass in a falsy value.
+To disable compression, use `compressor: false`.
 
 ## fallback
 - Type `Object`

--- a/en/api/configuration-render.md
+++ b/en/api/configuration-render.md
@@ -47,6 +47,8 @@ will be used (with respective options).
 If you want to use your own compression middleware, you can reference it
 directly (f.ex. `otherComp({ myOptions: 'example' })`).
 
+To disable compression, pass in a falsy value.
+
 ## fallback
 - Type `Object`
   - Default: `{ dist: {}, static: { skipUnknown: true } }`


### PR DESCRIPTION
Reflect changes from  [nuxtjs/nuxt#4381](https://github.com/nuxt/nuxt.js/pull/4381) on how to disable compression middleware.

I didn't change the `type` hint in the docs, as I didn't know whether to suggest `false`, or `undefined` as the alternate type

Note: `null` wouldn't work as expected, as `typeof null === 'object'`, so the suggestion for 'falsy' is incorrect.

Should `false` or `undefined` be the preferred way of disabling compression?