### PR TITLE
Fix: sourcemap config

### DIFF
--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -170,7 +170,7 @@ export default {
     extend (config, { isClient }) {
       // Extend only webpack config for client-bundle
       if (isClient) {
-        config.devtool = '#source-map'
+        config.devtool = 'source-map'
       }
     }
   }


### PR DESCRIPTION
## outline
I found `config.devtool = '#source-map'` does not work in Nuxt 2.10.
So I create a pull request to fix it.

## details
This line worked well in nuxt 2.7. However, in Nuxt 2.10 it works not enough. Nuxt2.10 generates some invalid sourcemap files without error. I don't know that this problem depends on whether webpack or nuxt. 