### PR TITLE
ja: Translate guide/commands.md

### DIFF
--- a/ja/guide/commands.md
+++ b/ja/guide/commands.md
@@ -106,14 +106,14 @@ npm run generate
 
 静的なホスティングサイトにデプロイする準備が整ったものが全て入った `dist` フォルダが作成されます。
 
-ページエラーが発生した際に0以外のステータスコードを返し、CI/CD によるデプロイまたはビルドを失敗させるには、 `--fail-on-page-error` 引数を使用することができます。
+ページエラーが発生した際に0以外のステータスコードを返し、CI/CD によるデプロイまたはビルドを失敗させるには、 `--fail-on-error` 引数を使用することができます。
 
 ```bash
-npm run generate --fail-on-page-error
+npm run generate --fail-on-error
 
 // または
 
-yarn generate --fail-on-page-error
+yarn generate --fail-on-error
 ```
 
 


### PR DESCRIPTION
@inouetakuya @aytdm 
resolve https://github.com/vuejs-jp/ja.docs.nuxtjs/issues/346

[コマンドのフラグ名差分](https://github.com/nuxt/docs/commit/a545eef904c4979417e53bfb6ef7666359d0fe7c)に対応しました。
レビューお願い致します🙇‍