### PR TITLE
docs(eslint-loader): use cache

### DIFF
--- a/en/guide/development-tools.md
+++ b/en/guide/development-tools.md
@@ -198,7 +198,10 @@ It is also recommended to enable ESLint hot reloading mode via webpack. This way
           enforce: "pre",
           test: /\.(js|vue)$/,
           loader: "eslint-loader",
-          exclude: /(node_modules)/
+          exclude: /(node_modules)/,
+          options: {
+            cache: true
+          }
         })
       }
     }


### PR DESCRIPTION
This will fix performance in very large projects. For example, in our project, the `dev` mode (`yarn dev`) was launched without this for **30 minutes**, and after using the cache, for **50 seconds**!!! 