### PR TITLE
docs(en): clarify universal mode definition

### DIFF
--- a/en/api/configuration-mode.md
+++ b/en/api/configuration-mode.md
@@ -7,7 +7,7 @@ description: Change default nuxt mode
   - Default: `universal`
   - Possible values:
     - `'spa'`: No server-side rendering (only client-side navigation)
-    - `'universal'`: Isomorphic application (server-side rendering + client-side navigation)
+    - `'universal'`: Isomorphic application (server-side rendering + client-side navigation) or Statically Generated (server-side served + client-side navigation)
 
 > You can use this option to change default nuxt mode for your project using `nuxt.config.js`
 


### PR DESCRIPTION
PR is a result of this "bug" https://github.com/nuxt/nuxt.js/issues/7444 caused by unclear description of how Nuxt modes behaves.

On Nuxt homepage we list 3 types of renderings:
- ***SERVER SIDE RENDERED*** - _"The most popular mode for Nuxt. With SSR, also called "universal" or "isomorphic" mode, a Node.js server will be used to deliver HTML based on your Vue components to the client instead of the pure javascript."_
- ***STATICALLY GENERATED*** - no mention it's SSR
- ***SINGLE PAGE APPLICATION (SPA)*** - _"Don't need SSR or Static Site Generation but still want to profit from the benefits that Nuxt provides..."_


So, on homepage we define SSR as server rendered with Node.js and separate it from static generation.

Using statically generated site requires setting mode to "universal" which is explained to be "Isomorphic application (server-side rendering)". Where with statically generated site, the application will not be Isomorphic (no same code running on backend) nor SSR (according to the homepage).

Actual modes are like:
- SPA = SPA
- Universal = SSR + SPA or ***Statically Generated*** (Server-side served + SPA)

This might help avoid confusion about unfortunate SSR term that relates to Node.js backend, but from the browser it might relate to any data served by a backend server.