### PR TITLE
fix: rename backer to nuxter

### DIFF
--- a/de/lang.json
+++ b/de/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "Become A Partner",
     "backer_sponsors": "Sponsors",
     "backer_become_a_sponsor": "Become A Sponsor",
-    "backer_backers": "Backers",
-    "backer_become_a_backer": "Become A Backer",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Become A Nuxter",
     "backer_foundations": "Foundations"
   },
   "sponsors": {

--- a/es/lang.json
+++ b/es/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "Become A Partner",
     "backer_sponsors": "Sponsors",
     "backer_become_a_sponsor": "Become A Sponsor",
-    "backer_backers": "Backers",
-    "backer_become_a_backer": "Become A Backer",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Become A Nuxter",
     "backer_foundations": "Foundations"
   },
   "sponsors": {

--- a/id/lang.json
+++ b/id/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "Become A Partner",
     "backer_sponsors": "Sponsors",
     "backer_become_a_sponsor": "Become A Sponsor",
-    "backer_backers": "Backers",
-    "backer_become_a_backer": "Become A Backer",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Become A Nuxter",
     "backer_foundations": "Foundations"
   },
   "sponsors": {

--- a/ja/lang.json
+++ b/ja/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "パートナーになる",
     "backer_sponsors": "スポンサー",
     "backer_become_a_sponsor": "スポンサーになる",
-    "backer_backers": "後援者",
-    "backer_become_a_backer": "後援者になる",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Nuxter になる",
     "backer_foundations": "財団"
   },
   "sponsors": {

--- a/ko/lang.json
+++ b/ko/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "Become A Partner",
     "backer_sponsors": "Sponsors",
     "backer_become_a_sponsor": "Become A Sponsor",
-    "backer_backers": "Backers",
-    "backer_become_a_backer": "Become A Backer",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Become A Nuxter",
     "backer_foundations": "Foundations"
   },
   "sponsors": {

--- a/pt-BR/lang.json
+++ b/pt-BR/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "Become A Partner",
     "backer_sponsors": "Sponsors",
     "backer_become_a_sponsor": "Become A Sponsor",
-    "backer_backers": "Backers",
-    "backer_become_a_backer": "Become A Backer",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Become A Nuxter",
     "backer_foundations": "Foundations"
   },
   "sponsors": {

--- a/ru/lang.json
+++ b/ru/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "Become A Partner",
     "backer_sponsors": "Sponsors",
     "backer_become_a_sponsor": "Become A Sponsor",
-    "backer_backers": "Backers",
-    "backer_become_a_backer": "Become A Backer",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Become A Nuxter",
     "backer_foundations": "Foundations"
   },
   "sponsors": {

--- a/zh/lang.json
+++ b/zh/lang.json
@@ -51,8 +51,8 @@
     "backer_become_a_partner": "Become A Partner",
     "backer_sponsors": "Sponsors",
     "backer_become_a_sponsor": "Become A Sponsor",
-    "backer_backers": "Backers",
-    "backer_become_a_backer": "Become A Backer",
+    "backer_backers": "Nuxters",
+    "backer_become_a_backer": "Become A Nuxter",
     "backer_foundations": "Foundations"
   },
   "sponsors": {


### PR DESCRIPTION
Related: https://github.com/nuxt/docs/commit/16228d9239e86da060c75679c541fa7404af11d0

close: [[doc] fix: rename backer to nuxter · Issue #227 · vuejs-jp/ja.docs.nuxtjs](https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/227)