### PR TITLE
Fixed small grammatical errors in english guide

### DIFF
--- a/en/guide/index.md
+++ b/en/guide/index.md
@@ -3,7 +3,7 @@ title: Introduction
 description: "Nuxt is a progressive framework based on Vue.js to create modern web applications. It is based on Vue.js official libraries (vue, vue-router and vuex) and powerful development tools (webpack, Babel and PostCSS)."
 ---
 
-> Nuxt is a progressive framework based on Vue.js to create modern web applications. It is based on Vue.js official libraries (vue, vue-router and vuex) and powerful development tools (webpack, Babel and PostCSS). Nuxt goal is to make web development powerful and performant with a great developer experience in mind.
+> Nuxt is a progressive framework based on Vue.js to create modern web applications. It is based on Vue.js official libraries (vue, vue-router and vuex) and powerful development tools (webpack, Babel and PostCSS). Nuxt's goal is to make web development powerful and performant with a great developer experience in mind.
 
 ## What is NuxtJS?
 
@@ -66,7 +66,7 @@ If, for any reason, you prefer not to use server side rendering or need static h
 
 Take a look at [the commands](/guide/commands) to learn more about usage.
 
-If you already have a server, you can plug Nuxt.js by using it as a middleware. There is no restriction at all when using Nuxt.js for developing your Universal Web Applications. See the [Using Nuxt.js Programmatically](/api/nuxt) guide.
+If you already have a server, you can plug in Nuxt.js by using it as a middleware. There is no restriction at all when using Nuxt.js for developing your Universal Web Applications. See the [Using Nuxt.js Programmatically](/api/nuxt) guide.
 
 ## Static Generated (Pre Rendering)
 


### PR DESCRIPTION
Added a plural ('s) to `Nuxt's goal`

Added "in" to `you can plug in Nuxt.js`