### PR TITLE
Minor grammar fix

### DIFF
--- a/en/api/internals-renderer.md
+++ b/en/api/internals-renderer.md
@@ -14,7 +14,7 @@ We can register hooks on certain life cycle events.
 Hook                      | Arguments                | When
 --------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  `render:before`          | (renderer, options)      | Before setting up middleware and resources for the Renderer class, useful to overload some methods or options.
- `render:setupMiddleware` | (app) *connect instance* | Before Nuxt adds it's middleware stack. We can use it to register custom server side middleware.
+ `render:setupMiddleware` | (app) *connect instance* | Before Nuxt adds its middleware stack. We can use it to register custom server side middleware.
  `render:errorMiddleware` | (app) *connect instance* | Before adding Nuxt error middleware, useful to add your own middleware before using Nuxt's. See the [Sentry module](https://github.com/nuxt-community/sentry-module/blob/master/lib/module.js#L122) for more info.
  `render:resourcesLoaded` | (resources)              | Called after resources for renderer are loaded (client manifest, server bundle, etc).
  `render:done`            |  (renderer)              | SSR Middleware and all resources are ready (Renderer ready)


### PR DESCRIPTION
`it's` ➡️ `its`