### PR TITLE
fix order of command line generate script

### DIFF
--- a/en/faq/github-pages.md
+++ b/en/faq/github-pages.md
@@ -91,7 +91,7 @@ For Nuxt >= v2.13
   "dev": "nuxt",
   "build": "nuxt build",
   "start": "nuxt start",
-  "generate": "nuxt export && nuxt build",
+  "generate": "nuxt build && nuxt export",
   "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"
 },
 ```


### PR DESCRIPTION
first `build` then `export` throws `Nuxt Fatal Error`:

Error: In order to use `nuxt export`, you need to run `nuxt build --target static`