### PR TITLE
ja: Add 53able to Japanese primary maintainer(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Chinese translation is maintained by AOTU Labs from China, Shenzhen.
 Japanese translation is maintained by [Vue.js Japan User Group](https://github.com/vuejs-jp/home).
 
 - Translation Repo - [https://github.com/vuejs-jp/ja.docs.nuxtjs](https://github.com/vuejs-jp/ja.docs.nuxtjs)
-- Primary maintainer - [INOUE Takuya(@inouetakuya)](http://blog.inouetakuya.info/), [numa(@aytdm)](https://github.com/aytdm)
-- Primary translator - [INOUE Takuya(@inouetakuya)](https://github.com/inouetakuya), [numa(@aytdm)](https://github.com/aytdm)
+- Primary maintainer - [INOUE Takuya(@inouetakuya)](http://blog.inouetakuya.info/), [numa(@aytdm)](https://github.com/aytdm), [53(@53able)](https://github.com/53able)
+- Primary translator - [INOUE Takuya(@inouetakuya)](https://github.com/inouetakuya), [numa(@aytdm)](https://github.com/aytdm), [53(@53able)](https://github.com/53able)
 
 ### Korean
 


### PR DESCRIPTION
@53able 

対応がめっちゃ遅くなって、ほんっと申し訳ありませんでした（なんか気絶してたのかなと笑っちゃうくらい）

下記を確認お願いします 🙏 

- 表示名
  -  `53` にするのが良いのか `Go Tadano` が良いか迷いました（お好きなほうで）
- リンク先の URL
  - とりあえず GitHub のアカウントページにしていますが、他の方のを見ると結構自由だったりするので「こっちを見てほしい」という URL があれば教えてください