### PR TITLE
en: Update development-tools.md

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -22,13 +22,8 @@ Then add a test script to our `package.json` and configure AVA to compile files 
   "test": "ava",
 },
 "ava": {
-  "require": [
-    "babel-register"
-  ]
-},
-"babel": {
-  "presets": [
-    "env"
+  "files": [
+    "test/**/*"
   ]
 }
 ```


### PR DESCRIPTION
Its no longer necessary define babel configs because conflicts with the Ava have by default, and cause some conflicts
In addition, if you write your tests inside a test folder, you need to define it in the package.json, ava object, with the `files` key
https://github.com/avajs/ava#latest-javascript-support