### PR TITLE
zh: Update Chinese documents to synchronize with English documents

### DIFF
--- a/zh/api/components-nuxt-link.md
+++ b/zh/api/components-nuxt-link.md
@@ -19,5 +19,18 @@ description: nuxt-link 组件用于在页面中添加链接至别的页面。
   </div>
 </template>
 ```
+**别名:** `<n-link>`, `<NuxtLink>`, 和 `<NLink>`
 
-将来我们会为 `nuxt-link` 组件增加更多的功能特性，例如资源预加载，用于提升 nuxt.js 应用的响应速度。
+> Nuxt.js v2.4.0添加
+
+为了提高Nuxt.js应用程序的响应能力，当链接将显示在视口中时，Nuxt.js将自动预获取代码分割页面。此功能的灵感来自Google Chrome Labs的[quicklink.js](https://github.com/GoogleChromeLabs/quicklink)。
+
+要禁用链接页面的预获取，可以使用`no-prefetch`：
+
+```html
+<n-link to="/about" no-prefetch>About page not pre-fetched</n-link>
+```
+
+您可以使用[router.prefetchLinks](/api/configuration-router#prefetchlinks)全局配置此行为。
+
+关于`prefetched-class`还可用于自定义在预获取代码分割页面时添加的类。确保使用[router.linkPrefetchedClass](/api/configuration-router#linkprefetchedclass)全局设置此功能。

--- a/zh/api/configuration-dev.md
+++ b/zh/api/configuration-dev.md
@@ -54,4 +54,4 @@ console.log('服务器运行于 localhost:' + port)
   }
 }
 ```
-注意: 要运行上面的示例，你需要运行 `npm install --save-dev cross-env` 安装 `cross-env`。 如果你在*非* Windows 环境下开发，你可以不用安装 cross-env，这时需要把 `start` 脚本中的 cross-env 去掉。
+注意: 要运行上面的示例，你需要运行 `npm install --save-dev cross-env` 安装 `cross-env`。 如果你在*非* Windows 环境下开发，你可以不用安装 cross-env，这时需要把 `start` 脚本中的 cross-env 去掉并直接设置`NODE_ENV`即可。

--- a/zh/api/configuration-ignore.md
+++ b/zh/api/configuration-ignore.md
@@ -3,6 +3,35 @@ title: "API: ignore 属性"
 description: 为Nuxt.js应用程序自定义忽略文件
 ---
 
+# .nuxtignore
+
+您可以使用`.nuxtignore`文件让Nuxt.js在构建打包阶段忽略项目根目录(`rootDir`)中的布局(`layout`)，页面(`page`)，`store`和中间件(`middleware`)文件。`.nu​​xtignore`文件与.gitignore和.eslintignore文件的规范相同，其中每一行都是一个glob模式，指定应该忽略哪些文件。
+
+例如:
+
+```
+# ignore layout foo.vue
+layouts/foo.vue
+# ignore layout files whose name ends with -ignore.vue
+layouts/*-ignore.vue
+
+# ignore page bar.vue
+pages/bar.vue
+# ignore page inside ignore folder
+layouts/ignore/*.vue
+
+# ignore store baz.js
+store/baz.js
+# ignore store files match *.test.*
+store/ignore/*.test.*
+
+# ignore middleware files under foo folder except foo/bar.js
+middleware/foo/*.js
+!middleware/foo/bar.js
+```
+
+> 在[gitignore doc](https://git-scm.com/docs/gitignore)中查看关于规范中的更多配置细节
+
 # ignorePrefix 属性
 
 - 类型: `String`

--- a/zh/api/configuration-render.md
+++ b/zh/api/configuration-render.md
@@ -44,6 +44,14 @@ export default {
 
 如果您想使用自己的压缩中间件，可以直接引用它(例如： `otherComp({ myOptions: 'example' })`)。
 
+## fallback
+- 类型 `Object`
+  - 默认: `{ dist: {}, static: { skipUnknown: true } }`
+
+中间件配置选项[serve-placeholder](https://github.com/nuxt/serve-placeholder)。
+
+如果要禁用其中一个或两者，则可以传递`false`。
+
 ### http2
 - 类型 `Object`
   - 默认: `{ push: false }`

--- a/zh/api/configuration-router.md
+++ b/zh/api/configuration-router.md
@@ -31,6 +31,22 @@ module.exports = {
 
 > 该配置项的值会被直接传给 vue-router 的[构造器](https://router.vuejs.org/zh-cn/api/options.html)。
 
+## routeNameSplitter
+
+- 类型: `String`
+- 默认: `'-'`
+
+您可能希望更改Nuxt.js使用的路由名称之间的分隔符。您可以通过配置文件中的`routeNameSplitter`选项执行此操作。想象一下，我们有页面文件`pages/posts/_id.vue`。Nuxt将以编程方式生成路由名称，在本例中为`posts-id`。因此，将`routeNameSplitter`配置修改为`/`，这样路由名称生成为`posts/id`。
+
+例如 (`nuxt.config.js`):
+```js
+export default {
+  router: {
+    routeNameSplitter: '/'
+  }
+}
+```
+
 ## extendRoutes
 
 - 类型: `Function`
@@ -91,6 +107,23 @@ export default {
 ```
 
 > 此选项直接提供给vue-router [linkexactactiveclass](https://router.vuejs.org/api/#linkexactactiveclass).
+
+## linkPrefetchedClass
+
+- 类型: `String`
+- 默认: `false`
+
+全局配置[`<nuxt-link>`](/api/components-nuxt-link)默认值(默认情况下禁用功能)
+
+例子 (`nuxt.config.js`):
+
+```js
+export default {
+  router: {
+    linkPrefetchedClass: 'nuxt-link-prefetched'
+  }
+}
+```
 
 ## middleware
 
@@ -193,6 +226,46 @@ module.exports = {
 提供自定义查询字符串解析/字符串化功能。覆盖默认值。
 
 > 此选项直接提供在vue-router [parseQuery / stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery).
+
+## prefetchLinks
+
+> Nuxt v2.4.0 添加
+
+- 类型: `Boolean`
+- 默认: `true`
+
+在视图中检测到时，配置`<nuxt-link>`用来预获取*代码分割*页面。需要支持[IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)(参阅 [CanIUse](https://caniuse.com/#feat=intersectionobserver))。
+
+我们建议使用[Polyfill.io](https://polyfill.io)等服务有条件地填充此功能：
+
+`nuxt.config.js`
+
+```js
+export default {
+  head: {
+    script: [
+      { src: 'https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver', body: true }
+    ]
+  }
+}
+```
+
+要禁用特定链接上的预取，可以使用`no-prefetch` 属性：
+
+```html
+<nuxt-link to="/about" no-prefetch>About page not pre-fetched</nuxt-link>
+```
+
+要全局禁用所有链接上的预取，请将`prefetchLinks`设置为`false`：
+
+```js
+// nuxt.config.js
+export default {
+  router: {
+    prefetchLinks: false
+  }
+}
+```
 
 ## fallback
 

--- a/zh/api/index.md
+++ b/zh/api/index.md
@@ -27,22 +27,3 @@ export default {
 注意：由于`asyncData`方法是在组件 **初始化** 前被调用的，所以在方法内是没有办法通过 `this` 来引用组件的实例对象。
 
 </div>
-
-## 上下文对象
-
-`context` 变量的可用属性一览：
-
-| 属性字段 | 类型 | 可用 | 描述 |
-|-----|------|--------------|-------------|
-| `isClient` | Boolean | 客户端 & 服务端 | 是否来自客户端渲染（_废弃_。请使用 `process.client`）。|
-| `isServer` | Boolean | 客户端 & 服务端 | 是否来自服务端渲染（_废弃_。请使用 `process.server`）。|
-| `isDev` | Boolean | 客户端 & 服务端 | 是否是开发(dev) 模式，在生产环境的数据缓存中用到 |
-| `route` | [vue-router 路由](https://router.vuejs.org/zh-cn/api/route-object.html) | 客户端 & 服务端 | `vue-router` 路由实例。|
-| `store` | [vuex 数据流](http://vuex.vuejs.org/zh-cn/api.html#vuexstore-instance-properties) | 客户端 & 服务端 | `Vuex.Store` 实例。**只有[vuex 数据流](/guide/vuex-store)存在相关配置时可用。** |
-| `env` | Object | 客户端 & 服务端 | `nuxt.config.js` 中配置的环境变量, 见 [环境变量 api](/api/configuration-env)  |
-| `params` | Object | 客户端 & 服务端 | route.params 的别名 |
-| `query` | Object | 客户端 & 服务端 | route.query 的别名 |
-| `req` | [http.Request](https://nodejs.org/api/http.html#http_class_http_incomingmessage) | 服务端 | Node.js API 的 Request 对象。如果 nuxt 以中间件形式使用的话，这个对象就根据你所使用的框架而定。*`nuxt generate` 不可用*。 |
-| `res` | [http.Response](https://nodejs.org/api/http.html#http_class_http_serverresponse) | 服务端 | Node.js API 的 Response 对象。如果 nuxt 以中间件形式使用的话，这个对象就根据你所使用的框架而定。*`nuxt generate` 不可用*。 |
-| `redirect` | Function | 客户端 & 服务端 | 用这个方法重定向用户请求到另一个路由。状态码在服务端被使用，默认 302。`redirect([status,] path [, query])` |
-| `error` | Function | 客户端 & 服务端 | 用这个方法展示错误页：`error(params)`。`params` 参数应该包含 `statusCode` 和 `message` 字段。 |

--- a/zh/api/menu.json
+++ b/zh/api/menu.json
@@ -12,6 +12,7 @@
       { "name": "fetch", "to": "/pages-fetch" },
       { "name": "head", "to": "/pages-head" },
       { "name": "layout", "to": "/pages-layout" },
+      { "name": "loading", "to": "/pages-loading" },
       { "name": "middleware", "to": "/pages-middleware" },
       { "name": "scrollToTop", "to": "/pages-scrolltotop" },
       {
@@ -118,11 +119,15 @@
         "contents": [
           { "name": "bundleRenderer", "to": "#bundleRenderer" },
           { "name": "etag", "to": "#etag" },
+          { "name": "compressor", "to": "#compressor" },
+          { "name": "fallback", "to": "#fallback" },
           { "name": "gzip", "to": "#gzip" },
           { "name": "http2", "to": "#http2" },
           { "name": "resourceHints", "to": "#resourceHints" },
           { "name": "ssr", "to": "#ssr" },
-          { "name": "static", "to": "#static" }
+          { "name": "static", "to": "#static" },
+          { "name": "dist", "to": "#dist" },
+          { "name": "csp", "to": "#csp" }
         ]
       },
       { "name": "rootDir", "to": "/configuration-rootdir" },
@@ -132,13 +137,15 @@
         "contents": [
           { "name": "base", "to": "#base" },
           { "name": "extendRoutes", "to": "#extendroutes" },
+          { "name": "fallback", "to": "#fallback" },
           { "name": "linkActiveClass", "to": "#linkactiveclass" },
           { "name": "linkExactActiveClass", "to": "#linkexactactiveclass" },
+          { "name": "linkPrefetchedClass", "to": "#linkprefetchedclass" },
           { "name": "middleware", "to": "#middleware" },
           { "name": "mode", "to": "#mode" },
-          { "name": "scrollBehavior", "to": "#scrollbehavior" },
           { "name": "parseQuery / stringifyQuery", "to": "#parsequery-stringifyquery" },
-          { "name": "fallback", "to": "#fallback" }
+          { "name": "prefetchLinks", "to": "#prefetchlinks" },
+          { "name": "scrollBehavior", "to": "#scrollbehavior" }
         ]
       },
       { "name": "server", "to": "/configuration-server" },

--- a/zh/api/pages-fetch.md
+++ b/zh/api/pages-fetch.md
@@ -13,6 +13,12 @@ description: fetch 方法用于在渲染页面前填充应用的状态树（stor
 
 `fetch` 方法的第一个参数是页面组件的[上下文对象](/api/#上下文对象) `context`，我们可以用 `fetch` 方法来获取数据填充应用的状态树。为了让获取过程可以异步，你需要**返回一个 Promise**，Nuxt.js 会等这个 promise 完成后再渲染组件。
 
+<div class="Alert Alert--orange">
+
+**警告**: 您无法在内部使用`this`获取**组件实例**，`fetch`是在**组件初始化之前**被调用
+
+</div>
+
 例如 `pages/index.vue`：
 ```html
 <template>

--- a/zh/guide/async-data.md
+++ b/zh/guide/async-data.md
@@ -9,9 +9,9 @@ description: Nuxt.js 扩展了 Vue.js，增加了一个叫 `asyncData` 的方法
   <a href="http://vueschool.io/?friend=nuxt" target="_blank" class="Promote">
     <img src="/async-data-with-nuxtjs.png" srcset="/async-data-with-nuxtjs-2x.png 2x" alt="AsyncData by vueschool"/>
     <div class="Promote__Content">
-      <h4 class="Promote__Content__Title">Async Data with Nuxt.js</h4>
-      <p class="Promote__Content__Description">Learn how to manage asynchronous data with Nuxt.js.</p>
-      <p class="Promote__Content__Signature">Video courses made by VueSchool to support Nuxt.js developpement.</p>
+      <h4 class="Promote__Content__Title">使用Nuxt.js的异步数据</h4>
+      <p class="Promote__Content__Description">了解如何使用Nuxt.js管理异步数据。</p>
+      <p class="Promote__Content__Signature">由VueSchool制作视频课程，用于支持Nuxt.js开发。</p>
     </div>
   </a>
 </div>

--- a/zh/guide/commands.md
+++ b/zh/guide/commands.md
@@ -27,6 +27,7 @@ description: Nuxt.js 提供了一系列常用的命令, 用于开发或发布部
 
 - **`--config-file` 或 `-c`:** 指定 `nuxt.config.js` 的文件路径。
 - **`--spa` 或 `-s`:** 禁用服务器端渲染，使用SPA模式
+- **`--unix-socket` 或 `-n`:** 指定UNIX Socket的路径。
 
 你可以将这些命令添加至 `package.json`：
 

--- a/zh/guide/development-tools.md
+++ b/zh/guide/development-tools.md
@@ -128,40 +128,85 @@ npm install --save-dev babel-eslint eslint eslint-config-standard eslint-plugin-
 ```
 
 然后, 在项目根目录下创建 `.eslintrc.js` 文件用于配置 ESLint：
+
 ```js
 module.exports = {
   root: true,
-  parser: 'babel-eslint',
   env: {
     browser: true,
     node: true
   },
-  extends: 'standard',
+  parserOptions: {
+    parser: 'babel-eslint'
+  },
+  extends: [
+    "eslint:recommended",
+    // https://github.com/vuejs/eslint-plugin-vue#priority-a-essential-error-prevention
+    // consider switching to `plugin:vue/strongly-recommended` or `plugin:vue/recommended` for stricter rules.
+    "plugin:vue/recommended",
+    "plugin:prettier/recommended"
+  ],
   // 校验 .vue 文件
   plugins: [
-    'html'
+    'vue'
   ],
   // 自定义规则
-  rules: {},
-  globals: {}
+  rules: {
+    "semi": [2, "never"],
+    "no-console": "off",
+    "vue/max-attributes-per-line": "off",
+    "prettier/prettier": ["error", { "semi": false }]
+  }
 }
 ```
 
-最后，我们在 `package.json` 文件中添加一个 `lint` 脚本命令：
+最后，我们在 `package.json` 文件中添加一个 `lint`和 `lintfix`脚本命令：
 
 ```js
 "scripts": {
-  "lint": "eslint --ext .js,.vue --ignore-path .gitignore ."
+  "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
+  "lintfix": "eslint --fix --ext .js,.vue --ignore-path .gitignore ."
 }
 ```
 
-通过以上配置，可使用以下命令对项目的代码进行 ESLint 校验：
+你现在可以启动`lint`来检查错误：
+
 ```bash
 npm run lint
 ```
 
-ESLint 会校验应用所有的 JavaScript 和 Vue 文件，除了在 `.gitignore` 中忽略了的之外。
+或者 `lintfix` 还可以修复那些可修复的
 
+```bash
+npm run lintfix
+```
+
+ESLint将忽略所有JavaScript和Vue文件，同时忽略``.gitignore`中定义的被忽略文件。
+
+还建议通过webpack启用ESLint热更新模式。这样ESLint将在`npm run dev`时保存。只需将以下内容添加到您的`nuxt.config.js`：
+
+```js
+...
+  /*
+   ** Build configuration
+  */
+  build: {
+   /*
+    ** 您可以在这里扩展webpack配置
+   */
+   extend(config, ctx) {
+      // Run ESLint on save
+      if (ctx.isDev && ctx.isClient) {
+        config.module.rules.push({
+          enforce: "pre",
+          test: /\.(js|vue)$/,
+          loader: "eslint-loader",
+          exclude: /(node_modules)/
+        })
+      }
+    }
+  }
+```
 <div class="Alert Alert--orange">
 
 有个最佳实践是在 `package.json` 中增加 `"precommit": "npm run lint"` ，这样可以实现每次提交代码之前自动进行代码检测校验。

--- a/zh/guide/directory-structure.md
+++ b/zh/guide/directory-structure.md
@@ -5,6 +5,14 @@ description: Nuxt.js 的应用目录架构提供了良好的代码分层结构�
 
 > Nuxt.js 的应用目录架构提供了良好的代码分层结构，适用于开发或大或小的应用。 当然，你也可以根据自己的偏好组织应用代码。
 
+<div class="Promo__Video">
+  <a href="https://vueschool.io/lessons/guided-nuxtjs-project-tour?friend=nuxt" target="_blank">
+    <p class="Promo__Video__Icon">
+      观看有关Vue School上 <strong>Nuxt.js目录结构</strong> 的免费课程 
+    </p>
+  </a>
+</div>
+
 ## 目录
 
 ### 资源目录

--- a/zh/guide/index.md
+++ b/zh/guide/index.md
@@ -29,6 +29,7 @@ Nuxt.js 集成了以下组件/框架，用于开发完整而强大的 Web 应用
 - [Vue 2](https://github.com/vuejs/vue)
 - [Vue-Router](https://github.com/vuejs/vue-router)
 - [Vuex](https://github.com/vuejs/vuex) (当配置了 [Vuex 状态树配置项](/guide/vuex-store) 时才会引入)
+- [Vue 服务器端渲染](https://ssr.vuejs.org/en/) (排除使用 [`mode: 'spa'`](/api/configuration-mode))
 - [Vue-Meta](https://github.com/declandewet/vue-meta)
 
 压缩并 gzip 后，总代码大小为：**57kb** （如果使用了 Vuex 特性的话为 60kb）。
@@ -56,13 +57,11 @@ Nuxt.js 集成了以下组件/框架，用于开发完整而强大的 Web 应用
 
 ![nuxt-schema](/nuxt-schema.svg)
 
-## 服务端渲染
+## 服务端渲染(通过SSR)
 
-你可以使用 Nuxt.js 作为你项目的UI渲染框架。
+您可以使用**Nuxt.js**作为框架来处理项目的所有UI呈现。
 
-当运行 `nuxt` 命令时，会启动一个支持 `热加载` 和 `服务端渲染`（基于Vue.js的 `vue-server-renderer` 模块）的开发服务器。
-
-可以查看 Nuxt.js 提供的各种 [命令](/guide/commands) 以了解更多的信息。
+启动时`nuxt`，它将启动具有热更新加载的开发服务器，并且[Vue 服务器端渲染](https://ssr.vuejs.org/en/)配置为自动为服务器呈现应用程序。
 
 ### 单页应用程序 (SPA)
 
@@ -78,6 +77,17 @@ Nuxt.js 集成了以下组件/框架，用于开发完整而强大的 Web 应用
 支持 Vue.js 应用的静态化算是 Nuxt.js 的一个创新点，通过 `nuxt generate` 命令实现。
 
 该命令依据应用的路由配置将每一个路由静态化成为对应的 HTML 文件。
+
+<div>
+  <a href="https://vueschool.io/courses/static-site-generation-with-nuxtjs?friend=nuxt" target="_blank" class="Promote">
+    <img src="/static-site-generation-with-nuxtjs.png" alt="Static Site Generation with Nuxt.js by vueschool"/>
+    <div class="Promote__Content">
+      <h4 class="Promote__Content__Title">使用Nuxt.js生成静态站点</h4>
+      <p class="Promote__Content__Description">了解如何生成静态站点(预渲染)用来提高性能和搜索引擎优化(SEO)，同时减少站点托管成本。</p>
+      <p class="Promote__Content__Signature">由VueSchool制作视频课程，用于支持Nuxt.js开发</p>
+    </div>
+  </a>
+</div>
 
 例如，以下文件结构：
 

--- a/zh/guide/installation.md
+++ b/zh/guide/installation.md
@@ -9,9 +9,9 @@ description: "Nuxt.js 十分简单易用。一个简单的项目只需将 `nuxt`
   <a href="https://vueschool.io/courses/nuxtjs-fundamentals/?friend=nuxt" target="_blank" class="Promote">
     <img src="/nuxt-fundamentals.png" srcset="/nuxt-fundamentals-2x.png 2x" alt="Nuxt Fundamentals by vueschool"/>
     <div class="Promote__Content">
-      <h4 class="Promote__Content__Title">Nuxt.js Fundamentals</h4>
-      <p class="Promote__Content__Description">Learn how to get started quickly with Nuxt.js in videos.</p>
-      <p class="Promote__Content__Signature">Video courses made by VueSchool to support Nuxt.js developpement.</p>
+      <h4 class="Promote__Content__Title">Nuxt.js 基础知识</h4>
+      <p class="Promote__Content__Description">了解如何在视频中快速使用Nuxt.js</p>
+      <p class="Promote__Content__Signature">由VueSchool制作视频课程，用于支持Nuxt.js开发</p>
     </div>
   </a>
 </div>
@@ -59,6 +59,7 @@ $ yarn create nuxt-app <项目名>
 当运行完时，它将安装所有依赖项，因此下一步是启动项目:
 
 ```bash
+$ cd <project-name>
 $ npm run dev
 ```
 

--- a/zh/guide/modules.md
+++ b/zh/guide/modules.md
@@ -22,6 +22,16 @@ description: 模块是Nuxt.js扩展，可以扩展其核心功能并添加无限
 - 通常是在短期限内完成，没有时间深入了解每个新库或集成的细节。
 - 厌倦了处理对低级接口的重大改变，并且需要能够正常工作的东西。
 
+## Nuxt.js 模块列表
+
+Nuxt.js 团队提供 **官方** 模块:
+- [@nuxt/http](https://http.nuxtjs.org): 基于[ky-universal](https://github.com/sindresorhus/ky-universal)的轻量级和通用的HTTP请求
+- [@nuxtjs/axios](https://axios.nuxtjs.org): 安全和使用简单Axios与Nuxt.js集成用来请求HTTP
+- [@nuxtjs/pwa](https://pwa.nuxtjs.org): 使用经过严格测试，更新且稳定的PWA解决方案来增强Nuxt
+- [@nuxtjs/auth](https://auth.nuxtjs.org): Nuxt.js的身份验证模块，提供不同的方案和验证策略
+
+Nuxt.js社区制作的模块列表可在 https://github.com/topics/nuxt-module 中查询
+
 ## 基本模块
 
 如上所述，模块只是简单的功能。它们可以打包为`npm`模块或直接包含在项目源代码中。
@@ -308,6 +318,53 @@ export default function () {
   })
 }
 ```
+
+## Module package commands
+
+**实验性的**
+
+从`v2.4.0` 开始，您可以通过Nuxt模块的包(package)添加自定义nuxt命令。为此，您必须`NuxtCommand`在定义命令时遵循API规则。假设放置的一个简单示例`my-module/bin/command.js`如下所示：
+
+```js
+#!/usr/bin/env node
+
+const consola = require('consola')
+const { NuxtCommand } = require('@nuxt/cli')
+
+NuxtCommand.run({
+  name: 'command',
+  description: 'My Module Command',
+  usage: 'command <foobar>',
+  options: {
+    foobar: {
+      alias: 'fb',
+      type: 'string',
+      description: 'Simple test string'
+    }
+  },
+  run(cmd) {
+    consola.info(cmd.argv)
+  }
+})
+```
+
+这里有一些值得注意的事情。首先，注意调用`/usr/bin/env`来检索Node可执行文件。另请注意，ES模块语法不能用于命令，除非您手动合并[`esm`](https://github.com/standard-things/esm)到代码中。
+
+接下来，您将注意到如何使用`NuxtCommand.run()`指定命令的设置和行为。定义选项`options`，通过解析[`minimist`](https://github.com/substack/minimist)。解析参数后，`run()``将使用`NuxtCommand`实例作为第一个参数自动调用。
+
+在上面的示例中，`cmd.argv`用于检索解析的命令行参数。有更多的方法和属性`NuxtCommand` --将提供有关它们的文档，因为此功能将进一步测试和改进。
+
+要使您的命令可以通过Nuxt CLI识别`bin`，请使用`nuxt-module`约定将其列在`package.json`的部分下，该约定module与您的包名称相关。使用此二进制文件，您可以根据`argv`需要进一步解析更多`subcommands`命令。
+
+```js
+{
+  "bin": {
+    "nuxt-foobar": "./bin/command.js"
+  }
+}
+```
+
+一旦安装了软件包(通过NPM或Yarn)，您就可以`nuxt foobar ...`在命令行上执行。
 
 <div class="Alert">
 

--- a/zh/guide/plugins.md
+++ b/zh/guide/plugins.md
@@ -61,6 +61,18 @@ module.exports = {
 
 想了解更多关于 `plugins` 的配置，请参考 [插件 API 文档](/api/configuration-plugins)。
 
+### ES6 插件
+
+如果插件位于`node_modules`并导出模块，需要将其添加到`transpile`构建选项：
+
+```js
+module.exports = {
+  build: {
+    transpile: ['vue-notifications']
+  }
+}
+```
+您可以参考 [构建配置](/api/configuration-build/#transpile) 文档来获取更多构建选项。
 
 ## 注入 $root 和 context
 

--- a/zh/guide/routing.md
+++ b/zh/guide/routing.md
@@ -59,6 +59,14 @@ router: {
 
 在 Nuxt.js 里面定义带参数的动态路由，需要创建对应的**以下划线作为前缀**的 Vue 文件 或 目录。
 
+<div class="Promo__Video">
+  <a href="https://vueschool.io/lessons/nuxtjs-dynamic-routes?friend=nuxt" target="_blank">
+    <p class="Promo__Video__Icon">
+      观看Vue School出品的 <strong>动态路由</strong> 免费课程
+    </p>
+  </a>
+</div>
+
 以下目录结构：
 
 ```bash

--- a/zh/guide/typescript.md
+++ b/zh/guide/typescript.md
@@ -11,6 +11,173 @@ title: 支持 TypeScript
 > - 支持TS编译 (`nuxt.config.ts`, `modules`, `serverMiddlewares`)
 > - 支持TSX
 
-## 遇到 `nuxt-ts`: TypeScript Nuxt
+## 快速开始
 
-开始使用 [TypeScript Nuxt](/examples/typescript).
+为了能够在项目中使用TypeScript，您需要将`@nuxt/typescript`和`ts-node`作为开发依赖项安装：
+
+```sh
+npm i -D @nuxt/typescript
+npm i ts-node
+# OR
+yarn add -D @nuxt/typescript
+yarn add ts-node
+```
+
+<div class="Alert Alert--gray">
+
+`@nuxt/typescript`提供了在单独的进程来编译TypeScript文件和检查类型所需的typescript相关依赖项。
+
+</div>
+
+<div class="Alert Alert--gray">
+
+`ts-node`扩展了Nuxt核心，为`nuxt.config.ts`和`serverMiddlewares`开启了运行时TypeScript支持。
+
+</div>
+
+您还需要通过代码编辑器或命令行在根项目文件夹中创建一个空的`tsconfig.json`文件：
+
+```sh
+touch tsconfig.json
+```
+
+<div class="Alert Alert--gray">
+
+**提示：** `tsconfig.json`文件将在您第一次运行`nuxt`命令时使用默认值自动更新。
+
+</div>
+
+## 从 JavaScript 到 TypeScript
+
+### 配置文件
+
+为了能够在配置文件中使用TypeScript，您只需要将`nuxt.config.js`重命名为`nuxt.config.ts`。
+
+Nuxt.js还带有提供自动补全和类型检查的类型定义：
+
+```ts
+import NuxtConfiguration from '@nuxt/config'
+
+const config: NuxtConfiguration = {
+  // Type or Press `Ctrl + Space` for autocompletion
+}
+
+export default config
+```
+
+### 组件
+
+在组件中，我们强烈建议使用依赖于[vue-property-decorator](https://github.com/kaorun343/vue-property-decorator)的[vue-class-component](https://github.com/vuejs/vue-class-component)。
+
+以下是可复用组件用来显示使用Nuxt中 `asyncData`获取的数据展示在页面中的基本示例。
+
+```ts
+/* models/Post.ts */
+export default interface Post {
+  id: number
+  title: string
+  description: string
+}
+```
+
+```html
+<!-- components/PostPreview.vue -->
+<template>
+  <div>
+    <h2>{{ post.title }}</h2>
+    <p>{{ post.description }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+import Post from '~/models/Post'
+
+@Component
+export default class PostPreview extends Vue {
+  @Prop({ type: Object, required: true }) post!: Post
+}
+</script>
+```
+
+```html
+<!-- pages/feed.vue -->
+<template>
+  <div>
+    <PostPreview v-for="post in posts" :key="post.id" :post="post" />
+  </div>
+</template>
+
+<script lang="ts">
+import axios from 'axios'
+import { Component, Vue } from 'vue-property-decorator'
+import Post from '~/models/Post'
+
+@Component({
+  components: {
+    PostPreview: () => import('~/components/PostPreview.vue')
+  },
+  async asyncData () {
+    let { data } = await axios.get(`https://my-api/posts`)
+    return {
+      posts: data
+    }
+  }
+})
+export default class FeedPage extends Vue {
+  posts: Post[] = []
+}
+</script>
+```
+
+您可以对**布局组件(`layouts`)**使用完全相同的逻辑。
+
+## 使用ESLint
+
+If you're using ESLint to lint your project, here is how you can make ESLint lint your TypeScript files.
+如果您正在使用ESLint来对项目进行代码规范检查，那么您可以使用以下方法将ESLint添加进来：
+<div class="Alert Alert--teal">
+
+**重点：** 我们假设您已经在项目中设置了[nuxt/eslint-config](https://github.com/nuxt/eslint-config)。
+
+</div>
+
+首先，您需要安装[typescript-eslint](https://github.com/typescript-eslint/typescript-eslint)插件：
+
+```sh
+npm install -D @typescript-eslint/eslint-plugin
+# OR
+yarn add -D @typescript-eslint/eslint-plugin
+```
+
+然后，通过添加`@typescript-eslint`插件并使`@typescript-eslint/parser`作为默认解析器来编辑ESLint配置(`.eslintrc.js`)。
+
+最轻量化配置应如下所示：
+
+```js
+module.exports = {
+  plugins: ['@typescript-eslint'],
+  parserOptions: {
+    parser: '@typescript-eslint/parser'
+  },
+  extends: [
+    '@nuxtjs'
+  ],
+  rules: {
+    '@typescript-eslint/no-unused-vars': 'error'
+  }
+}
+
+```
+
+最后，添加或编辑`package.json`的`lint`脚本：
+
+```json
+"lint": "eslint --ext .ts,.js,.vue --ignore-path .gitignore ."
+```
+
+> `--ignore-path` option is useful to prevent ESLint linting files/folders like `node_modules`, `.nuxt` or whatever you don't want it to lint.
+
+--ignore-path选项对于忽略某些不想被检查的文件或文件夹(例如`node_modules`，`.nuxt`或任何您不希望它被检查的文件或者文件夹)非常有用。
+
+您现在可以通过运行`npm run lint` (或者 `yarn lint`)来检查您的TypeScript文件的代码风格错误或其他不规范。

--- a/zh/guide/views.md
+++ b/zh/guide/views.md
@@ -131,6 +131,14 @@ export default {
 
 页面组件实际上是 Vue 组件，只不过 Nuxt.js 为这些组件添加了一些特殊的配置项（对应 Nuxt.js 提供的功能特性）以便你能快速开发通用应用。
 
+<div class="Promo__Video">
+  <a href="https://vueschool.io/lessons/nuxtjs-page-components?friend=nuxt" target="_blank">
+    <p class="Promo__Video__Icon">
+      观看Vue School出品的 <strong>Nuxt.js 页面组件</strong> 的免费课程 
+    </p>
+  </a>
+</div>
+
 ```html
 <template>
   <h1 class="red">Hello {{ name }}!</h1>

--- a/zh/guide/vuex-store.md
+++ b/zh/guide/vuex-store.md
@@ -5,6 +5,14 @@ description: 对于每个大项目来说，使用状态树 (store) 管理状态 
 
 > 对于每个大项目来说，使用状态树 (store) 管理状态 (state) 十分有必要。这就是为什么 Nuxt.js 内核实现了 [Vuex](https://github.com/vuejs/vuex)。
 
+<div class="Promo__Video">
+  <a href="https://vueschool.io/lessons/utilising-the-vuex-store-nuxtjs?friend=nuxt" target="_blank">
+    <p class="Promo__Video__Icon">
+    在Vue School 上观看关于<strong>Nuxt.js 和 Vuex</strong> 的免费课程
+    </p>
+  </a>
+</div>
+
 ## 使用状态树
 
 Nuxt.js 会尝试找到应用根目录下的 `store` 目录，如果该目录存在，它将做以下的事情：
@@ -14,8 +22,12 @@ Nuxt.js 会尝试找到应用根目录下的 `store` 目录，如果该目录存
 3. 设置 `Vue` 根实例的 `store` 配置项
 
 Nuxt.js 支持两种使用 `store` 的方式，你可以择一使用：
-- **普通方式：** `store/index.js` 返回一个 Vuex.Store 实例
+
 - **模块方式：** `store` 目录下的每个 `.js` 文件会被转换成为状态树[指定命名的子模块](http://vuex.vuejs.org/en/modules.html) （当然，`index` 是根模块）
+
+- **Classic(不建议使用)：** `store/index.js`返回创建Vuex.Store实例的方法。
+
+无论使用那种模式，您的`state`的值应该**始终是**`function`，为了避免返回引用类型，会导致多个实例相互影响。
 
 ### 普通方式
 
@@ -231,7 +243,11 @@ actions: {
 
 `export const strict = false`
 
-### 普通方式
+### 经典模式
+
+> 此功能已经弃用，将在Nuxt 3中删除。
+
+要使用经典模式创建Vuex，我们应该创建`store/index.js`到处返回Vuex实例的方法的文件：
 
 ```js
 import Vuex from 'vuex'
@@ -251,4 +267,14 @@ const createStore = () => {
 }
 
 export default createStore
+```
+
+> 我们不需要安装，因为Vuex由Nuxt.js提供。
+
+我们现在可以在我们的组件中使用`this.$store`：
+
+```html
+<template>
+  <button @click="$store.commit('increment')">{{ $store.state.counter }}</button>
+</template>
 ```

--- a/zh/lang.json
+++ b/zh/lang.json
@@ -1,6 +1,6 @@
 {
   "iso": "zh",
-  "docVersion": "2.4.x",
+  "docVersion": "2.6.x",
   "links": {
     "api": "API",
     "blog": "博客",


### PR DESCRIPTION
## 中文

### 新增:speech_balloon: 

* API分类，`.nuxtignore`文档新增

* API分类，render模块: `fallback`新增，并增加目录索引：`ssr`, `static`, `dist`, 'csp'等

* API分类，router模块: `prefetchLinks`, `scrollBehavior`, `linkPrefetchedClass`等文档新增

* API分类， nuxt-link模块： `no-prefetch`等文档新增

* Guide分类， modules模块：模块列表，module package commands 等

* Guide分类， plugins模块：ES6插件

* Guide分类， typescript模块新增TS使用


### 删除 :fire:

* API分类，asyncData模块： 删除表格，重复

### 修复 :bug:

* 更新版本号为: 2.6.X版本

* Gui分类，Vuex中修正中文文档错误

------

## English

### News :speech_balloon: 

* API, new to `.nuxtignore` document

* API, render module: `fallback` added, and add directory index: `ssr`, `static`, `dist`, 'csp', etc.

* API, router module: `prefetchLinks`, `scrollBehavior`, `linkPrefetchedClass`

* API, nuxt-link module: new documentation such as `no-prefetch`

* Guide, modules module: module list, module package commands

* Guide, plugins module: ES6 plugin

* Guide, typescript module added TS use


### Remove :fire:

* API，asyncData： Delete form, repeat

### Repair :bug:

* The updated version number is: 2.6.X version

* Guide, Vuex fix Chinese document error