### PR TITLE
Update webpack-plugins.md

### DIFF
--- a/en/faq/webpack-plugins.md
+++ b/en/faq/webpack-plugins.md
@@ -3,7 +3,12 @@ title: How to add webpack plugins?
 description: How to add webpack plugins into my Nuxt.js application?
 ---
 
-In your `nuxt.config.js` file:
+In your `nuxt.config.js` file, under the `build` option, you can pass webpack `plugins`, the same way you would do
+it in [a `webpack.config.js` file](https://webpack.js.org/configuration/plugins/).
+
+In this example we add the webpack built-in [ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/)
+for automatically loading JavaScript modules (_lodash_ and _jQuery_) instead of having to `import` or `require`
+them everywhere.
 
 ```js
 import webpack from 'webpack'
@@ -12,11 +17,15 @@ export default {
   build: {
     plugins: [
       new webpack.ProvidePlugin({
+        // global modules
         '$': 'jquery',
         '_': 'lodash'
-        // ...etc.
       })
     ]
   }
 }
 ```
+
+> Note: You might not need jQuery in a Vue-based app.
+
+With Nuxt, you can also control plugins execution context: if they are meant to be run on the `client` or in the `server` builds (or differentiating `dev` and `prod` builds) within [`build.extend`](/api/configuration-build#extend), where you can manually pass webpack plugins too.


### PR DESCRIPTION
- Provide more context.
- Explain the why `ProvidePlugin` is in the docs and what it does.
- And slight difference with `build.extend` where you can also pass webpack plugins.