### PR TITLE
fix: use backquotation for the keywords in "API: The Context" chapter

### DIFF
--- a/de/api/context.md
+++ b/de/api/context.md
@@ -1,6 +1,6 @@
 ---
 title: "API: The Context"
-description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`.
+description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, `middlewares`, `modules`, and `store/nuxtServerInit`.
 ---
 
 ## Context

--- a/en/api/context.md
+++ b/en/api/context.md
@@ -1,6 +1,6 @@
 ---
 title: "API: The Context"
-description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`.
+description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, `middlewares`, `modules`, and `store/nuxtServerInit`.
 ---
 
 # The Context

--- a/fr/api/context.md
+++ b/fr/api/context.md
@@ -1,6 +1,6 @@
 ---
 title: "API : le contexte"
-description: L'objet `context` fournit des objets et paramètres additionnels en provenance de Nuxt qui ne sont pas traditionnellement disponibles dans les composants Vue. Le `context` est disponible dans des aires de cycle de vie spécifique à Nuxt. On y retrouve, par exemple, `asyncData`, `plugins`, 'middlewares', 'modules', et 'store/nuxtServerInit`.
+description: L'objet `context` fournit des objets et paramètres additionnels en provenance de Nuxt qui ne sont pas traditionnellement disponibles dans les composants Vue. Le `context` est disponible dans des aires de cycle de vie spécifique à Nuxt. On y retrouve, par exemple, `asyncData`, `plugins`, `middlewares`, `modules`, et `store/nuxtServerInit`.
 ---
 
 ## Contexte

--- a/id/api/context.md
+++ b/id/api/context.md
@@ -2,8 +2,8 @@
 title: 'API: Konteks (Context)'
 description: Konteks (`context`) menyediakan objek/parameter tambahan dari Nuxt yang
   tidak tersedia secara tradisional untuk komponen Vue. Konteks (`context`) tersedia
-  dalam area siklus (lifecycle) spesial nuxt  seperti `asyncData`, `plugins`, 'middlewares',
-  'modules', dan 'store/nuxtServerInit`.
+  dalam area siklus (lifecycle) spesial nuxt  seperti `asyncData`, `plugins`, `middlewares`,
+  `modules`, dan `store/nuxtServerInit`.
 ---
 
 ## Konteks (Context)

--- a/pt-BR/api/context.md
+++ b/pt-BR/api/context.md
@@ -1,6 +1,6 @@
 ---
 title: "API: The Context"
-description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, 'middlewares', 'modules', and 'store/nuxtServerInit`.
+description: The `context` provides additional objects/params from Nuxt not traditionally available to Vue components. The `context` is available in special nuxt lifecycle areas like `asyncData`, `plugins`, `middlewares`, `modules`, and `store/nuxtServerInit`.
 ---
 
 ## Context


### PR DESCRIPTION
some of the keywords in the section does not wrapped in back quotations correctly so that it shows like below; 'middleware', 'modules', and 'nuxtServerInit`.
![Screenshot from 2019-06-24 01-52-47](https://user-images.githubusercontent.com/14945055/59979427-cb936600-9622-11e9-9ff8-bae850de13a1.png)

This PR fixes it in some languages which have `api/context.md`.