### PR TITLE
[Docs] Update GA Plugin to `mode: 'client'`

### DIFF
--- a/de/faq/google-analytics.md
+++ b/de/faq/google-analytics.md
@@ -50,7 +50,7 @@ Then, we tell Nuxt.js to import it in our main application:
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/en/faq/google-analytics.md
+++ b/en/faq/google-analytics.md
@@ -48,7 +48,7 @@ Then, we tell Nuxt.js to import it in our main application:
 ```js
 export default {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/es/faq/google-analytics.md
+++ b/es/faq/google-analytics.md
@@ -46,7 +46,7 @@ Then, we tell nuxt.js to import it in our main application:
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/fr/faq/google-analytics.md
+++ b/fr/faq/google-analytics.md
@@ -48,7 +48,7 @@ Puis nous expliquons à Nuxt.js d'importer le plugin dans notre application prin
 ```js
 export default {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/ja/faq/google-analytics.md
+++ b/ja/faq/google-analytics.md
@@ -48,7 +48,7 @@ export default ({ app }) => {
 ```js
 export default {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/ko/faq/google-analytics.md
+++ b/ko/faq/google-analytics.md
@@ -83,7 +83,7 @@ export default ({ app: { router }, store }) => {
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/pt-BR/faq/google-analytics.md
+++ b/pt-BR/faq/google-analytics.md
@@ -50,7 +50,7 @@ Then, we tell Nuxt.js to import it in our main application:
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/ru/faq/google-analytics.md
+++ b/ru/faq/google-analytics.md
@@ -50,7 +50,7 @@ export default ({ app }) => {
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```

--- a/zh/faq/google-analytics.md
+++ b/zh/faq/google-analytics.md
@@ -49,7 +49,7 @@ export default ({ app: { router }, store }) => {
 ```js
 module.exports = {
   plugins: [
-    { src: '~plugins/ga.js', ssr: false }
+    { src: '~plugins/ga.js', mode: 'client' }
   ]
 }
 ```


### PR DESCRIPTION
I have updated to plugin configuration part from `ssr: false`, cause of deprecated, to `mode: 'client'`.