### PR TITLE
docs(en,ja): add explanation for 'nuxt generate --fail-on-error=[number]'

### DIFF
--- a/en/guide/commands.md
+++ b/en/guide/commands.md
@@ -161,6 +161,16 @@ npm run generate --fail-on-error
 yarn generate --fail-on-error
 ```
 
+When called `--fail-on-error` with a number the command returns a non-zero status after the number of error occurred.
+
+```bash
+npm run generate --fail-on-error=10
+
+// OR
+
+yarn generate --fail-on-error=10
+```
+
 <div class="Alert Alert-blue">
 
 As of Nuxt v2.13 there is a crawler installed that will now crawl your link tags and generate your routes when using the command `nuxt build && nuxt export` based on those links. 

--- a/en/guide/commands.md
+++ b/en/guide/commands.md
@@ -161,14 +161,14 @@ npm run generate --fail-on-error
 yarn generate --fail-on-error
 ```
 
-When called `--fail-on-error` with a number the command returns a non-zero status after the number of error occurred.
+When called `--max-errors` with a number the command returns after the number of error occurred.
 
 ```bash
-npm run generate --fail-on-error=10
+npm run generate --max-errors=10
 
 // OR
 
-yarn generate --fail-on-error=10
+yarn generate --max-errors=10
 ```
 
 <div class="Alert Alert-blue">

--- a/ja/guide/commands.md
+++ b/ja/guide/commands.md
@@ -116,14 +116,14 @@ npm run generate --fail-on-error
 yarn generate --fail-on-error
 ```
 
-数値とともに `--fail-on-error` が呼ばれると、指定した数のエラーが発生した後、0以外のステータスコードを返して終了します。
+`--max-errors` を指定すると、エラーの発生件数により途中で終了させることができます。
 
 ```bash
-npm run generate --fail-on-error=10
+npm run generate --max-error=10
 
-// OR
+// または
 
-yarn generate --fail-on-error=10
+yarn generate --max-error=10
 ```
 
 プロジェクトで [動的なルーティング](/guide/routing#dynamic-routes) を使っている場合は、Nuxt.js に動的なルーティングを生成させるために [generate 設定](/api/configuration-generate) に目を通してください。

--- a/ja/guide/commands.md
+++ b/ja/guide/commands.md
@@ -116,6 +116,15 @@ npm run generate --fail-on-error
 yarn generate --fail-on-error
 ```
 
+数値とともに `--fail-on-error` が呼ばれると、指定した数のエラーが発生した後、0以外のステータスコードを返して終了します。
+
+```bash
+npm run generate --fail-on-error=10
+
+// OR
+
+yarn generate --fail-on-error=10
+```
 
 プロジェクトで [動的なルーティング](/guide/routing#dynamic-routes) を使っている場合は、Nuxt.js に動的なルーティングを生成させるために [generate 設定](/api/configuration-generate) に目を通してください。
 


### PR DESCRIPTION
add explanation for 'nuxt generate --fail-on-error=[number]' 

languages: en, ja

(now I prepare for PR in nuxt/nuxtjs )

updated: 
https://github.com/nuxt/nuxt.js/pull/9956