### PR TITLE
Fixed typo in nuxt-render-route.md

### DIFF
--- a/en/api/nuxt-render-route.md
+++ b/en/api/nuxt-render-route.md
@@ -36,7 +36,7 @@ new Builder(nuxt)
   .build()
   .then(() => nuxt.renderRoute('/'))
   .then(({ html, error, redirected }) => {
-  // `html` will be always a string
+  // `html` will always be a string
 
     // `error` not null when the error layout is displayed, the error format is:
     // { statusCode: 500, message: 'My error message' }


### PR DESCRIPTION
Fixed a typo in the comments // `html` will be always a string to // `html` will always be a string