### PR TITLE
fr: fix <router-link> docs URL

### DIFF
--- a/fr/api/components-nuxt-link.md
+++ b/fr/api/components-nuxt-link.md
@@ -7,7 +7,7 @@ description: Lie les pages entre elles avec `<nuxt-link>`.
 
 > Ce composant est utilisé pour lier les composants de page entre eux.
 
-Actuellement, `<nuxt-link>` est identique à [`<router-link>`](https://router.vuejs.org/fr/api/router-link.html). Nous vous recommandons d'apprendre à l'utiliser avec la [documentation de Vue Router](https://router.vuejs.org/fr/api/router-link.html).
+Actuellement, `<nuxt-link>` est identique à [`<router-link>`](https://router.vuejs.org/fr/api/#router-link). Nous vous recommandons d'apprendre à l'utiliser avec la [documentation de Vue Router](https://router.vuejs.org/fr/api/#router-link).
 
 Exemple (`pages/index.vue`) :
 


### PR DESCRIPTION
Fix two dead links for the French translation of the [`<nuxt-link>` page](https://fr.nuxtjs.org/api/components-nuxt-link/).