### PR TITLE
doc: remove 'watchQuery' section from 'nuxtChildKey' doc

### DIFF
--- a/de/api/components-nuxt.md
+++ b/de/api/components-nuxt.md
@@ -49,10 +49,6 @@ There are 3 ways to handle internal `key` prop of `<router-view/>`.
   }
   ```
 
-3. `watchQuery` option in page components: `boolean` or `string[]`
-
-  Queries specified in [watchQuery](/api/pages-watchquery) option will be considered on building the key. If `watchQuery` is `true`, `fullPath` is used.
-
 - name: `string` (_introduced with Nuxt v2.4.0_)
   - This prop will be set to `<router-view/>`, used to render named-view of page component.
   - Default: `default`

--- a/en/api/components-nuxt.md
+++ b/en/api/components-nuxt.md
@@ -49,10 +49,6 @@ There are 3 ways to handle internal `key` prop of `<router-view/>`.
   }
   ```
 
-3. `watchQuery` option in page components: `boolean` or `string[]`
-
-  Queries specified in [watchQuery](/api/pages-watchquery) option will be considered on building the key. If `watchQuery` is `true`, `fullPath` is used.
-
 - name: `string` (_introduced with Nuxt v2.4.0_)
   - This prop will be set to `<router-view/>`, used to render named-view of page component.
   - Default: `default`

--- a/es/api/components-nuxt.md
+++ b/es/api/components-nuxt.md
@@ -49,10 +49,6 @@ There are 3 ways to handle internal `key` prop of `<router-view/>`.
   }
   ```
 
-3. `watchQuery` option in page components: `boolean` or `string[]`
-
-  Queries specified in [watchQuery](/api/pages-watchquery) option will be considered on building the key. If `watchQuery` is `true`, `fullPath` is used.
-
 - name: `string` (_introduced with Nuxt v2.4.0_)
   - This prop will be set to `<router-view/>`, used to render named-view of page component.
   - Default: `default`

--- a/ja/api/components-nuxt.md
+++ b/ja/api/components-nuxt.md
@@ -49,10 +49,6 @@ description: レイアウト内でページコンポーネントを表示しま�
   }
   ```
 
-3. 各ページコンポーネントの `watchQuery` オプション: `boolean` or `string[]`
-
-  [watchQuery](/api/pages-watchquery) に設定されたクエリはキーを生成するとき考慮されます。 `watchQuery` が `true` の場合は `fullPath` が使われます。
-
 - name：`string` (_Nuxt v2.4.0で導入されました_)
   - この prop は `<router-view/>` に設定され、ページコンポーネントの名前付きビューをレンダリングするのに利用されます。
   - デフォルト: `default`

--- a/ko/api/components-nuxt.md
+++ b/ko/api/components-nuxt.md
@@ -49,10 +49,6 @@ description: 레이아웃 내부의 페이지 컴포넌트를 보여줍니다.
   }
   ```
 
-3. 각 페이지 컴포넌트의 `watchQuery` 옵션: `boolean` or `string[]`
-
-  [watchQuery](/api/pages-watchquery) 옵션에 설정한 쿼리는 키를 생성할 때 고려됩니다. 만약 `watchQuery`가 `true`라면 `fullPath`를 사용하게 됩니다.
-
 - name: `string` (_introduced with Nuxt v2.4.0_)
   - 이 속성은 `<router-view/>`의 속성으로 설정됩니다. 페이지 컴포넌트의 named-view를 렌더링 하는데 사용됩니다.
   - 기본값: `default`


### PR DESCRIPTION
Related: https://github.com/nuxt/nuxt.js/pull/5757

With the pull request above, `watchQuery` no more affects `nuxtChildKey`.