### PR TITLE
docs: configuration-generate

### DIFF
--- a/en/api/configuration-generate.md
+++ b/en/api/configuration-generate.md
@@ -11,6 +11,15 @@ description: Configure the generation of your universal web application to a sta
 
 When launching `nuxt generate` or calling `nuxt.generate()`, Nuxt.js will use the configuration defined in the `generate` property.
 
+nuxt.config.js 
+```js
+export default {
+  generate: {
+    ...
+  }
+}
+```
+
 ## dir
 
 - Type: `String`
@@ -202,6 +211,15 @@ Example:
 
 When set to false, HTML files are generated according to the route path:
 
+nuxt.config.js 
+```js
+export default {
+  generate: {
+    subFolders: false
+  }
+}
+```
+
 ```bash
 -| dist/
 ---| index.html
@@ -209,6 +227,7 @@ When set to false, HTML files are generated according to the route path:
 ---| products/
 -----| item.html
 ```
+
 
 _Note: this option could be useful using [Netlify](https://netlify.com) or any static hosting using HTML fallbacks._
 


### PR DESCRIPTION
Sometimes it's not obvious what the generate property is and how to modify it especially if you are not generating dynamic pages therefore don't have a generated property in your nuxt.config.js and one isn't there by default. Adding an example might make things a bit clearer especially for the subFolders option which I think is one that might be used a lot. We could of course add the example for each one to make it even clearer but explaining what other options you could have for example the fallback default is 200, what else would you put or are these things that nobody will change therefore we are just telling people that they are there. It would be great to have a better understanding of some of these generate features.