### PR TITLE
fixed typo in pages-middleware.md

### DIFF
--- a/en/api/pages-middleware.md
+++ b/en/api/pages-middleware.md
@@ -60,4 +60,4 @@ export default {
 </script>
 ```
 
-To learn more about the middleware, see the [middleware guide](/guide/routing#middleware).
+To learn more about the middleware, see the [middleware guide](/guide/routing/#middleware).


### PR DESCRIPTION
The previous link gave a 500 error. The new link is correct and tested.