### PR TITLE
Fixed a typo in Crawler Key

### DIFF
--- a/en/api/configuration-generate.md
+++ b/en/api/configuration-generate.md
@@ -29,7 +29,7 @@ The generation of routes are concurrent, `generate.concurrency` specifies the am
  - Type: `boolean`
  - Default: true
 
-As of Nuxt <= v2.13 Nuxt.js comes with a crawler installed that will crawl your relative links and generate your dynamic links based on these links. If you want to disable this feature you can set the value to `false`
+As of Nuxt >= v2.13 Nuxt.js comes with a crawler installed that will crawl your relative links and generate your dynamic links based on these links. If you want to disable this feature you can set the value to `false`
 
 ```js
 export default {


### PR DESCRIPTION
Changed less-than-equals ( <= ) sign with greater-than-equals sign ( >= )
Crawler is available by default from Nuxt v2.13 and greater.