### PR TITLE
fr: update views.md first section title

### DIFF
--- a/fr/guide/views.md
+++ b/fr/guide/views.md
@@ -7,7 +7,7 @@ description: La section des vues décrit tout ce dont vous avez besoin pour conf
 
 ![nuxt-views-schema](/nuxt-views-schema.svg)
 
-## modèle de l'application
+## Document
 
 > Vous pouvez personnaliser le modèle HTML de l'application utilisée par Nuxt.js pour inclure des scripts ou du CSS conditionnel.
 


### PR DESCRIPTION
I'm not sure about this one but something should be done as the menu is using `Document` and the views.md section title related is `modèle de l'application` so the link does not work.

I don't think this term is really used in french and `Document` is simple enough.