### PR TITLE
Added Dokku example config for Yarn users

### DIFF
--- a/en/faq/dokku-deployment.md
+++ b/en/faq/dokku-deployment.md
@@ -11,7 +11,7 @@ We need to tell Dokku to install the `devDependencies` of the project (to be abl
 
 ```bash
 // on Dokku Server
-dokku config:set my-nuxt-app NPM_CONFIG_PRODUCTION=false
+dokku config:set my-nuxt-app NPM_CONFIG_PRODUCTION=false YARN_PRODUCTION=false
 ```
 
 Also, we want our application to listen on the host `0.0.0.0` and run in production mode:


### PR DESCRIPTION
If the project uses Yarn (has a `yarn.lock` file) Dokku will need `YARN_PRODUCTION=false` as an environment variable to disable pruning of `devDependencies`.