### PR TITLE
en: add upgrading instructions

### DIFF
--- a/en/guide/upgrading.md
+++ b/en/guide/upgrading.md
@@ -1,0 +1,27 @@
+---
+title: Upgrading
+description: Upgrading Nuxt.js is quick, but more involved than updating your package.json
+---
+
+> Upgrading Nuxt.js is quick, but more involved than updating your package.json
+
+## Getting Started
+
+1. Check the [https://nuxtjs.org/guide/release-notes](https://nuxtjs.org/guide/release-notes) for the version you wish to upgrade to to see if there are any additional instructions for that particular release.
+2. Update the version specified for the `nuxt` package in your `package.json` file.
+
+After this step instructions vary depending upon whether you are using Yarn or NPM. _[Yarn](https://yarnpkg.com/en/docs/usage) is the preferred package manager for working with Nuxt as it is the development tool which tests have been written against._
+
+## Yarn
+
+3. remove `yarn.lock` file
+4. remove `node_modules` directory
+5. Run the `yarn` command
+6. After installation has completed and you have run your tests consider upgrading other dependencies as well. The `yarn outdated` command can be used.
+
+## NPM
+
+3. remove `package-lock.json` file
+4. remove `node_modules` directory
+5. Run the `npm install` command
+6. After installation has completed and you have run your tests consider upgrading other dependencies as well. The `npm outdated` command can be used.

--- a/en/guide/upgrading.md
+++ b/en/guide/upgrading.md
@@ -7,7 +7,7 @@ description: Upgrading Nuxt.js is quick, but more involved than updating your pa
 
 ## Getting Started
 
-1. Check the [https://nuxtjs.org/guide/release-notes](https://nuxtjs.org/guide/release-notes) for the version you wish to upgrade to to see if there are any additional instructions for that particular release.
+1. Check the [/guide/release-notes](https://nuxtjs.org/guide/release-notes) for the version you wish to upgrade to to see if there are any additional instructions for that particular release.
 2. Update the version specified for the `nuxt` package in your `package.json` file.
 
 After this step instructions vary depending upon whether you are using Yarn or NPM. _[Yarn](https://yarnpkg.com/en/docs/usage) is the preferred package manager for working with Nuxt as it is the development tool which tests have been written against._


### PR DESCRIPTION
Hi, I recently had a [frustrating experience](https://github.com/nuxt/nuxt.js/issues/6079) trying to upgrade. While trying to upgrade to 2.8.1 I couldn't find clear instructions on how to upgrade. I eventually found the instructions on previous versions (2.6.0, 2.3.1), but it took a while to find them and once I did find them I wasn't confident they were still relevant to the version I wanted to upgrade to.

I imagine I'm not alone in wishing these instructions were featured more prominently in the documentation. I've taken the instructions from the 2.6.0 release and expanded upon them in order to make them more explicit. I can also see this being a section on the Installation page or the FAQ page.

Not sure if I'm following protocol for a submission so please let me know how I can help. Thanks!