### PR TITLE
ja: fix: use backquotation for the keywords

### DIFF
--- a/ja/api/context.md
+++ b/ja/api/context.md
@@ -1,8 +1,6 @@
 ---
 title: 'API: コンテキスト'
-description: "`context`は、従来 Vue コンポーネントが使用できないオブジェクト/パラメータを Nuxt から追加で提供します。`context`は`
-  asyncData`、 `plugins`、 'middlewares'、 'modules' や 'store / nuxtServerInit` といった
-  nuxt の特別なライフサイクル内で使用できます。"
+description: "`context` は、従来 Vue コンポーネントが使用できないオブジェクト/パラメータを Nuxt から追加で提供します。`context` は `asyncData`、`plugins`、`middlewares`、`modules` や `store / nuxtServerInit` といった nuxt の特別なライフサイクル内で使用できます。"
 ---
 
 # コンテキスト


### PR DESCRIPTION
fix: [[doc] fix: use backquotation for the keywords · Issue #195 · vuejs-jp/ja.docs.nuxtjs](https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/195)
