### PR TITLE
Add documentation for key property

### DIFF
--- a/en/api/menu.json
+++ b/en/api/menu.json
@@ -11,6 +11,7 @@
       { "name": "asyncData", "to": "/" },
       { "name": "fetch", "to": "/pages-fetch" },
       { "name": "head", "to": "/pages-head" },
+      { "name": "key", "to": "/pages-key" },
       { "name": "layout", "to": "/pages-layout" },
       { "name": "loading", "to": "/pages-loading" },
       { "name": "middleware", "to": "/pages-middleware" },

--- a/en/api/pages-key.md
+++ b/en/api/pages-key.md
@@ -1,0 +1,21 @@
+---
+title: "API: The key Property"
+description: Set the `key` property of internal `<router-view>` component
+---
+
+# The key Property
+
+> Set the `key` property of internal `<router-view>` component
+- **Type:** `String` or `Function`
+
+The `key` property is propagated into `<router-view>`, which is useful to make transitions inside a dynamic page and different route. Different keys result in rerendering of page components.
+
+There are several ways to set the key. For more details, please refer to the `nuxtChildKey` prop in [the nuxt component](/api/components-nuxt).
+
+```js
+export default {
+  keys(route) {
+    return route.fullPath
+  }
+}
+```

--- a/ja/api/menu.json
+++ b/ja/api/menu.json
@@ -11,6 +11,7 @@
       { "name": "asyncData", "to": "/" },
       { "name": "fetch", "to": "/pages-fetch" },
       { "name": "head", "to": "/pages-head" },
+      { "name": "key", "to": "/pages-key" },
       { "name": "layout", "to": "/pages-layout" },
       { "name": "loading", "to": "/pages-loading" },
       { "name": "middleware", "to": "/pages-middleware" },

--- a/ja/api/pages-key.md
+++ b/ja/api/pages-key.md
@@ -1,0 +1,22 @@
+---
+title: "key プロパティ"
+description: 内部の `<router-view>` コンポーネントに `key` プロパティを設定します
+---
+
+# key プロパティ
+
+> 内部の `<router-view>` コンポーネントに `key` プロパティを設定します。
+
+- **型:** `String` or `Function`
+
+各ページコンポーネントで設定された `key` プロパティは内部の `<router-view>` の `key` プロパティとして設定されます。この `key` プロパティは動的ページでのルートトランジションに使われます。違うキーを持つルートの場合ページコンポーネントを再レンダリングします。
+
+`<router-view>` の `key` プロパティを設定する方法は他にもあります。詳細については [nuxt コンポーネント](/api/components-nuxt)の `nuxtChildKey` プロパティを参照してください。
+
+```js
+export default {
+  keys(route) {
+    return route.fullPath
+  }
+}
+```

--- a/ko/api/menu.json
+++ b/ko/api/menu.json
@@ -5,6 +5,7 @@
       { "name": "API: asyncData 메소드", "to": "/" },
       { "name": "API: fetch 메소드", "to": "/pages-fetch" },
       { "name": "API: head 메서드", "to": "/pages-head" },
+      { "name": "API: key 프로퍼티", "to": "/pages-key" },
       { "name": "API: layout 프로퍼티", "to": "/pages-layout" },
       { "name": "API: middleware 프로퍼티", "to": "/pages-middleware" },
       { "name": "API: scrollToTop 프로퍼티", "to": "/pages-scrolltotop" },

--- a/ko/api/pages-key.md
+++ b/ko/api/pages-key.md
@@ -1,0 +1,22 @@
+---
+title: "API: key 프로퍼티"
+description: 내부의 `<router-view>` 컴포넌트의 `key` 프로퍼티를 설정합니다.
+---
+
+# key 프로퍼티
+
+> 내부의 `<router-view>` 컴포넌트의 `key` 프로퍼티를 설정합니다.
+
+- **타입:** `String` 또는 `Function`
+
+각 페이지에 설정된 `key` 프로퍼티는 `<router-view>`로 전달됩니다. 전달된 `key` 프로퍼티는 동적 페이지에서 여러 라우트간의 트랜지션을 만드는데 사용될 수 있습니다. 서로 다른 키를 사용하는 라우트의 경우 페이지 컴포넌트를 새로 렌더링합니다.
+
+`<router-view>`의 `key` 프로퍼티를 세팅하는 방법은 여러가지가 있습니다. 더 자세한 내용에 대해서는 [nuxt 컴포넌트](/api/components-nuxt)의 `nuxtChildKey` 프로퍼티를 참고하세요.
+
+```js
+export default {
+  keys(route) {
+    return route.fullPath
+  }
+}
+```


### PR DESCRIPTION
Related: https://github.com/nuxt/nuxt.js/pull/5516

There is an undocumented `key` property for page components.

I've added the documentation for EN, KO and JA.

EN and JA are not my mother tongue, so please feel free to review and comment. Will follow up quickly.

cc: @inouetakuya @potato4d