### PR TITLE
A tiny mistake

### DIFF
--- a/zh/api/configuration-loading.md
+++ b/zh/api/configuration-loading.md
@@ -126,7 +126,7 @@ export default {
 
 ```js
 module.exports = {
-  loading: '~components/loading.vue'
+  loading: '~/components/loading.vue'
 }
 ```
 


### PR DESCRIPTION
The introduction method here should be changed to '~ / components / loading.vue', otherwise an error not found will be reported