### PR TITLE
fix nuxt/docs#1628

### DIFF
--- a/en/api/configuration-extend-plugins.md
+++ b/en/api/configuration-extend-plugins.md
@@ -1,0 +1,29 @@
+---
+title: "API: The extendPlugins Property"
+description: The extendPlugins property lets you customize Nuxt.js plugins.
+---
+
+> The extendPlugins property lets you customize Nuxt.js plugins ([options.plugins](/api/configuration-plugins)).
+
+- Type: `Function`
+- Default: `undefined`
+
+You may want to extend plugins or change plugins order created by Nuxt.js.
+This function accepts array of [plugin](/api/configuration-plugins) objects and should return array of plugin objects.
+
+Example of changing plugins order:
+
+Example (`nuxt.config.js`):
+```js
+export default {
+  extendPlugins: plugins => {
+    const pluginIndex = plugins.findIndex(
+        ({ src }) => src === '~/plugins/shouldBeFirst.js',
+    );
+    const shouldBeFirstPlugin = plugins[pluginIndex];
+    plugins.splice(pluginIndex, 1);
+    plugins.unshift(shouldBeFirstPlugin);
+    return plugins;
+  },
+}
+```

--- a/en/api/internals-builder.md
+++ b/en/api/internals-builder.md
@@ -19,7 +19,8 @@ this.nuxt.hook('build:done', (builder) => {
 Hook                 | Arguments                                  | When
 ---------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------
 `build:before`       | (nuxt, buildOptions)                       | Before Nuxt build started
-`build:prepared`     | (nuxt, buildOptions)                       | The build directories have been created
+`builder:prepared`     | (nuxt, buildOptions)                       | The build directories have been created
+`builder:extendPlugins`| (plugins)                                  | Generating plugins
 `build:templates`    | ({ templatesFiles, templateVars, resolve }) | Generating `.nuxt` template files
 `build:extendRoutes` | (routes, resolve)                          | Generating routes
 `build:config`       | (webpackConfigs)                           | Before configuration of compilers

--- a/en/api/internals-module-container.md
+++ b/en/api/internals-module-container.md
@@ -69,6 +69,10 @@ Allows easily extending webpack build config by chaining [options.build.extend](
 
 Allows easily extending routes by chaining [options.build.extendRoutes](/api/configuration-router#extendroutes) function.
 
+### extendPlugins (fn)
+
+Allows easily extending plugins by chaining [options.extendPlugins](/api/configuration-extend-plugins) function.
+
 ### addModule (moduleOpts, requireOnce)
 
 *Async function*


### PR DESCRIPTION
- fix nuxt/docs#1628, adding extendPlugins docs
- fix internals builder `build:prepare` hook to `builder:prepare`