### PR TITLE
en: fix name of flag to --fail-on-error

### DIFF
--- a/en/guide/commands.md
+++ b/en/guide/commands.md
@@ -106,14 +106,14 @@ npm run generate
 
 It will create a `dist` folder with everything inside ready to be deployed on a static hosting site.
 
-To return a non-zero status code when a page error is encountered and let the CI/CD fail the deployment or build, you can use the `--fail-on-page-error` argument.
+To return a non-zero status code when a page error is encountered and let the CI/CD fail the deployment or build, you can use the `--fail-on-error` argument.
 
 ```bash
-npm run generate --fail-on-page-error
+npm run generate --fail-on-error
 
 // OR
 
-yarn generate --fail-on-page-error
+yarn generate --fail-on-error
 ```
 
 If you have a project with [dynamic routes](/guide/routing#dynamic-routes), take a look at the [generate configuration](/api/configuration-generate) to tell Nuxt.js how to generate these dynamic routes.


### PR DESCRIPTION
This flag is called `--fail-on-page-error` in docs, but in code it is actually `--fail-on-error`. That seems incorrect and confusing (at least to me).

See https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/commands/generate.js#L49