### PR TITLE
en: update moduleOptions description in modules.md

### DIFF
--- a/en/guide/modules.md
+++ b/en/guide/modules.md
@@ -61,7 +61,7 @@ export default function SimpleModule (moduleOptions) {
 
 **`moduleOptions`**
 
-This is the object passed using `modules` array by user we can use it to customize it's behavior.
+This is an object passed as the second item within your module's containing array inside `nuxt.config.js`'s `modules` property. It's used as a method to customize your module's behavior directly from `nuxt.config.js`.
 
 **`this.options`**
 


### PR DESCRIPTION
There seems to be some grammatical issues with the current description (I got confused the first time reading it and didn't understand what the argument was until I tested things out myself in Nuxt). I updated the description to describe exactly what the argument does and where it's located (nuxt.config.js).