### PR TITLE
Provide deployment doc for serverMiddleware

### DIFF
--- a/en/api/configuration-servermiddleware.md
+++ b/en/api/configuration-servermiddleware.md
@@ -84,3 +84,8 @@ serverMiddleware: [
     '~/api/logger'
 ]
 ```
+
+## Deploying Server Middleware
+
+When deploying server middleware it is a requirement that the middleware is also copied over during the build proces. It should reside in the `dist/server` directory.
+


### PR DESCRIPTION
There was no previous indication that serverMiddleware had to be deployed to production and copied anywhere in order to function correctly. This should help users identify that this is a requirement as of now.