### PR TITLE
ja: improve translate of focus

### DIFF
--- a/ja/lang.json
+++ b/ja/lang.json
@@ -10,7 +10,7 @@
     "api_page_not_found": "API ページが見つかりません",
     "please_define_title": "Frontmatter 内の title を定義してください",
     "please_define_description": "Frontmatter 内の description を定義してください",
-    "search": "検索 (\"/\" で絞り込み)",
+    "search": "検索 (\"/\" でフォーカス)",
     "version": "バージョン"
   },
   "homepage": {


### PR DESCRIPTION
Improve #1652

@inouetakuya @aytdm

> Original message `"/" to focus` means **type "<kbd>/</kbd>" key to focus search input area**, 「絞り込み」has no meaning.
>
> _Originally posted by @hinaloe in https://github.com/nuxt/docs/pull/1652#issuecomment-545508020_