### PR TITLE
en: reduce confusion around asyncData

### DIFF
--- a/en/guide/directory-structure.md
+++ b/en/guide/directory-structure.md
@@ -27,7 +27,7 @@ The `components` directory contains your Vue.js Components.
 
 <div class="Alert Alert--orange">
   
-Components located in this directory will not have access to [`asyncData`](/guide/async-data].
+Components in this directory will not have access to [`asyncData`](/guide/async-data].
 
 </div>
 

--- a/en/guide/directory-structure.md
+++ b/en/guide/directory-structure.md
@@ -23,7 +23,13 @@ The `assets` directory contains your un-compiled assets such as Stylus or Sass f
 
 ### The Components Directory
 
-The `components` directory contains your Vue.js Components. You can't use `asyncData` in these components.
+The `components` directory contains your Vue.js Components. 
+
+<div class="Alert Alert--orange">
+  
+Components located in this directory will not have access to [`asyncData`](/guide/async-data].
+
+</div>
 
 ### The Layouts Directory
 


### PR DESCRIPTION
New users who are not familiar with Nuxt's architecture need an easy jump off point in case they're wondering what this restriction is. The current verbiage:

> The components directory contains your Vue.js Components. You can't use asyncData in these components.

assumes knowledge of what asyncData is when it shows up later in the guide. In addition, this warning does give the user a reason to pause and doubt themselves as to whether they need to learn about asyncData before continuing with the guide. And this is a fairly dangerous rabbit hole if this knowledge is not essential to getting started.

Since this limitation was included in the original docs, I'm assuming that this was a common confusion point for users; therefore the better compromise might be to wrap it in the warning box as a way to say, "Hey! Something to keep in mind, but you can keep on reading." while also including a link directly to the asyncData section of the guide for those who are curious to learn more.

Happy to discuss further if you'd like!