### PR TITLE
fix a typo

### DIFF
--- a/en/api/pages-key.md
+++ b/en/api/pages-key.md
@@ -14,7 +14,7 @@ There are several ways to set the key. For more details, please refer to the `nu
 
 ```js
 export default {
-  keys(route) {
+  key(route) {
     return route.fullPath
   }
 }


### PR DESCRIPTION
property 'keys' to 'key'