### PR TITLE
Promote using ava test context to pass nuxt

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -65,10 +65,6 @@ import test from 'ava'
 import { Nuxt, Builder } from 'nuxt'
 import { resolve } from 'path'
 
-// We keep a reference to Nuxt so we can close
-// the server at the end of the test
-let nuxt = null
-
 // Init Nuxt.js and start listening on localhost:4000
 test.before('Init Nuxt.js', async t => {
   const rootDir = resolve(__dirname, '..')
@@ -77,13 +73,15 @@ test.before('Init Nuxt.js', async t => {
   config.rootDir = rootDir // project folder
   config.dev = false // production build
   config.mode = 'universal' // Isomorphic application
-  nuxt = new Nuxt(config)
+  const nuxt = new Nuxt(config)
+  t.context.nuxt = nuxt // We keep a reference to Nuxt so we can close the server at the end of the test
   await new Builder(nuxt).build()
   nuxt.listen(4000, 'localhost')
 })
 
 // Example of testing only generated html
 test('Route / exits and render HTML', async t => {
+  const { nuxt } = t.context
   let context = {}
   const { html } = await nuxt.renderRoute('/', context)
   t.true(html.includes('<h1 class="red">Hello world!</h1>'))
@@ -91,6 +89,7 @@ test('Route / exits and render HTML', async t => {
 
 // Example of testing via DOM checking
 test('Route / exists and renders HTML with CSS applied', async t => {
+  const { nuxt } = t.context
   const window = await nuxt.renderAndGetWindow('http://localhost:4000/')
   const element = window.document.querySelector('.red')
   t.not(element, null)
@@ -101,6 +100,7 @@ test('Route / exists and renders HTML with CSS applied', async t => {
 
 // Close the Nuxt server
 test.after('Closing server', t => {
+  const { nuxt } = t.context
   nuxt.close()
 })
 ```


### PR DESCRIPTION
Ava supports [test context](https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#test-context), which can be used to pass Nuxt server instance. It's a better practice because you don't have to deal with scope variables declared here and there, and also your test functions become more pure and isolated.