### PR TITLE
en: don't pin pug dep

### DIFF
--- a/en/faq/pre-processors.md
+++ b/en/faq/pre-processors.md
@@ -32,7 +32,7 @@ export default data: ->
 To use these pre-processors, we need to install their webpack loaders:
 
 ```bash
-npm install --save-dev pug@2.0.3 pug-plain-loader
+npm install --save-dev pug pug-plain-loader
 ```
 
 ```bash


### PR DESCRIPTION
Pug is now 2.0.4 released. And we have no reason to specify the Pug version anymore.