### PR TITLE
Fix the link to vue-meta Nuxt.js example

### DIFF
--- a/en/guide/views.md
+++ b/en/guide/views.md
@@ -200,7 +200,7 @@ More information about the pages properties usage: [API Pages](/api)
 
 Nuxt.js uses [vue-meta](https://github.com/nuxt/vue-meta) to update the `document head` and `meta attributes` of your application.
 
-The `vue-meta` Nuxt.js uses can be found [on GitHub](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/index.js#L29-L35)
+The `vue-meta` Nuxt.js uses can be found [on GitHub](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/index.js#L42-L48).
 
 <div class="Alert Alert--teal">
 


### PR DESCRIPTION
Fixed line numbers in the URL and added a dot.