### PR TITLE
fr: add translation for api (fetch + configuration)

### DIFF
--- a/fr/api/configuration-build.md
+++ b/fr/api/configuration-build.md
@@ -1,0 +1,809 @@
+---
+title: "API: La propriété build"
+description: Nuxt.js vous permet de personnaliser la configuration de webpack pour créer votre application web comme vous le souhaitez.
+---
+
+> Nuxt.js vous permet de personnaliser la configuration de webpack pour créer votre application web comme vous le souhaitez.
+
+## analyze
+
+> Nuxt.js utilise [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) pour vous 
+> permettre de visualiser vos paquets et comment les optimiser.
+
+- Type: `Boolean` ou `Object`
+- Par défaut: `false`
+
+Si c'est un objet, voir les propriétés disponibles [ici](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin).
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    analyze: true,
+    // ou
+    analyze: {
+      analyzerMode: 'static'
+    }
+  }
+}
+```
+
+<div class="Alert Alert--teal">
+
+**Info:** vous pouvez utiliser la commande `yarn nuxt build --analyze` ou `yarn nuxt build -a` pour construire votre application et lancer l'analyseur de paquet [http://localhost:8888](http://localhost:8888). Si vous n'utilisez pas `yarn`, vous pouvez exécuter la commande avec `npx`.
+
+</div>
+
+## babel
+
+> Personnalisez la configuration Babel pour les fichiers JavaScript et Vue. `.babelrc` est ignoré par défaut.
+
+- Type: `Object` Voir les [options](https://github.com/babel/babel-loader#options) de `babel-loader` ainsi que les [options](https://babeljs.io/docs/en/options) de `babel`
+- Par défaut:
+
+  ```js
+  {
+    babelrc: false,
+    cacheDirectory: undefined,
+    presets: ['@nuxt/babel-preset-app']
+  }
+  ```
+
+Les cibles par défaut de [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/index.js) sont `ie: '9'` dans la version `client`, et `node: 'current'` dans la version `server`.
+
+### presets
+
+- Type: `Function`
+- Argument:
+  1. `Object`: { isServer: true | false }
+  2. `Array`:
+      - le nom du préréglage `@nuxt/babel-preset-app`
+      - [`options`](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app#options) de `@nuxt/babel-preset-app`
+
+**Remarque**: Les pré-réglages configurés dans `build.babel.presets` seront appliqués à la fois à la génération du client 
+et du serveur. La cible sera fixée par Nuxt en conséquence (client/serveur). Si vous souhaitez configurer le 
+préréglage différemment pour le client ou la version du serveur, veuillez utiliser `presets` comme fonction:
+
+> Nous **recommandons vivement** d'utiliser le pré-réglage par défaut au lieu de la personnalisation ci-dessous:
+
+```js
+export default {
+  build: {
+    babel: {
+      presets({ isServer }, [ preset, options ]) {
+        // changer les options directement
+        options.targets = isServer ? ... :  ...
+        options.corejs = ...
+        // ne retourne rien
+      }
+    }
+  }
+}
+```
+
+Ou remplacez la valeur par défaut en renvoyant la liste complète des pré-réglages:
+
+```js
+export default {
+  build: {
+    babel: {
+      presets ({ isServer }, [ preset, options ]) {
+        return [
+          [
+            preset, {
+              buildTarget: isServer ? 'server' : 'client',
+              ...options
+            }],
+          [
+            // Autres pré-réglage
+          ]
+        ]
+      }
+    }
+  }
+}
+```
+
+## cache
+
+- Type: `Boolean`
+- Par défaut: `false`
+- ⚠️ Expérimentale
+
+> Activer le cache [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin#options) et [cache-loader](https://github.com/webpack-contrib/cache-loader#cache-loader)
+
+## crossorigin
+
+- Type: `String`
+- Par défaut: `undefined`
+
+  Configurez l'attribut `crossorigin` sur les balises `<link rel="stylesheet">` et `<script>` dans le code HTML généré.
+
+  Plus d'informations: [attributes des paramètres CORS](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
+
+## cssSourceMap
+
+- Type: `boolean`
+- Par défaut: `true` pour le mode dev et `false` pour la production.
+
+> Activer la prise en charge de CSS Source Map
+
+## devMiddleware
+
+- Type: `Object`
+
+Voir [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) pour les options disponibles.
+
+## devtools
+
+- Type: `boolean`
+- Par défaut: `false`
+
+Configurer s'il faut autoriser l'inspection [vue-devtools](https://github.com/vuejs/vue-devtools).
+
+Si vous l'avez déjà activé via `nuxt.config.js` ou autrement, devtools est activé indépendamment de l'indicateur.
+
+## extend
+
+> Étendez manuellement la configuration de webpack pour les paquets client et serveur.
+
+- Type: `Function`
+
+L'extension est appelée deux fois, une fois pour le groupe de serveurs et une fois pour le groupe de clients. Les 
+arguments de la méthode sont:
+
+1. L'objet de configuration Webpack,
+2. Un objet avec les clés suivantes (tous booléens sauf `loaders`): `isDev`, `isClient`, `isServer`, `loaders`.
+
+
+<div class="Alert Alert--orange">
+
+  **Attention:**
+  Les clés `isClient` et `isServer` fournies sont distinctes des clés disponibles dans [`context`](/api/context).
+  Elles ne **sont pas** dépréciées. N'utilisez pas `process.client` et `process.server` ici car elles ne sont pas définies 
+  à ce stade.
+
+</div>
+
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    extend (config, { isClient }) {
+      // Étendre uniquement la configuration de webpack pour le paquet client
+      if (isClient) {
+        config.devtool = 'source-map'
+      }
+    }
+  }
+}
+```
+
+Si vous souhaitez en savoir plus sur notre configuration de webpack par défaut, jetez un œil à notre 
+[répertoire webpack](https://github.com/nuxt/nuxt.js/tree/dev/packages/webpack/src/config).
+
+### loaders in extend
+
+`loaders` a la même structure d'objet que [build.loaders](#loaders), afin que vous puissiez modifier les options des 
+chargement à l'intérieur de `extend`.
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    extend (config, { isClient, loaders: { vue } }) {
+      // Étendre uniquement la configuration de webpack pour le paquet client
+      if (isClient) {
+        vue.transformAssetUrls.video = ['src', 'poster']
+      }
+    }
+  }
+}
+```
+
+## extractCSS
+
+> Active l'extraction CSS commune à l'aide du moteur de rendu Vue Serveur [lignes directrices](https://ssr.vuejs.org/en/css.html).
+
+- Type: `Boolean`
+- Par défaut: `false`
+
+En utilisant [`extract-css-chunks-webpack-plugin`](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) 
+sous le capot, tous vos CSS seront extraits dans des fichiers séparés, généralement un par composant. Cela permet de 
+mettre en cache votre CSS et JavaScript séparément et vaut la peine d'essayer si vous avez beaucoup de CSS globaux 
+ou partagés.
+
+<div class="Alert Alert--teal">
+
+**Remarque:** Il y avait un bug avant Vue 2.5.18 qui supprimait les importations CSS critiques lors de l'utilisation 
+de ces options.
+
+</div>
+
+Vous voudrez peut-être extraire tout votre CSS dans un seul fichier.
+Il existe une solution pour cela:
+
+<div class="Alert Alert--orange">
+⚠️ Il n'est pas recommandé d'extraire tout dans un seul fichier.
+L'extraction dans plusieurs fichiers CSS est meilleure pour la mise en cache et l'isolation de préchargement.
+Cela peut également améliorer les performances des pages en téléchargeant et en résolvant uniquement les ressources 
+nécessaires.
+</div>
+
+```js
+export default {
+  build: {
+    extractCSS: true,
+    optimization: {
+      splitChunks: {
+        cacheGroups: {
+          styles: {
+            name: 'styles',
+            test: /\.(css|vue)$/,
+            chunks: 'all',
+            enforce: true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## filenames
+
+> Personnalisez les noms de fichiers des paquets.
+
+- Type: `Object`
+- Par défaut:
+
+  ```js
+  {
+    app: ({ isDev }) => isDev ? '[name].js' : '[contenthash].js',
+    chunk: ({ isDev }) => isDev ? '[name].js' : '[contenthash].js',
+    css: ({ isDev }) => isDev ? '[name].css' : '[contenthash].css',
+    img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[contenthash:7].[ext]',
+    font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[contenthash:7].[ext]',
+    video: ({ isDev }) => isDev ? '[path][name].[ext]' : 'videos/[contenthash:7].[ext]'
+  }
+  ```
+
+Cet exemple modifie les noms des fichiers en identifiants numériques (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    filenames: {
+      chunk: ({ isDev }) => isDev ? '[name].js' : '[id].[contenthash].js'
+    }
+  }
+}
+```
+
+Pour en savoir un peu plus sur l'utilisation des manifestes, jetez un œil à la [documentation webpack](https://webpack.js.org/guides/code-splitting/).
+
+## friendlyErrors
+
+- Type: `Boolean`
+- Par défaut: `true` (Superposition activée)
+
+Active ou désactive la superposition fournie par [FriendlyErrorsWebpackPlugin](https://github.com/nuxt/friendly-errors-webpack-plugin)
+
+## hardSource
+
+- Type: `Boolean`
+- Par défaut: `false`
+- ⚠️ Expérimentale
+
+Activez [HardSourceWebpackPlugin](https://github.com/mzgoddard/hard-source-webpack-plugin) pour une mise en cache améliorée
+
+## hotMiddleware
+
+- Type: `Object`
+
+Voir [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware) pour les options disponibles.
+
+## html.minify
+
+- Type: `Object`
+- Par défaut:
+
+```js
+{
+  collapseBooleanAttributes: true,
+  decodeEntities: true,
+  minifyCSS: true,
+  minifyJS: true,
+  processConditionalComments: true,
+  removeEmptyAttributes: true,
+  removeRedundantAttributes: true,
+  trimCustomFragments: true,
+  useShortDoctype: true
+}
+```
+
+**Attention:** Si vous apportez des modifications à `html.minify`, elles ne seront pas fusionnées avec les valeurs par défaut!
+
+Configuration du plugin [html-minifier](https://github.com/kangax/html-minifier) utilisé pour minimiser 
+les fichiers HTML créés pendant le processus de construction (seront appliqués pour *tous les modes*).
+
+## indicator
+
+> Affichage de l'indicateur de construction pour le remplacement à chaud du module en cours de développement (disponible dans `v2.8.0+`)
+- Type: `Boolean`
+- Par défaut: `true`
+
+![nuxt-build-indicator](https://user-images.githubusercontent.com/5158436/58500509-93ba0f80-8197-11e9-8524-e115c6d32571.gif)
+
+## loaders
+
+> Personnalisez les options des chargements Webpack intégrés Nuxt.js.
+
+- Type: `Object`
+- Par défaut:
+
+```js
+{
+  file: {},
+  fontUrl: { limit: 1000 },
+  imgUrl: { limit: 1000 },
+  pugPlain: {},
+  vue: {
+    transformAssetUrls: {
+      video: 'src',
+      source: 'src',
+      object: 'src',
+      embed: 'src'
+    }
+  },
+  css: {},
+  cssModules: {
+    localIdentName: '[local]_[hash:base64:5]'
+  },
+  less: {},
+  sass: {
+    indentedSyntax: true
+  },
+  scss: {},
+  stylus: {},
+  vueStyle: {}
+}
+```
+
+> Remarque: En plus de spécifier les configurations dans `nuxt.config.js`, il peut également être modifié par [build.extend](#extend)
+
+### loaders.file
+
+> Plus de détails dans [file-loader options](https://github.com/webpack-contrib/file-loader#options).
+
+### loaders.fontUrl et loaders.imgUrl
+
+>Plus de détails dans [url-loader options](https://github.com/webpack-contrib/url-loader#options).
+
+### loaders.pugPlain
+
+> Plus de détails dans [pug-plain-loader](https://github.com/yyx990803/pug-plain-loader) ou [Pug compiler options](https://pugjs.org/api/reference.html#options).
+
+### loaders.vue
+
+> Plus de détails dans [vue-loader options](https://vue-loader.vuejs.org/options.html).
+
+### loaders.css et loaders.cssModules
+
+> Plus de détails dans [css-loader options](https://github.com/webpack-contrib/css-loader#options). Remarque: chargement des options cssModules pour l'utilisation des [modules CSS](https://vue-loader.vuejs.org/guide/css-modules.html#css-modules)
+
+### loaders.less
+
+> Vous pouvez passer toutes les options moins spécifiques à `less-loader` via `loaders.less`. Voir la [documentation de Less](http://lesscss.org/usage/#command-line-usage-options) pour toutes les options disponibles.
+
+### loaders.sass and loaders.scss
+
+> Voir la documentation [Node Sass](https://github.com/sass/node-sass/blob/master/README.md#options) pour toutes les options Sass disponibles. Remarque: `loaders.sass` est pour la [syntaxe indentée Sass](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html)
+
+### loaders.vueStyle
+
+> Plus de détails dans [vue-style-loader options](https://github.com/vuejs/vue-style-loader#options).
+
+## optimization
+
+- Type: `Object`
+- Par défaut:
+
+  ```js
+  {
+    minimize: true,
+    minimizer: [
+      // terser-webpack-plugin
+      // optimize-css-assets-webpack-plugin
+    ],
+    splitChunks: {
+      chunks: 'all',
+      automaticNameDelimiter: '.',
+      name: undefined,
+      cacheGroups: {}
+    }
+  }
+  ```
+
+La valeur par défaut de `splitChunks.name` est `true` en mode `dev` ou `analyze`.
+
+Vous pouvez définir `minimizer` sur un tableau personnalisé de plugins ou définir `minimize` sur `false` pour désactiver 
+tous les minimiseurs.
+(`minimize` est désactivé par défaut pour le développement)
+
+Voir [l'optimisation de Webpack](https://webpack.js.org/configuration/optimization).
+
+## optimizeCSS
+
+- Type: `Object` or `Boolean`
+- Par défaut:
+  - `false`
+  - `{}` lorsque extractCSS est activé
+
+Options du plugin OptimizeCSSAssets.
+
+Voir [NMFR/optimize-css-assets-webpack-plugin](https://github.com/NMFR/optimize-css-assets-webpack-plugin).
+
+## parallel
+
+- Type: `Boolean`
+- Par défaut: `false`
+- ⚠️ Expérimentale
+
+> Activez [thread-loader](https://github.com/webpack-contrib/thread-loader#thread-loader) dans la construction de webpack
+
+## plugins
+
+> Ajout de plugins webpack
+
+- Type: `Array`
+- Par défaut: `[]`
+
+Exemple (`nuxt.config.js`):
+
+```js
+import webpack from 'webpack'
+import { version } from './package.json'
+export default {
+  build: {
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.VERSION': version
+      })
+    ]
+  }
+}
+```
+
+## postcss
+
+> Personnalisez le plugin [de chargement PostCSS](https://github.com/postcss/postcss-loader#usage).
+
+- Type: `Array` (hérité, remplacera les valeurs par défaut), `Object` (recommandé), `Function` ou `Boolean`
+
+  **Remarque:** Nuxt.js a appliqué [PostCSS Preset Env](https://github.com/csstools/postcss-preset-env). Par défaut, il active les [fonctionnalités Stage 2](https://cssdb.org/) et [Autoprefixer](https://github.com/postcss/autoprefixer), vous pouvez utiliser `build.postcss.preset` pour le configurer.
+
+- Par défaut:
+
+  ```js
+  {
+    plugins: {
+      'postcss-import': {},
+      'postcss-url': {},
+      'postcss-preset-env': this.preset,
+      'cssnano': { preset: 'default' } // disabled in dev mode
+    },
+    order: 'presetEnvAndCssnanoLast',
+    preset: {
+      stage: 2
+    }
+  }
+  ```
+
+Vos paramètres de plugin personnalisés seront fusionnés avec les plugins par défaut (sauf si vous utilisez un `Array` 
+à la place d'un `Object`).
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    postcss: {
+      plugins: {
+        // Désactiver `postcss-url`
+        'postcss-url': false,
+        // Ajouter quelques plugins
+        'postcss-nested': {},
+        'postcss-responsive-type': {},
+        'postcss-hexrgba': {}
+      },
+      preset: {
+        autoprefixer: {
+          grid: true
+        }
+      }
+    }
+  }
+}
+```
+
+Si la configuration postcss est un `Object`, `order` peut être utilisé pour définir l'ordre des plugins:
+
+- Type: `Array` (noms de plugins ordonnés), `String` (nom prédéfini ordonné), `Function`
+- Par défaut: `cssnanoLast` (mettre `cssnano` en dernier)
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    postcss: {
+      // nom prédéfini
+      order: 'cssnanoLast',
+      // noms de plugins ordonnés
+      order: ['postcss-import', 'postcss-preset-env', 'cssnano']
+      // Fonction pour calculer l'ordre des plugins
+      order: (names, presets) => presets.cssnanoLast(names)
+    }
+  }
+}
+```
+### postcss plugins & nuxt-tailwindcss
+
+Si vous souhaitez appliquer le plugin postcss (par exemple postcss-pxtorem) sur la configuration de nuxt-tailwindcss, 
+vous devez changer l'ordre et charger tailwindcss en premier.
+
+**Cette configuration n'a aucun impact sur le nuxt-purgecss.**
+
+Exemple (`nuxt.config.js`):
+
+```js
+import { join } from 'path'
+
+export default {
+  // ...
+  build: {
+    postcss: {
+      plugins: {
+        tailwindcss: join(__dirname, 'tailwind.config.js'),
+        'postcss-pxtorem': {
+          propList: [
+            '*',
+            '!border*',
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+## profile
+
+- Type: `Boolean`
+- Par défaut: activé par l'argument de ligne de commande `--profile`
+
+> Activer le profileur dans [WebpackBar](https://github.com/nuxt/webpackbar#profile)
+
+## publicPath
+
+> Nuxt.js vous permet de télécharger vos fichiers dist sur votre CDN pour des performances maximales, il suffit de définir le `publicPath` sur votre CDN.
+
+- Type: `String`
+- Par défaut: `'/_nuxt/'`
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    publicPath: 'https://cdn.nuxtjs.org'
+  }
+}
+```
+
+Ensuite, lorsque vous lancez `nuxt build`, téléchargez le contenu du répertoire `.nuxt/dist/client` sur votre CDN et voilà!
+
+## quiet
+
+> Supprime la plupart des générations de traces de sortie
+
+- Type: `Boolean`
+- Par défaut: activé lorsqu'un environnement `CI` ou `test` est détecté par [std-env](https://github.com/blindmedia/std-env)
+
+## splitChunks
+
+- Type: `Object`
+- Par défaut:
+
+  ```js
+  {
+    layouts: false,
+    pages: true,
+    commons: true
+  }
+  ```
+
+Si diviser les codes pour `layout`, `pages` et `commons` (bibliothèques communes: vue|vue-loader|vue-router|vuex...).
+
+## ssr
+
+> Crée un paquet webpack spécial pour le rendu SSR.
+
+- Type: `Boolean`
+- Par défaut: `true` pour le mode universel et `false` pour le mode spa
+
+Cette option est automatiquement définie en fonction de la valeur de `mode` si elle n'est pas fournie.
+
+## styleResources
+
+- Type: `Object`
+- Par défaut: `{}`
+
+<div class="Alert Alert--orange">
+
+**Attention:** Cette propriété est dépréciée. Veuillez utiliser [style-resources-module](https://github.com/nuxt-community/style-resources-module/) à la place pour de meilleures performances et un meilleur rendu!
+
+</div>
+
+Ceci est utile lorsque vous devez injecter des variables et des mixins dans vos pages sans avoir les importer à chaque fois.
+
+Nuxt.js utilise [style-resources-loader](https://github.com/yenshih/style-resources-loader) pour obtenir ce comportement.
+
+Vous devez spécifier les motifs/chemin que vous souhaitez inclure pour les pré-processeurs donnés: `less`, `sass`, `scss` 
+ou `stylus`.
+
+Vous ne pouvez pas utiliser d'alias de chemin ici (`~` et `@`), vous devez utiliser des chemins relatifs ou absolus.
+
+`nuxt.config.js`:
+
+```js
+{
+  build: {
+    styleResources: {
+      scss: './assets/variables.scss',
+      less: './assets/*.less',
+      // sass: ...,
+      // scss: ...
+      options: {
+        // Voir https://github.com/yenshih/style-resources-loader#options
+        // Sauf la propriété `patterns`
+      }
+    }
+  }
+}
+```
+
+## templates
+
+> Nuxt.js vous permet de fournir vos propres modèles qui seront rendus en fonction de la configuration de Nuxt. 
+> Cette fonctionnalité est particulièrement utile pour une utilisation avec [modules](/guide/modules).
+
+- Type: `Array`
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    templates: [
+      {
+        src: '~/modules/support/plugin.js', // `src` peut être absolu ou relatif
+        dst: 'support.js', // `dst` est relative au dossier du projet `.nuxt`
+        options: { // Les options sont fournies au modèle comme la clé `options`
+          live_chat: false
+        }
+      }
+    ]
+  }
+}
+```
+
+Les modèles sont rendues à l'aide de [`lodash.template`](https://lodash.com/docs/#template), vous pouvez en savoir plus 
+sur leur utilisation [ici](https://github.com/learn-co-students/javascript-lodash-templates-v-000).
+
+## terser
+
+- Type: `Object` or `Boolean`
+- Par défaut:
+
+```js
+{
+  parallel: true,
+  cache: false,
+  sourceMap: false,
+  extractComments: {
+    filename: 'LICENSES'
+  },
+  terserOptions: {
+    output: {
+      comments: /^\**!|@preserve|@license|@cc_on/
+    }
+  }
+}
+```
+
+Option du plugin Terser. Définir sur `false` pour désactiver ce plugin.
+
+`sourceMap` sera activée lorsque webpack `config.devtool` trouvera `source-?map`
+
+Voir [webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).
+
+## transpile
+
+- Type: `Array<String | RegExp | Function>`
+- Par défaut: `[]`
+
+Si vous souhaitez transpiler des dépendances spécifiques avec Babel, vous pouvez les ajouter dans `build.transpile`. 
+Chaque élément transpilé peut être un nom de package, une chaîne ou un objet regex correspondant au nom de fichier de 
+la dépendance.
+
+À partir de `v2.9.0`, vous pouvez également utiliser une fonction pour transpiler conditionnellement, la fonction 
+recevra un objet (`{ isDev, isServer, isClient, isModern, isLegacy }`):
+
+```js
+{
+  build: {
+    transpile: [
+      ({ isLegacy }) => isLegacy && 'ky'
+    ]
+  }
+}
+```
+
+## vueLoader
+
+> Remarque: Cette configuration a été supprimée depuis Nuxt 2.0, veuillez utiliser [`build.loaders.vue`](#loaders) à la place.
+
+- Type: `Object`
+- Par défaut:
+
+  ```js
+  {
+    productionMode: !this.options.dev,
+    transformAssetUrls: {
+      video: 'src',
+      source: 'src',
+      object: 'src',
+      embed: 'src'
+    }
+  }
+  ```
+
+> Spécifiez les [options de Vue Loader](https://vue-loader.vuejs.org/options.html).
+
+## watch
+
+> Vous pouvez fournir vos fichiers personnalisés à regarder et à régénérer après les modifications. Cette fonctionnalité 
+> est particulièrement utile pour une utilisation avec [modules](/guide/modules).
+
+- Type: `Array<String>`
+
+```js
+export default {
+  build: {
+    watch: [
+      '~/.nuxt/support.js'
+    ]
+  }
+}
+```
+
+## followSymlinks
+
+> Par défaut, le processus de génération n'analyse pas les fichiers à l'intérieur des liens symboliques. Ce booléen les 
+> inclut, permettant ainsi l'utilisation de liens symboliques dans des dossiers tels que le dossier "pages", par exemple.  
+
+- Type: `Boolean`
+
+```js
+export default {
+  build: {
+    followSymlinks: false
+  }
+}
+```

--- a/fr/api/configuration-hooks.md
+++ b/fr/api/configuration-hooks.md
@@ -1,0 +1,155 @@
+---
+title: "API: La propriété d'écouteurs"
+description: Les écouteurs écoutent les événements Nuxt qui sont généralement utilisés dans les modules Nuxt, mais sont également disponibles dans `nuxt.config.js`.
+---
+
+- Type: `Object`
+
+> Les écouteurs sont [des évènements d'écoutes de](/api/internals) qui sont généralement utilisés dans les modules Nuxt, mais sont également disponibles dans `nuxt.config.js`. [En savoir plus](/api/internals)
+
+Exemple (`nuxt.config.js`):
+
+```js
+import fs from 'fs'
+import path from 'path'
+
+export default {
+  hooks: {
+    build: {
+      done (builder) {
+        const extraFilePath = path.join(builder.nuxt.options.buildDir, 'extra-file')
+        fs.writeFileSync(extraFilePath, 'Something extra')
+      }
+    }
+  }
+}
+```
+
+En interne, les écouteurs respectent un modèle de nommage en utilisant à l'aide des deux points (cf, `build:done`). Pour 
+faciliter la configuration, vous pouvez les structurer comme un objet hiérarchique lorsque vous utilisez `nuxt.config.js` 
+(comme illustré ci-dessus) pour définir vos propres écouteurs. Voir [Nuxt en interne](/api/internals) pour des 
+informations plus détaillées sur leur fonctionnement. 
+
+## Listes des écouteurs
+
+- [Écouteurs Nuxt](https://nuxtjs.org/api/internals-nuxt#hooks)
+- [Écouteurs de rendu](https://nuxtjs.org/api/internals-renderer#hooks)
+- [Écouteurs de ModulesContainer](https://nuxtjs.org/api/internals-module-container#hooks)
+- [Écouteurs de constructeurs](https://nuxtjs.org/api/internals-builder#hooks)
+- [Écouteurs de génerateurs](https://nuxtjs.org/api/internals-generator#hooks)
+
+## Exemples
+
+### Rediriger vers router.base lorsqu'il n'est pas sur la racine
+
+Supposons que vous souhaitiez servir des pages en tant que `/portal` au lieu de `/`.
+
+Il s'agit peut-être d'un cas limite, et l'intérêt de _nuxt.config.js_ `router.base` est pour quand un serveur Web 
+servira Nuxt ailleurs que la racine du domaine.
+
+Mais en développement local, en tapant sur _localhost_, lorsque router.base n'est pas / retourne un 404.
+Pour éviter cela, vous pouvez configurer un écouteur.
+
+La redirection n'est peut-être pas le meilleur cas d'utilisation pour un site Web de production, mais cela vous aidera 
+à tirer parti des écouteurs.
+
+Pour commencer, vous [pouvez changer `router.base`](/api/configuration-router#base); Mettez à jour votre `nuxt.config.js`:
+
+```js
+// nuxt.config.js
+import hooks from './hooks'
+export default {
+  router: {
+    base: '/portal'
+  }
+  hooks: hooks(this)
+}
+```
+
+Ensuite, créez quelques fichiers;
+
+1. `hooks/index.js`, module d'écouteur
+
+   ```js
+   // file: hooks/index.js
+   import render from './render'
+
+   export default nuxtConfig => ({
+     render: render(nuxtConfig)
+   })
+   ```
+
+1. `hooks/render.js`, écouteur de rendu
+
+   ```js
+   // file: hooks/render.js
+   import redirectRootToPortal from './route-redirect-portal'
+
+   export default (nuxtConfig) => {
+     const router = Reflect.has(nuxtConfig, 'router') ? nuxtConfig.router : {}
+     const base = Reflect.has(router, 'base') ? router.base : '/portal'
+
+     return {
+       /**
+        * 'render:setupMiddleware'
+        * {@link node_modules/nuxt/lib/core/renderer.js}
+        */
+       setupMiddleware (app) {
+         app.use('/', redirectRootToPortal(base))
+       }
+     }
+   }
+   ```
+
+1. `hooks/route-redirect-portal.js`, le middleware lui-même
+
+   ```js
+   // file: hooks/route-redirect-portal.js
+
+   /**
+    * L'écouteur du middleware Nuxt pour rediriger de / ver /portal (ou tout ce que nous avons défini dans nuxt.config.js)
+    *
+    * Doit être la même version que connect
+    * {@link node_modules/connect/package.json}
+    */
+   import parseurl from 'parseurl'
+
+   /**
+    * Connectez le middleware pour gérer la redirection vers la racine de contexte d'application Web souhaitée.
+    *
+    * Notez que les documents Nuxt manquent d'expliquer comment utiliser les écouteurs.
+    * Ceci est un exemple de routeur pour aider à expliquer.
+    *
+    * Voir une belle mise en œuvre d'inspiration:
+    * - https://github.com/nuxt/nuxt.js/blob/dev/examples/with-cookies/plugins/cookies.js
+    * - https://github.com/yyx990803/launch-editor/blob/master/packages/launch-editor-middleware/index.js
+    *
+    * [http_class_http_clientrequest]: https://nodejs.org/api/http.html#http_class_http_clientrequest
+    * [http_class_http_serverresponse]: https://nodejs.org/api/http.html#http_class_http_serverresponse
+    *
+    * @param {http.ClientRequest} req Objet de requête client interne Node.js [http_class_http_clientrequest]
+    * @param {http.ServerResponse} res Réponse interne de Node.js [http_class_http_serverresponse]
+    * @param {Function} next middleware callback
+    */
+   export default desiredContextRoot =>
+     function projectHooksRouteRedirectPortal (req, res, next) {
+       const desiredContextRootRegExp = new RegExp(`^${desiredContextRoot}`)
+       const _parsedUrl = Reflect.has(req, '_parsedUrl') ? req._parsedUrl : null
+       const url = _parsedUrl !== null ? _parsedUrl : parseurl(req)
+       const startsWithDesired = desiredContextRootRegExp.test(url.pathname)
+       const isNotProperContextRoot = desiredContextRoot !== url.pathname
+       if (isNotProperContextRoot && startsWithDesired === false) {
+         const pathname = url.pathname === null ? '' : url.pathname
+         const search = url.search === null ? '' : url.search
+         const Location = desiredContextRoot + pathname + search
+         res.writeHead(302, {
+           Location
+         })
+         res.end()
+       }
+       next()
+     }
+   ```
+
+Ainsi, chaque fois qu'un collègue en développement frappe accidentellement `/` pour atteindre le service de 
+développement Web, Nuxt redirigera automatiquement vers `/portal`

--- a/fr/api/configuration-loading-indicator.md
+++ b/fr/api/configuration-loading-indicator.md
@@ -1,0 +1,47 @@
+---
+title: "API: Propriété de l'indicateur de chargement"
+description: Afficher un indicateur de fantaisie pendant le chargement de la page SPA!
+---
+
+> Afficher un indicateur de fantaisie pendant le chargement de la page SPA!
+
+Lors de l'exécution de Nuxt.js en mode SPA, il n'y a pas de contenu côté serveur lors du premier chargement de page. 
+Ainsi, au lieu d'afficher une page vierge pendant le chargement de la page, nous pouvons afficher un spinner.
+
+Cette propriété peut avoir 3 types différents: `string` ou `false` ou `object`. Si une valeur de chaîne est fournie, 
+elle est convertie en style d'objet.
+
+La valeur par défaut est:
+```js
+{
+  name: 'circle',
+  color: '#3B8070',
+  background: 'white'
+}
+```
+
+## Indicateurs intégrés
+
+Ces indicateurs sont portés à partir du projet génial de [Spinkit](http://tobiasahlin.com/spinkit). Vous pouvez utiliser 
+sa page de démonstration pour prévisualiser les loaders.
+
+- circle
+- cube-grid
+- fading-circle
+- folding-cube
+- chasing-dots
+- nuxt
+- pulse
+- rectangle-bounce
+- rotating-plane
+- three-bounce
+- wandering-cubes
+
+Les indicateurs intégrés supportent les options `color` et `background`.
+
+## Indicateurs personnalisés
+
+Si vous avez besoin de votre propre indicateur spécial, une valeur de chaîne ou un nom de clé peut également être un 
+chemin vers un modèle html de code source d'indicateur! Toutes les options sont également transmises au modèle.
+
+Le [code source](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) fonction intégrée de Nuxt est également disponible si vous avez besoin d'une base!

--- a/fr/api/configuration-mode.md
+++ b/fr/api/configuration-mode.md
@@ -1,0 +1,13 @@
+---
+title: "API: La propriété mode"
+description: Changer le mode nuxt par défaut
+---
+
+- Type: `string`
+  - Par défaut: `universal`
+  - Valeurs possibles:
+    - `'spa'`: Pas de rendu côté serveur (uniquement navigation côté client)
+    - `'universal'`: Application isomorphe (rendu côté serveur + navigation côté client)
+
+> Vous pouvez utiliser cette option pour changer le mode nuxt par défaut pour votre projet en utilisant `nuxt.config.js`
+

--- a/fr/api/configuration-modern.md
+++ b/fr/api/configuration-modern.md
@@ -1,0 +1,46 @@
+---
+title: "API: La propriété modern"
+description: Créez et servez un bundle moderne
+---
+
+> Cette fonctionnalité est inspirée du [mode monderne vue-cli](https://cli.vuejs.org/guide/browser-compatibility.html#modern-mode) 
+
+- Type: `String` or `Boolean`
+  - Par défaut: false
+  - Valeurs possibles:
+    - `'client'`: Servir les deux, le bundle moderne `<script type="module">` et les bundles hérités `<script nomodule>`, fournissent également un `<link rel="modulepreload">` pour le bundle moderne. Chaque navigateur qui comprend le type `module` chargera l'ensemble du bundle moderne tandis que les anciens navigateurs retomberont sur l'héritage (transpilé).
+    - `'server'` ou `true`: Le serveur Node.js vérifiera la version du navigateur en fonction de l'agent utilisateur et servira le bundle moderne ou hérité correspondant.
+    - `false`: Désactiver le bundle moderne
+
+Les deux versions de bundles sont:
+
+1. Bundle moderne: ciblant les navigateurs modernes prenant en charge les modules ES
+1. Bundle hérité: ciblant les anciens navigateurs basés sur la configuration babel (compatible IE9 par défaut).
+
+**Info:**
+
+- Utiliser l'option de commande `[--modern | -m]=[mode]` pour construire/démarrer des bundles modernes, par exemple: dans `package.json`:
+
+```json
+{
+  "scripts": {
+    "build:modern": "nuxt build --modern=server",
+    "start:modern": "nuxt start --modern=server"
+  }
+}
+```
+**Remarque sur *nuxt generate*:** La propriété `modern` fonctionne également avec la commande `nuxt generate`, mais dans 
+ce cas seule l'option `client` est honorée et sélectionnée automatiquement lors du lancement de la commande 
+`nuxt generate --modern` sans fournir de valeur.
+
+- Nuxt détectera automatiquement la version `modern` dans` nuxt start` lorsque `modern` n'est pas spécifiée, le mode auto-détecté est:
+
+| Mode          | Modern Mode   |
+| ------------- |:-------------:|
+| universal     | server        |
+| spa           | client        |
+
+- Le mode moderne pour `nuxt generate` peut seulement être `client`
+- Utilisez [`build.crossorigin`](/api/configuration-build#crossorigin) pour modifier l'attribut `crossorigin` dans `<link>` et `<script>`
+
+> Veuillez consulter [l'excellent article de Phillip Walton](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) pour plus de connaissances sur les constructions modernes.

--- a/fr/api/configuration-modules.md
+++ b/fr/api/configuration-modules.md
@@ -1,0 +1,61 @@
+---
+title: "API: La propriété modules"
+description: Les modules sont des extensions Nuxt.js qui peuvent étendre ses fonctionnalités de base et ajouter des intégrations sans fin.
+---
+
+- Type: `Array`
+
+> Les modules sont des extensions Nuxt.js qui peuvent étendre ses fonctionnalités de base et ajouter des intégrations sans fin. [En savoir plus](/guide/modules)
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  modules: [
+    // Utilisation du nom du package
+    '@nuxtjs/axios',
+
+    // Par rapport à votre projet srcDir
+    '~/modules/awesome.js',
+
+    // Offrir des options
+    ['@nuxtjs/google-analytics', { ua: 'X1234567' }],
+
+    // Définition en ligne
+    function () { }
+  ]
+}
+```
+Les développeurs de modules fournissent généralement les étapes et les détails supplémentaires nécessaires à l'utilisation.
+
+Nuxt.js essaie de résoudre chaque élément du tableau de modules en utilisant le chemin de nœud requis (dans le 
+`node_modules`), puis sera résolu à partir du projet `srcDir` si l'alias `~` est utilisé. Les modules sont exécutés 
+séquentiellement, donc l'ordre est important.
+
+Les modules doivent exporter une fonction pour améliorer la construction/exécution de Nuxt et éventuellement renvoyer 
+une promesse jusqu'à ce que leur travail soit terminé.
+Notez qu'ils sont requis au moment de l'exécution et doivent donc déjà être transpilés si cela dépend des fonctionnalités 
+ES6 modernes.
+
+Veuillez consulter le [Guide des modules](/guide/modules) pour plus d'informations sur leur fonctionnement ou si vous 
+êtes intéressé par le développement de votre propre module.
+Nous avons également fourni une section officielle [Modules](https://github.com/nuxt-community/awesome-nuxt#modules) 
+répertoriant des dizaines de modules prêts à la production fabriqués par la communauté Nuxt.
+
+## `buildModules`
+
+<div class="Alert Alert--info">
+
+Cette fonctionnalité est disponible depuis Nuxt v2.9
+
+</div>
+
+Certains modules ne sont nécessaires que pendant le développement et la construction. L'utilisation de `buildModules` 
+permet d'accélérer le démarrage de la production et également de réduire considérablement la taille de `node_modules` 
+pour les déploiements de production. Veuillez vous référer à la documentation de chaque module pour voir s'il est 
+recommandé d'utiliser `modules` ou `buildModules`.
+
+La différence d'utilisation est:
+
+- Au lieu d'ajouter à `modules` dans` nuxt.config.js`, utilisez `buildModules`
+- Au lieu d'ajouter à `dependencies` dans `package.json`, utilisez `devDependencies` (`yarn add --dev` ou `npm install --save-dev`)

--- a/fr/api/configuration-modulesdir.md
+++ b/fr/api/configuration-modulesdir.md
@@ -1,0 +1,21 @@
+---
+title: "API: La propriété modulesDir"
+description: Définissez le répertoire des modules pour votre application Nuxt.js
+---
+
+- Type: `Array`
+- Par défaut: `['node_modules']`
+
+> Utilisé pour définir les répertoires des modules pour la résolution de chemin, par exemple: Webpack `resolveLoading`, `nodeExternals` et `postcss`.Le chemin de configuration est relatif à [options.rootDir](/api/configuration-rootdir) (par défaut: `process.cwd()`).
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  modulesDir: ['../../node_modules']
+}
+```
+
+La définition de ce champ peut être nécessaire si votre projet est organisé comme un mono-référentiel de style espace de 
+travail Yarn.
+

--- a/fr/api/configuration-plugins.md
+++ b/fr/api/configuration-plugins.md
@@ -1,0 +1,69 @@
+---
+title: 'API: La propriété plugins'
+description: Utilisez les plugins vue.js avec l'option plugins de Nuxt.js.
+---
+
+**Remarque**: Depuis Nuxt.js 2.4, `mode` a été introduit comme option de `plugins` pour spécifier le type de plugin, 
+les valeurs possibles sont: `client` ou `server`. `ssr: false` sera adapté à `mode: 'client'` et déconseillé dans la
+prochaine version majeure. 
+
+- Type: `Array`
+  - Éléments: `String` ou `Object`
+
+Si l'élément est un objet, les propriétés sont:
+
+  - src: `String` (chemin du fichier)
+  - mode: `String` (peut être `client` ou `server`) *S'il est défini, le fichier sera inclus uniquement du côté respectif (client ou serveur).*
+
+**Remarque**: Ancienne version
+
+- Type: `Array`
+  - Éléments: `String` ou `Object`
+
+Si l'élément est un objet, les propriétés sont:
+
+  - src: `String` (chemin du fichier)
+  - ssr: `Boolean` (`true` par défaut) *Si faux, le fichier sera inclus uniquement du côté client.*
+
+> La propriété plugins vous permet d'ajouter facilement des plugins vue.js à votre application principale.
+
+Exemple (`nuxt.config.js`):
+
+```js
+export default {
+  plugins: [
+    { src: '~/plugins/both-sides.js' },
+    { src: '~/plugins/client-only.js', mode: 'client' },
+    { src: '~/plugins/server-only.js', mode: 'server' }
+  ]
+}
+```
+
+Exemple de framework UI (`nuxt.config.js`):
+
+```js
+export default {
+  plugins: ['@/plugins/ant-design-vue']
+}
+```
+
+Il s'agit d'un fichier dans `plugins/ant-design-vue.js`:
+
+```js
+import Vue from 'vue'
+import Antd from 'ant-design-vue'
+import 'ant-design-vue/dist/antd.css' // Docs Ant Design
+
+Vue.use(Antd)
+```
+
+Remarquez que le css a été [importé selon la documentation Ant Design](https://vue.ant.design/docs/vue/getting-started/#3.-Use-antd's-Components "Astuce externe pertinente pour la création de plugins")
+
+Tous les chemins définis dans la propriété `plugins` seront **importés** avant d'initialiser l'application principale.
+
+## Quand utiliser des plugins?
+
+Chaque fois que vous devez utiliser `Vue.use()`, vous devez créer un fichier dans `plugins/` et ajouter son chemin 
+vers `plugins` dans `nuxt.config.js`.
+
+Pour en savoir plus sur l'utilisation des plugins, consultez la [documentation du guide](/guide/plugins#vue-plugins).

--- a/fr/api/menu.json
+++ b/fr/api/menu.json
@@ -101,7 +101,7 @@
         ]
       },
       { "name": "head", "to": "/configuration-head" },
-      { "name": "hooks (EN)", "to": "/configuration-hooks" },
+      { "name": "hooks", "to": "/configuration-hooks" },
       { "name": "ignore", "to": "/configuration-ignore" },
       {
         "name": "loading", "to": "/configuration-loading",
@@ -112,12 +112,12 @@
           { "name": "Internals of the Progress Bar", "to": "#internals-of-the-progress-bar" }
         ]
       },
-      { "name": "loadingIndicator (EN)", "to": "/configuration-loading-indicator" },
-      { "name": "mode (EN)", "to": "/configuration-mode" },
-      { "name": "modern (EN)", "to": "/configuration-modern" },
-      { "name": "modules (EN)", "to": "/configuration-modules" },
-      { "name": "modulesDir (EN)", "to": "/configuration-modulesdir" },
-      { "name": "plugins (EN)", "to": "/configuration-plugins" },
+      { "name": "loadingIndicator", "to": "/configuration-loading-indicator" },
+      { "name": "mode", "to": "/configuration-mode" },
+      { "name": "modern", "to": "/configuration-modern" },
+      { "name": "modules", "to": "/configuration-modules" },
+      { "name": "modulesDir", "to": "/configuration-modulesdir" },
+      { "name": "plugins", "to": "/configuration-plugins" },
       {
         "name": "render (EN)", "to": "/configuration-render",
         "contents": [

--- a/fr/api/menu.json
+++ b/fr/api/menu.json
@@ -47,7 +47,7 @@
     "title": "Configuration",
     "links": [
       {
-        "name": "build (EN)", "to": "/configuration-build",
+        "name": "build", "to": "/configuration-build",
         "contents": [
           { "name": "analyze", "to": "#analyze" },
           { "name": "babel", "to": "#babel" },

--- a/fr/api/pages-fetch.md
+++ b/fr/api/pages-fetch.md
@@ -3,6 +3,230 @@ title: "API : la méthode fetch"
 description: La méthode `fetch` est utilisée pour remplir le store avant de rendre la page, elle est similaire à la méthode `asyncData` sauf qu'elle ne définit pas les données du composant.
 ---
 
+## Nuxt >= 2.12
+
+Nuxt.js `v2.12` introduit un nouvel écouteur appelé `fetch` **dans n'importe lequel de vos composants Vue**.
+
+Voir la [démo en direct](https://nuxt-new-fetch.surge.sh) et [le code d'exemple](https://github.com/nuxt/nuxt.js/tree/dev/examples/new-fetch).
+
+<div class="Alert Alert--orange">
+
+`fetch(context)` est obsolète, vous pouvez utiliser à la place un [middleware anonyme](/api/pages-middleware#anonymous-middleware) dans votre page: `middleware(context)`
+
+</div>
+
+### Quand utiliser fetch?
+
+Chaque fois que vous devez obtenir des données **asynchrones**. `fetch` est appelé côté serveur lors du rendu du chemin 
+et côté client lors de la navigation.
+
+Il expose `$fetchState` au niveau du composant:
+- `$fetchState.pending`: `Boolean`, vous permet d'afficher quelque chose lorsque `fetch` est appelé *côté client*.
+- `$fetchState.error`: `null` ou `Error`, vous permet d'afficher un message d'erreur.
+- `$fetchState.timestamp`: `Integer`, est un timestamp de la dernière extraction, utile pour la mise en cache avec `keep-alive`
+
+Si vous souhaitez appeler `fetch` à partir de vos méthodes de composant ou de votre mise en page, utilisez:
+
+```html
+<button @click="$fetch">Refresh</button>
+```
+
+Vous pouvez accéder au [contexte](/api/context) de Nuxt à travers l'écouteur de fetch en utilisant `this.$nuxt.context`.
+
+### Options
+
+- `fetchOnServer`: `Boolean` ou `Function` (par défaut: `true`), appeler `fetch()` lors du rendu du serveur sur la page
+- `fetchDelay`: `Integer` (par défaut: `200`), définir le temps d'exécution minimum en millisecondes (pour éviter les flashs rapides)
+
+<div class="Alert Alert--green">
+  
+Lorsque `fetchOnServer` est définie sur faux (`false` ou renvoie `false`), `fetch` sera appelée uniquement côté client 
+et `$fetchState.pending` renverra `true` lors du rendu du serveur par le composant.
+
+</div>
+
+```html
+<script>
+export default {
+  data () {
+    return {
+      posts: []
+    }
+  },
+  async fetch () {
+    this.posts = await this.$http.$get('https://jsonplaceholder.typicode.com/posts')
+  },
+  fetchOnServer: false
+}
+</script>
+```
+
+### Exemple
+
+<div class="Alert Alert--green">
+
+Nous allons utiliser le [module http](https://http.nuxtjs.org) officiel pour faire des requêtes HTTP.
+
+</div>
+
+Récupérons un blog avec notre page d'accueil répertoriant nos articles:
+
+`pages/index.vue`
+
+```html
+<template>
+  <div>
+    <h1>Blog posts</h1>
+    <p v-if="$fetchState.pending">Fetching posts...</p>
+    <p v-else-if="$fetchState.error">Error while fetching posts: {{ $fetchState.error.message }}</p>
+    <ul v-else>
+      <li v-for="post of posts" :key="post.id">
+        <n-link :to="`/posts/${post.id}`">{{ post.title }}</n-link>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      posts: []
+    }
+  },
+  async fetch () {
+    this.posts = await this.$http.$get('https://jsonplaceholder.typicode.com/posts')
+  }
+}
+</script>
+```
+
+Si vous allez directement sur [http://localhost:3000/](http://localhost:3000/), vous verrez directement la liste 
+complète des articles qui ont été **rendus par le serveur** (idéal pour le référencement) .
+
+<img width="669" alt="Screenshot 2019-03-11 at 23 04 57" src="https://user-images.githubusercontent.com/904724/54161334-1f9e8400-4452-11e9-97bf-996a6e69d9db.png">
+
+
+<div class="Alert Alert--green">
+  
+Nuxt détectera intelligemment les données que vous avez mutées dans `fetch` et optimisera le JSON inclus dans le code HTML renvoyé.
+
+</div>
+
+Maintenant, ajoutons la page `pages/posts/_id.vue` pour afficher une publication sur `/posts/:id`.
+
+`pages/posts/_id.vue`
+```html
+<template>
+  <div v-if="$fetchState.pending">Fetching post #{{$route.params.id}}...</div>
+  <div v-else>
+    <h1>{{ post.title }}</h1>
+    <pre>{{ post.body }}</pre>
+    <p><n-link to="/">Back to posts</n-link></p>
+  </div>
+</template>
+    
+<script>
+export default {
+  data () {
+    return {
+      post: {}
+    }
+  },
+  async fetch() {
+    this.post = await this.$http.$get(`https://jsonplaceholder.typicode.com/posts/${this.$route.params.id}`)
+  }
+}
+</script>
+```
+
+Lors de la navigation, vous devriez maintenant voir `"Fetching post #... "` côté client, et pas de chargement 
+lors de l'actualisation d'un article (actualisation depuis le navigateur).
+
+<img width="669" alt="fetch-nuxt3" src="https://user-images.githubusercontent.com/904724/54161844-d3544380-4453-11e9-9586-7428597db40e.gif">
+
+<div class="Alert Alert--green">
+  
+Si le composant contient l'écouteur `fetch`, vous aurez également accès à `this.$fetch()` pour rappeler l'écouteur 
+`fetch` (`$fetchState.pending` deviendra à nouveau` true`).
+
+</div>
+
+
+### Écoute des modifications de chaîne de requête
+
+L'écouteur `fetch` **n'est pas appelé** lors des changements de chaîne de requête par défaut. Pour surveiller les 
+changements de requête, vous pouvez ajouter un observateur sur `$route.query` et appeler `$fetch`:
+
+```js
+export default {
+  watch: {
+    '$route.query': '$fetch'
+  },
+  async fetch() {
+    // Appelé également lors des modifications de requête
+  }
+}
+```
+
+### Mise en cache
+
+Vous pouvez utiliser la directive `keep-alive` dans les composants `<nuxt />` et `<nuxt-child />` pour enregistrer les 
+appels `fetch` sur les pages que vous avez déjà visitées:
+
+`layouts/default.vue`
+```html
+<template>
+  <nuxt keep-alive />
+</template>
+```
+
+<div class="Alert Alert--green">
+  
+Vous pouvez également spécifier les [propriétés](https://vuejs.org/v2/api/#keep-alive) transmis à `<keep-alive>` en 
+passant une propriété `keep-alive-props` au composant `<nuxt>` component.<br>
+Exemple: `<nuxt keep-alive :keep-alive-props="{ max: 10 }" />` pour ne conserver que 10 composants de page en mémoire.
+
+</div>
+
+### Utilisation de l'écouteur `activated`
+
+Nuxt remplira directement `this.$fetchState.timestamp` (timestamp) du dernier appel `fetch` (ssr inclus). Vous pouvez 
+utiliser cette propriété combinée avec l'écouteur `activated` pour ajouter un cache de 30 secondes à `fetch`:
+
+`pages/posts/_id.vue`
+
+```html
+<template>
+  ...
+</template>
+    
+<script>
+export default {
+  data () {
+    return {
+      post: {}
+    }
+  },
+  activated() {
+    // Récupération de l'appel si la dernière récupération remonte à plus de 30 secondes
+    if (this.$fetchState.timestamp <= (Date.now() - 30000)) {
+      this.$fetch()
+    }
+  },
+  async fetch() {
+    this.post = await this.$http.$get(`https://jsonplaceholder.typicode.com/posts/${this.$route.params.id}`)
+  }
+}
+</script>
+```
+
+La navigation vers la même page n'appellera pas `fetch` si le dernier appel `fetch` remonte à plus de 30 secondes.
+
+![fetch-keep-alive-nuxt](https://user-images.githubusercontent.com/904724/54164405-c6881d80-445c-11e9-94e0-366406270874.gif)
+
+## Nuxt <= 2.11
+
 > La méthode fetch est utilisée pour remplir le store avant le rendu de la page, elle est similaire à la méthode `asyncData` sauf qu'elle ne définit pas les données du composant.
 
 - **Type:** `Function`

--- a/fr/guide/menu.json
+++ b/fr/guide/menu.json
@@ -82,7 +82,7 @@
         ]
       },
       {
-        "to": "/modules", "name": "Modules (EN)",
+        "to": "/modules", "name": "Modules",
         "contents": [
           { "to": "#introduction", "name": "Introduction" },
           { "to": "#list-of-nuxt-js-modules", "name": "List of Nuxt.js modules" },

--- a/fr/guide/modules.md
+++ b/fr/guide/modules.md
@@ -78,7 +78,8 @@ Ceci est une référence à l'instance courante de Nuxt. Se référer à
 
 **`this`**
 
-Contexte des modules. Veuillez consulter la documentation de la classe [ModuleContainer](/api/internals-module-container) pour les méthodes disponibles.
+Contexte des modules. Veuillez consulter la documentation de la classe 
+[contenu de module](/api/internals-module-container) pour les méthodes disponibles.
 
 **`module.exports.meta`**
 

--- a/fr/guide/modules.md
+++ b/fr/guide/modules.md
@@ -78,8 +78,7 @@ Ceci est une référence à l'instance courante de Nuxt. Se référer à
 
 **`this`**
 
-Contexte des modules. Veuillez consulter la documentation de la classe 
-[ModuleContainer](/api/internals-module-container) pour les méthodes disponibles.
+Contexte des modules. Veuillez consulter la documentation de la classe [ModuleContainer](/api/internals-module-container) pour les méthodes disponibles.
 
 **`module.exports.meta`**
 

--- a/fr/guide/modules.md
+++ b/fr/guide/modules.md
@@ -79,7 +79,7 @@ Ceci est une référence à l'instance courante de Nuxt. Se référer à
 **`this`**
 
 Contexte des modules. Veuillez consulter la documentation de la classe 
-[contenu de module](/api/internals-module-container) pour les méthodes disponibles.
+[ModuleContainer](/api/internals-module-container) pour les méthodes disponibles.
 
 **`module.exports.meta`**
 


### PR DESCRIPTION
Translated pages: 

- fr/api/configuration-build.md 
- fr/api/configuration-hooks.md 
- fr/api/configuration-loading-indicator.md
- fr/api/configuration-mode.md 
- fr/api/configuration-modern.md 
- fr/api/configuration-modules.md
- fr/api/configuration-modulesdir.md 
- fr/api/configuration-plugins.md 
- fr/api/pages-fetch.md 

+ updated menu : 
- fr/api/menu.json
- fr/guide/menu.json