### PR TITLE
Update components-client-only.md

### DIFF
--- a/en/api/components-client-only.md
+++ b/en/api/components-client-only.md
@@ -3,7 +3,7 @@ title: "API: The <client-only> Component"
 description: Render a component only on client-side, and display a placeholder text on server-side.
 ---
 
-> This component is used to purposely render a component only on client-side.
+> This component is used to purposely render a component only on client-side. To import a component only on the client, register the component in a [client-side only plugin](/guide/plugins#client-side-only).
 
 <div class="Alert Alert--orange">
 


### PR DESCRIPTION
Adds detail on how to import a component only in the client. This is useful for legacy components that reference `document` or `window` and cannot be imported server-side.