### PR TITLE
Update path -> url

### DIFF
--- a/en/api/configuration-servermiddleware.md
+++ b/en/api/configuration-servermiddleware.md
@@ -67,7 +67,7 @@ Middleware (`api/logger.js`):
 ```js
 export default function (req, res, next) {
     // req is the Node.js http request object
-    console.log(req.path)
+    console.log(req.url)
 
     // res is the Node.js http response object
 


### PR DESCRIPTION
req.path is not found for the Node versions that I'm using... Perhaps there are some older Node versions that had `req.path`?