### PR TITLE
en: update firebase custom 404.html handling

### DIFF
--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -322,26 +322,7 @@ GitHub Pages and Netlify recognize the `404.html` file automatically, so setting
 
 #### Implementation for Firebase Hosting
 
-To use the fallback on Firebase Hosting, configure `generate.fallback` to `true` and use the following config ([more info](https://firebase.google.com/docs/hosting/url-redirects-rewrites#section-rewrites)):
-
-``` json
-{
-  "hosting": {
-    "public": "dist",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/404.html"
-      }
-    ]
-  }
-}
-```
+Firebase Hosting [can handle](https://firebase.google.com/docs/hosting/full-config#404) the `404.html` file automatically, so setting `generate.fallback` to `true` will render the error page with a default response code of 404.
 
 ## Transitions
 


### PR DESCRIPTION
Firebase Hosting now automatically supports `404.html` with a default 404 status code without having to modify `firebase.json` anymore. Using the previous config from these docs actually resulted in a response code of 200 for Page Not Found errors.