### PR TITLE
Fixing a small typo on SSR CSP property name.

### DIFF
--- a/en/api/configuration-render.md
+++ b/en/api/configuration-render.md
@@ -154,7 +154,7 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 > Use this to configure to load external resources of Content-Security-Policy
 
-Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatiblity` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
+Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
 
 Example (`nuxt.config.js`)
 

--- a/ja/api/configuration-render.md
+++ b/ja/api/configuration-render.md
@@ -153,7 +153,7 @@ pushAssets: (req, res, publicPath, preloadFiles) => preloadFiles
 
 > これは Content-Security-Policy で適用された外部リソースを読み込む設定をするために使用します。
 
-`script-src` ポリシーに `'unsafe-inline'` が含まれている場合、CSP のハッシュは追加されないことに注意してください。これは、ハッシュが存在する場合、ブラウザが `'unsafe-inline'` を無視するためです。CSPv1 の後方互換性のために `'unsafe-inline'` とハッシュの両方の定義が必要な場合は、オプションの `unsafeInlineCompatiblity` を `true` に設定します。
+`script-src` ポリシーに `'unsafe-inline'` が含まれている場合、CSP のハッシュは追加されないことに注意してください。これは、ハッシュが存在する場合、ブラウザが `'unsafe-inline'` を無視するためです。CSPv1 の後方互換性のために `'unsafe-inline'` とハッシュの両方の定義が必要な場合は、オプションの `unsafeInlineCompatibility` を `true` に設定します。
 
 例 (`nuxt.config.js`)
 


### PR DESCRIPTION
Just fixing a minor typo that can create confusion when typing this property (correctly) from memory.

Replacing all occurrences of `unsafeInlineCompatiblity` to `unsafeInlineCompatibility`.

Please watch: https://github.com/nuxt/nuxt.js/pull/6583