### PR TITLE
Fixed french typo

### DIFF
--- a/fr/api/pages-head.md
+++ b/fr/api/pages-head.md
@@ -27,7 +27,7 @@ export default {
     return {
       title: this.title,
       meta: [
-        // hid est utiliser comme identifiant unique. N'utilisez pas `vmid` car ça ne fonctionnera pas
+        // hid est utilisé comme identifiant unique. N'utilisez pas `vmid` car ça ne fonctionnera pas
         { hid: 'description', name: 'description', content: 'Ma description personnalisée' }
       ]
     }


### PR DESCRIPTION
The verb "utiliser" in the phrase "hid est utiliser" should be spelled "utilisé" like "hid est utilisé".