### PR TITLE
en: fix typo in components-client-only.md

### DIFF
--- a/en/api/components-client-only.md
+++ b/en/api/components-client-only.md
@@ -26,7 +26,7 @@ description: Render a component only on client-side, and display a placeholder t
     <client-only placeholder="Loading...">
       <!-- this component will only be rendered on client-side -->
       <comments />
-    </client-side>
+    </client-only>
   </div>
 </template>
 ```


### PR DESCRIPTION
Fixes a typo in the closing tag of `<client-only>`