### PR TITLE
ja: Fix link of guide/typescript.md

### DIFF
--- a/ja/guide/typescript.md
+++ b/ja/guide/typescript.md
@@ -3,4 +3,4 @@ title: TypeScript サポート
 description: "Nuxt.js 公式の TypeScript サポート"
 ---
 
-Nuxt.js は typescript（runtime と buildtime の両方）を完全にサポートしています。ドキュメントについては、[https://typescript.nuxtjs.org/](https://typescript.nuxtjs.org/) を参照してください。
+Nuxt.js は typescript（runtime と buildtime の両方）を完全にサポートしています。ドキュメントについては、[https://typescript.nuxtjs.org/](https://typescript.nuxtjs.org/ja/) を参照してください。


### PR DESCRIPTION
Changed the link to typescript.nuxtjs.org to Japanese directory