### PR TITLE
Updated en-docs about page transitions

### DIFF
--- a/en/api/pages-transition.md
+++ b/en/api/pages-transition.md
@@ -90,7 +90,7 @@ You can also define methods in the `pageTransition`, these are for the [JavaScri
 
 ### Transition Mode
 
-**Default transition mode for pages differs from the default mode in VueJS**. The `pageTransition` mode is by default set to `out-in`. If you want to run leaving and entering transitions simultaneously, you have to set the mode to empty string `mode:""`. 
+**The default transition mode for pages differs from the default mode in Vue.js**. The `pageTransition` mode is by default set to `out-in`. If you want to run leaving and entering transitions simultaneously, you have to set the mode to the empty string `mode: ''`. 
 
 ```js
 export default {

--- a/en/api/pages-transition.md
+++ b/en/api/pages-transition.md
@@ -3,7 +3,7 @@ title: "API: The pageTransition Property"
 description: Nuxt.js uses the `<transition>` component to let you create amazing transitions/animations between your pages.
 ---
 
-# The transition Property
+# The pageTransition Property
 
 > Nuxt.js uses the [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
 

--- a/en/api/pages-transition.md
+++ b/en/api/pages-transition.md
@@ -1,5 +1,5 @@
 ---
-title: "API: The transition Property"
+title: "API: The pageTransition Property"
 description: Nuxt.js uses the `<transition>` component to let you create amazing transitions/animations between your pages.
 ---
 
@@ -7,28 +7,30 @@ description: Nuxt.js uses the `<transition>` component to let you create amazing
 
 > Nuxt.js uses the [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
 
+> Nuxt v2.7.0 introduces key "pageTransition" in favor of the "transition" key to consolidate the naming with layout transition keys. From the Nuxt v3.0.0 will be the "transition" key deprecated.
+
 - **Type:** `String` or `Object` or `Function`
 
-To define a custom transition for a specific route, simply add the `transition` key to the page component.
+To define a custom transition for a specific route, simply add the `pageTransition` key to the page component.
 
 ```js
 export default {
   // Can be a String
-  transition: ''
+  pageTransition: ''
   // Or an Object
-  transition: {}
+  pageTransition: {}
   // or a Function
-  transition (to, from) {}
+  pageTransition (to, from) {}
 }
 ```
 
 ## String
 
-If the `transition` key is set as a string, it will be used as the `transition.name`.
+If the `pageTransition` key is set as a string, it will be used as the `transition.name`.
 
 ```js
 export default {
-  transition: 'test'
+  pageTransition: 'test'
 }
 ```
 
@@ -40,11 +42,11 @@ Nuxt.js will use these settings to set the component as follows:
 
 ## Object
 
-If the `transition` key is set as an object:
+If the `pageTransition` key is set as an object:
 
 ```js
 export default {
-  transition: {
+  pageTransition: {
     name: 'test',
     mode: 'out-in'
   }
@@ -57,7 +59,7 @@ Nuxt.js will use these settings to set the component as follows:
 <transition name="test" mode="out-in">
 ```
 
-The `transition` object can have the following properties:
+The `pageTransition` object can have the following properties:
 
 | key                | Type      | Default    | definition                                                                                                                                                                                                                 |
 |--------------------|-----------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -73,7 +75,7 @@ The `transition` object can have the following properties:
 | `leaveToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
 | `leaveActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
 
-You can also define methods in the `transition`, these are for the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
+You can also define methods in the `pageTransition`, these are for the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
 
 - `beforeEnter(el)`
 - `enter(el, done)`
@@ -86,13 +88,26 @@ You can also define methods in the `transition`, these are for the [JavaScript h
 
 *Note: it’s also a good idea to explicitly add `css: false` for JavaScript-only transitions so that Vue can skip the CSS detection. This also prevents CSS rules from accidentally interfering with the transition.*
 
-## Function
+### Transition Mode
 
-If the `transition` key is set as a function:
+**Default transition mode for pages differs from the default mode in VueJS**. The `pageTransition` mode is by default set to `out-in`. If you want to run leaving and entering transitions simultaneously, you have to set the mode to empty string `mode:""`. 
 
 ```js
 export default {
-  transition (to, from) {
+  pageTransition: {
+    name: 'test',
+    mode: ''
+  }
+}
+```
+
+## Function
+
+If the `pageTransition` key is set as a function:
+
+```js
+export default {
+  pageTransition (to, from) {
     if (!from) return 'slide-left'
     return +to.query.page < +from.query.page ? 'slide-right' : 'slide-left'
   }


### PR DESCRIPTION
- change `transition` key to `pageTransition`
- added info from which version and when `transition` will be deprecated
- added subsection about transition mode