### PR TITLE
en: remove useless section of heroku deployment.

### DIFF
--- a/en/faq/heroku-deployment.md
+++ b/en/faq/heroku-deployment.md
@@ -13,13 +13,7 @@ We recommend you read the [Heroku documentation for Node.js](https://devcenter.h
   </a>
 </div>
 
-First, we need to tell Heroku to install the `devDependencies` of the project (to be able to launch `npm run build`):
-
-```bash
-heroku config:set NPM_CONFIG_PRODUCTION=false
-```
-
-Also, we want our application to listen on the host `0.0.0.0` and run in production mode:
+First, we want our application to listen on the host `0.0.0.0` and run in production mode:
 
 ```bash
 heroku config:set HOST=0.0.0.0


### PR DESCRIPTION
Hi, 
the NPM_CONFIG_PRODUCTION=false is outdated, and not necessary anymore:

>By default, Heroku will install all dependencies listed in package.json under dependencies and devDependencies.
>After running the installation and build steps Heroku will strip out the packages declared under devDependencies before deploying the application.

https://devcenter.heroku.com/articles/nodejs-support#package-installation