### PR TITLE
Link to webpack code splitting is broken on filenames entry

### DIFF
--- a/configuration-build.md
+++ b/configuration-build.md
@@ -246,7 +246,7 @@ export default {
 }
 ```
 
-To understand a bit more about the use of manifests, take a look at this [webpack documentation](https://webpack.js.org/guides/code-splitting-libraries/).
+To understand a bit more about the use of manifests, take a look at this [webpack documentation](https://webpack.js.org/guides/code-splitting/).
 
 ## friendlyErrors
 


### PR DESCRIPTION
https://webpack.js.org/guides/code-splitting-libraries/ is broken on filename entry: replace it with https://webpack.js.org/guides/code-splitting/