### PR TITLE
ja: Add necessary semicolon in nginx-proxy.md

### DIFF
--- a/ja/faq/nginx-proxy.md
+++ b/ja/faq/nginx-proxy.md
@@ -68,7 +68,7 @@ server {
 
     charset utf-8;
 
-    root /var/www/NUXT_PROJECT_PATH/dist
+    root /var/www/NUXT_PROJECT_PATH/dist;
 
     location ~* \.(?:ico|gif|jpe?g|png|woff2?|eot|otf|ttf|svg|js|css)$ {
         expires $expires;


### PR DESCRIPTION
Added a semicolon at the end of document root in nginx-proxy.md :bow:

resolve https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/308

@inouetakuya @aytdm
Please review 🙏