### PR TITLE
fix: Function needs to be injected in context.app

### DIFF
--- a/en/guide/plugins.md
+++ b/en/guide/plugins.md
@@ -158,7 +158,10 @@ Injecting content into Vue instances works similar to when doing this in standar
 
 ```js
 export default ({ app }, inject) => {
-  inject('myInjectedFunction', string => console.log('That was easy!', string))
+  const myInjectedFunction = string => console.log('This was easey', string)
+  
+  app.myInjectedFunction = myInjectedFunction
+  inject('myInjectedFunction', myInjectedFunction)
 }
 ```
 


### PR DESCRIPTION
To access the injected function in the context, it needs to be explicitly injected into it.
`app.injectedFunction = injectedFunction`
Without doing this, I realized it did not exist in the `context.app` object