### PR TITLE
Bug fix in code for vuex-store.md

### DIFF
--- a/en/guide/vuex-store.md
+++ b/en/guide/vuex-store.md
@@ -59,7 +59,7 @@ export const mutations = {
       done: false
     })
   },
-  remove (state, { todo }) {
+  remove (state, todo) {
     state.list.splice(state.list.indexOf(todo), 1)
   },
   toggle (state, todo) {


### PR DESCRIPTION
`todo` is null and consequently the last todo is removed instead of the specified todo.