### PR TITLE
en: remove unnecessary env variable from GAE deploy

### DIFF
--- a/en/faq/appengine-deployment.md
+++ b/en/faq/appengine-deployment.md
@@ -36,7 +36,6 @@ handlers:
 
 env_variables:
   HOST: '0.0.0.0'
-  NODE_ENV: 'production'
 ```
 
 or for flexible environment the minimal configuration is:


### PR DESCRIPTION
`NODE_ENV` is set to `production` by Google App Engine itself. No need to redefine it.
https://cloud.google.com/appengine/docs/standard/nodejs/runtime#environment_variables