### PR TITLE
en: fix typo

### DIFF
--- a/en/api/configuration-head.md
+++ b/en/api/configuration-head.md
@@ -31,6 +31,6 @@ You can also use `head` in your components and access to the component data thro
 
 <div class="Alert Alert--teal">
 
-<b>Info:</b> To avoid duplicated meta tags when used in child component, set up an unique identifier with the `hid` key for your meta elements ([read more](https://vue-meta.nuxtjs.org/api/#tagidkeyname)).
+<b>Info:</b> To avoid duplicated meta tags when used in child component, set up a unique identifier with the `hid` key for your meta elements ([read more](https://vue-meta.nuxtjs.org/api/#tagidkeyname)).
 
 </div>


### PR DESCRIPTION
Many people adhere to a belief that you use the article “a” before words that begin with consonants and “an” before words that begin with vowels. But that isn’t the rule.

The real rule is this: You use the article “a” before words that start with a consonant sound and “an” before words that start with a vowel sound. For example, "He has a unique point of view on the subject and talked about it for an hour". The “u” in “unique” makes the “Y” sound—a consonant sound—therefore you use “a” as your article, while the “h” in “hour” sounds like it starts with “ow” — a vowel sound.

(c) Brian A. Klems, https://www.writersdigest.com/online-editor/a-before-consonants-and-an-before-vowels-is-not-the-rule