### PR TITLE
Changing the search text to indicate the availability of focus

### DIFF
--- a/en/lang.json
+++ b/en/lang.json
@@ -30,7 +30,7 @@
     "please_wait": "Please wait...",
     "please_define_title": "Please define a title in the front matter",
     "please_define_description": "Please define a description in the front matter",
-    "search": "Search",
+    "search": "Search (\"/\" to focus)",
     "version": "Version"
   },
   "homepage": {


### PR DESCRIPTION
This is a follow up PR from https://github.com/nuxt/nuxtjs.org/issues/233 for changing the search box's placeholder text.

Before:
![image](https://user-images.githubusercontent.com/38608518/66053862-b0ed5900-e550-11e9-8107-acc0df69c70a.png)

With the placeholder text change:
![image](https://user-images.githubusercontent.com/38608518/66053895-bea2de80-e550-11e9-96a3-94b389657b99.png)

