### PR TITLE
docs(contribution-guide): added link to nuxt repo

### DIFF
--- a/en/guide/contribution-guide.md
+++ b/en/guide/contribution-guide.md
@@ -23,7 +23,7 @@ or [bug report](https://bug.nuxtjs.org/).
 
 ### Getting started
 
-1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
+1. [Fork](https://help.github.com/articles/fork-a-repo/) the [Nuxt repository](https://github.com/nuxt/nuxt.js) to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 2. Run `npm install` or `yarn install` to install the dependencies.
 
 > _Note that both **npm** and **yarn** have been seen to miss installing dependencies. To remedy that, you can either delete the `node_modules` folder in your example app and install again or do a local install of the missing dependencies._


### PR DESCRIPTION
Added a link directly to the nuxt repo as saying fork this repo is wrong as you are not in the repo you are on the docs website