### PR TITLE
ja: translate `docs(middleware): Make it more clear that middleware key can accept an array of multiple middlewares` to Japanese

### DIFF
--- a/ja/guide/routing.md
+++ b/ja/guide/routing.md
@@ -442,14 +442,14 @@ export default {
 
 これで `stats` ミドルウェアはすべてのルート変更時に呼び出されるようになります。
 
-同様に、特定のレイアウトもしくはページ内にもミドルウェアを追加することができます:
+同様に、特定のレイアウトもしくはページ内にもミドルウェア（複数であっても）を追加することができます:
 
 
 `pages/index.vue` または `layouts/default.vue`
 
 ```js
 export default {
-  middleware: 'stats'
+  middleware: ['auth', 'stats']
 }
 ```
 


### PR DESCRIPTION

@inouetakuya @aytdm
I translated `docs(middleware): Make it more clear that middleware key can accept an array of multiple middlewares` in #1809 to Japanese.
Please review 🙏 

resolve vuejs-jp#336