### PR TITLE
Fix typo in description of Components Directory

### DIFF
--- a/en/guide/directory-structure.md
+++ b/en/guide/directory-structure.md
@@ -23,7 +23,7 @@ The `assets` directory contains your un-compiled assets such as Stylus or Sass f
 
 ### The Components Directory
 
-The `components` directory contains your Vue.js Components. You can't use either `asyncData` or `fetch` in these components.
+The `components` directory contains your Vue.js Components. You can use either `asyncData` or `fetch` in these components.
 
 ### The Layouts Directory
 

--- a/en/guide/directory-structure.md
+++ b/en/guide/directory-structure.md
@@ -23,7 +23,7 @@ The `assets` directory contains your un-compiled assets such as Stylus or Sass f
 
 ### The Components Directory
 
-The `components` directory contains your Vue.js Components. You can use either `asyncData` or `fetch` in these components.
+The `components` directory contains your Vue.js Components. You can't use `asyncData` in these components.
 
 ### The Layouts Directory
 


### PR DESCRIPTION
can't -> can

I'm new to Nuxt.  While going through the documentation I encountered what I believe is a typo.  If I'm wrong and you **cannot** use `asyncData` or `fetch` then we should change `either` + `or` to `neither` + `nor` or remove `either entirely.

Thanks!