### PR TITLE
Fix env name for baseURL

### DIFF
--- a/de/api/configuration-env.md
+++ b/de/api/configuration-env.md
@@ -14,17 +14,17 @@ Example (`nuxt.config.js`):
 ```js
 module.exports = {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-This lets you create a `baseUrl` property that will be equal to the `BASE_URL` environment variable if defined, otherwise, equal to `'http://localhost:3000'`.
+This lets you create a `baseURL` property that will be equal to the `BASE_URL` environment variable if defined, otherwise, equal to `'http://localhost:3000'`.
 
-Then, I can access my `baseUrl` variable with 2 ways:
+Then, I can access my `baseURL` variable with 2 ways:
 
-1. Via `process.env.baseUrl`.
-2. Via `context.env.baseUrl`, see [context API](/api/context).
+1. Via `process.env.baseURL`.
+2. Via `context.env.baseURL`, see [context API](/api/context).
 
 You can use the `env` property for giving public token for example.
 
@@ -36,7 +36,7 @@ For the example above, we can use it to configure [axios](https://github.com/mza
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/en/api/configuration-env.md
+++ b/en/api/configuration-env.md
@@ -16,18 +16,18 @@ Example (`nuxt.config.js`):
 ```js
 export default {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-This lets you create a `baseUrl` property that will be equal to the `BASE_URL` server side environment variable if available or defined. If not, `baseUrl` in client side will be equal to `'http://localhost:3000'`. The server side variable BASE_URL is therefore copied to the client side via the `env` property in the `nuxt.config.js`. 
+This lets you create a `baseURL` property that will be equal to the `BASE_URL` server side environment variable if available or defined. If not, `baseURL` in client side will be equal to `'http://localhost:3000'`. The server side variable BASE_URL is therefore copied to the client side via the `env` property in the `nuxt.config.js`. 
 Alternatively, the other value is defined (http://localhost:3000). 
 
-Then, I can access my `baseUrl` variable in 2 ways:
+Then, I can access my `baseURL` variable in 2 ways:
 
-1. Via `process.env.baseUrl`.
-2. Via `context.env.baseUrl`, see [context API](/api/context).
+1. Via `process.env.baseURL`.
+2. Via `context.env.baseURL`, see [context API](/api/context).
 
 You can use the `env` property for giving a public token for example.
 
@@ -39,7 +39,7 @@ For the example above, we can use it to configure [axios](https://github.com/mza
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/es/api/configuration-env.md
+++ b/es/api/configuration-env.md
@@ -14,17 +14,17 @@ Example (`nuxt.config.js`):
 ```js
 module.exports = {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-This lets me create a `baseUrl` property that will be equal to the `BASE_URL` environment variable if defined, otherwise, equal to `http://localhost:3000`.
+This lets me create a `baseURL` property that will be equal to the `BASE_URL` environment variable if defined, otherwise, equal to `http://localhost:3000`.
 
-Then, I can access my `baseUrl` variable with 2 ways:
+Then, I can access my `baseURL` variable with 2 ways:
 
-1. Via `process.env.baseUrl`
-2. Via `context.env.baseUrl`, see [context api](/api#context)
+1. Via `process.env.baseURL`
+2. Via `context.env.baseURL`, see [context api](/api#context)
 
 You can use the `env` property for giving public token for example.
 
@@ -35,7 +35,7 @@ For the example above, we can use it to configure [axios](https://github.com/mza
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/fr/api/configuration-env.md
+++ b/fr/api/configuration-env.md
@@ -16,18 +16,18 @@ Exemple (`nuxt.config.js`):
 ```js
 export default {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-Cela nous permet de créer une propriété `baseUrl` qui sera égale à la valeur de `BASE_URL`, la variable d'environement côté serveur si définie et accessible. Sinon, `baseUrl` côté client sera égale à `'http://localhost:3000'`. Par conséquent la variable côté serveur BASE_URL est copiée au côté client dans la propriété `env` par l'intermédiaire de `nuxt.config.js`.
+Cela nous permet de créer une propriété `baseURL` qui sera égale à la valeur de `BASE_URL`, la variable d'environement côté serveur si définie et accessible. Sinon, `baseURL` côté client sera égale à `'http://localhost:3000'`. Par conséquent la variable côté serveur BASE_URL est copiée au côté client dans la propriété `env` par l'intermédiaire de `nuxt.config.js`.
 Autrement, la valeur sera (http://localhost:3000). 
 
-à partir de là, Nous pouvons accéder à `baseUrl` de 2 manières:
+à partir de là, Nous pouvons accéder à `baseURL` de 2 manières:
 
-1. Via `process.env.baseUrl`.
-2. Via `context.env.baseUrl`, voir [context API](/api/context).
+1. Via `process.env.baseURL`.
+2. Via `context.env.baseURL`, voir [context API](/api/context).
 
 If you define environment variables starting with `NUXT_ENV_` in the build phase (f.ex. `NUXT_ENV_COOL_WORD=freezing nuxt build`, they'll be automatically injected into the process environment. Be aware that they'll potentially take precedence over defined variables in your `nuxt.config.js` with the same name.
 
@@ -43,7 +43,7 @@ Pour l'exemple ci-dessus, nous pouvons l'utiliser pour configurer [axios](https:
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/id/api/configuration-env.md
+++ b/id/api/configuration-env.md
@@ -14,17 +14,17 @@ Contoh (`nuxt.config.js`):
 ```js
 module.exports = {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-Ini memungkinkan kita membuat properti `baseUrl` yang akan sama dengan variabel lingkungan (environment) `BASE_URL` jika terdefinisi, tetapi jika tidak, properti baseUrl akan sama dengan `http://localhost:3000`.
+Ini memungkinkan kita membuat properti `baseURL` yang akan sama dengan variabel lingkungan (environment) `BASE_URL` jika terdefinisi, tetapi jika tidak, properti baseURL akan sama dengan `http://localhost:3000`.
 
-Kemudian, kita bisa mengakses variabel `baseUrl` di atas dengan 2 cara:
+Kemudian, kita bisa mengakses variabel `baseURL` di atas dengan 2 cara:
 
-1. Melalui `process.env.baseUrl`, atau
-2. Melalui `context.env.baseUrl`, lihat [context api](/api/context)
+1. Melalui `process.env.baseURL`, atau
+2. Melalui `context.env.baseURL`, lihat [context api](/api/context)
 
 Anda dapat menggunakan properti `env` untuk memberikan "public token" sebagai contoh.
 
@@ -36,7 +36,7 @@ Untuk contoh di atas, kita bisa menggunakannya untuk mengkonfigurasi [axios](htt
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/ja/api/configuration-env.md
+++ b/ja/api/configuration-env.md
@@ -16,18 +16,18 @@ env プロパティはクライアントサイドで使用できる環境変数�
 ```js
 export default {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-これにより、利用可能または定義されていれば、サーバーサイドの環境変数 `BASE_URL` と等しい `baseUrl` プロパティが作成することができます。もしそうでなければ、クライアントサイドの `baseUrl` は `http://localhost:3000` と等しくなります。したがってサーバーサイドの環境変数 BASE_URL は `nuxt.config.js` の `env` プロパティを経由してクライアントサイドにコピーされます。
+これにより、利用可能または定義されていれば、サーバーサイドの環境変数 `BASE_URL` と等しい `baseURL` プロパティが作成することができます。もしそうでなければ、クライアントサイドの `baseURL` は `http://localhost:3000` と等しくなります。したがってサーバーサイドの環境変数 BASE_URL は `nuxt.config.js` の `env` プロパティを経由してクライアントサイドにコピーされます。
 あるいは、他の値が定義されます（http://localhost:3000）。
 
-そして `baseUrl` 変数にアクセスするには 2つの方法があります:
+そして `baseURL` 変数にアクセスするには 2つの方法があります:
 
-1. `process.env.baseUrl` 経由でアクセスする
-2. `context.env.baseUrl` を経由する。詳細は [コンテキスト API](/api/context)
+1. `process.env.baseURL` 経由でアクセスする
+2. `context.env.baseURL` を経由する。詳細は [コンテキスト API](/api/context)
 
 例えば `env` プロパティを使って公開トークンを付与することができます。
 
@@ -39,7 +39,7 @@ export default {
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/ko/api/configuration-env.md
+++ b/ko/api/configuration-env.md
@@ -14,16 +14,16 @@ description: 클라이언트와 서버 사이 공유되는 환경 변수.
 ```js
 module.exports = {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-`BASE_URL`가 정의되어 있다면, `baseUrl` 프로피티를 만들 수 있으며 `baseUrl`은 `http://localhost:3000`과 같습니다.
+`BASE_URL`가 정의되어 있다면, `baseURL` 프로피티를 만들 수 있으며 `baseURL`은 `http://localhost:3000`과 같습니다.
 
-자신의 `baseUrl`로 접근할 2가지 방법이 있습니다:
-1. `process.env.baseUrl`
-2. `context.baseUrl`, [context api](/api#context) 페이지로 확인할 수 있습니다.
+자신의 `baseURL`로 접근할 2가지 방법이 있습니다:
+1. `process.env.baseURL`
+2. `context.baseURL`, [context api](/api#context) 페이지로 확인할 수 있습니다.
 
 예제의 public token을 제공하기 위해 `env` 프로퍼티를 사용합니다.
 
@@ -34,7 +34,7 @@ module.exports = {
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/pt-BR/api/configuration-env.md
+++ b/pt-BR/api/configuration-env.md
@@ -14,17 +14,17 @@ Example (`nuxt.config.js`):
 ```js
 module.exports = {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-This lets me create a `baseUrl` property that will be equal to the `BASE_URL` environment variable if defined, otherwise, equal to `http://localhost:3000`.
+This lets me create a `baseURL` property that will be equal to the `BASE_URL` environment variable if defined, otherwise, equal to `http://localhost:3000`.
 
-Then, I can access my `baseUrl` variable with 2 ways:
+Then, I can access my `baseURL` variable with 2 ways:
 
-1. Via `process.env.baseUrl`
-2. Via `context.env.baseUrl`, see [context api](/api/context)
+1. Via `process.env.baseURL`
+2. Via `context.env.baseURL`, see [context api](/api/context)
 
 You can use the `env` property for giving public token for example.
 
@@ -35,7 +35,7 @@ For the example above, we can use it to configure [axios](https://github.com/mza
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 

--- a/zh/api/configuration-env.md
+++ b/zh/api/configuration-env.md
@@ -14,16 +14,16 @@ description: Nuxt.js 让你可以配置在客户端和服务端共享的环境�
 ```js
 module.exports = {
   env: {
-    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 }
 ```
 
-以上配置我们创建了一个 `baseUrl` 环境变量，如果应用设定了 `BASE_URL` 环境变量，那么 `baseUrl` 的值等于 `BASE_URL` 的值，否则其值为 `http://localhost:3000`。
+以上配置我们创建了一个 `baseURL` 环境变量，如果应用设定了 `BASE_URL` 环境变量，那么 `baseURL` 的值等于 `BASE_URL` 的值，否则其值为 `http://localhost:3000`。
 
-然后， 我们可以通过以下两种方式来使用 `baseUrl` 变量：
-1. 通过 `process.env.baseUrl`
-2. 通过 `context.baseUrl`，请参考 [context api](/api#上下文对象)
+然后， 我们可以通过以下两种方式来使用 `baseURL` 变量：
+1. 通过 `process.env.baseURL`
+2. 通过 `context.baseURL`，请参考 [context api](/api#上下文对象)
 
 你可以使用 `env` 属性配置第三方服务的公钥信息。
 
@@ -34,7 +34,7 @@ module.exports = {
 import axios from 'axios'
 
 export default axios.create({
-  baseURL: process.env.baseUrl
+  baseURL: process.env.baseURL
 })
 ```
 


### PR DESCRIPTION
Hello,

I encountered a problem today which allowed me to identify an error in the documentation (I think).

The `baseUrl` env variable is not considered in my `nuxt.config.js` so I tried `baseURL` which works.

[In the docs](https://nuxtjs.org/api/configuration-env/) it's actually `baseUrl` so my PR only change `baseUrl` into `baseURL`.

My version of Nuxt.JS is 2.11.0
Hope my update is good !

Thank you all for your work :)
