### PR TITLE
en(directory-structure): fix link to `asyncData`

### DIFF
--- a/en/guide/directory-structure.md
+++ b/en/guide/directory-structure.md
@@ -27,7 +27,7 @@ The `components` directory contains your Vue.js Components.
 
 <div class="Alert Alert--orange">
   
-Components in this directory will not have access to [`asyncData`](/guide/async-data].
+Components in this directory will not have access to [`asyncData`](/guide/async-data).
 
 </div>
 


### PR DESCRIPTION
I think this should link to the `asyncData` page but is wrong and was closed with a `]` instead of a `)` accidentally.