### PR TITLE
ja: fix unbalanced quotations

### DIFF
--- a/ja/api/configuration-router.md
+++ b/ja/api/configuration-router.md
@@ -285,7 +285,7 @@ export default {
 }
 ```
 
-Nuxt.js v2.10.0 からは prefetchLinks` を `false` に設定した上で特定のリンクを先読みしたい場合 `prefetch` プロパティを使うことができます。
+Nuxt.js v2.10.0 からは `prefetchLinks` を `false` に設定した上で特定のリンクを先読みしたい場合 `prefetch` プロパティを使うことができます。
 
 ```html
 <nuxt-link to="/about" prefetch>先読みするページについて</nuxt-link>


### PR DESCRIPTION
@inouetakuya @aytdm
I fixed an unbalanced quotation in `api/configuration-router.md`.

![image](https://user-images.githubusercontent.com/28696621/81551518-f44c5780-93bc-11ea-8adc-8b4152f86840.png)
