### PR TITLE
Fix to reference loading component correctly

### DIFF
--- a/ko/api/configuration-loading.md
+++ b/ko/api/configuration-loading.md
@@ -104,6 +104,6 @@ export default {
 
 ```js
 module.exports = {
-  loading: '~components/loading.vue'
+  loading: '~/components/loading.vue'
 }
 ```


### PR DESCRIPTION
`~components/loading.vue` doesn't reference the given component properly.

Instead `~/components/loading.vue` worked. (Tested on Nuxt v2.10.2)