### PR TITLE
fix: correct description of fetchDelay

### DIFF
--- a/en/api/pages-fetch.md
+++ b/en/api/pages-fetch.md
@@ -35,7 +35,7 @@ You can access the Nuxt [context](/api/context) within the fetch hook using `thi
 ### Options
 
 - `fetchOnServer`: `Boolean` (default: `true`), call `fetch()` when server-rendering the page
-- `fetchDelay`: `Integer` (default: `200`), set the minimum executing time in milliseconds (to avoid quick flashes)
+- `fetchDelay`: `Integer` (default: `200`), milliseconds to wait before calling `fetch()` (to avoid rendering flashes)
 
 <div class="Alert Alert--green">
   


### PR DESCRIPTION
The current description of `fetchDelay` states:

> set the minimum executing time in milliseconds (to avoid quick flashes)

While it's true that a delay would establish a minimum execution time, that description itself is not particularly descriptive of its purpose. I think a more helpful description would be:

> milliseconds to wait before calling `fetch()` (to avoid rendering flashes)