### PR TITLE
Noting that serverMiddleware can't access nuxt env variables

### DIFF
--- a/en/api/configuration-env.md
+++ b/en/api/configuration-env.md
@@ -61,3 +61,7 @@ after
 ```js
 if ('testing123' == 'testing123')
 ```
+
+## serverMiddleware
+
+As [serverMiddleware](/api/configuration-servermiddleware) is decoupled from the main Nuxt build, `env` variables defined in `nuxt.config.js` are not available there.


### PR DESCRIPTION
Based on this answer: https://github.com/nuxt/nuxt.js/issues/2800#issuecomment-414041637

(It took me quite some time to figure out why it wasn't working on my case; so I'm documenting what's the expected behavior.)