### PR TITLE
Remove polyfill.io from the docs

### DIFF
--- a/en/api/configuration-router.md
+++ b/en/api/configuration-router.md
@@ -251,7 +251,7 @@ Provide custom query string parse / stringify functions. Overrides the default.
 Configure `<nuxt-link>` to prefetch the *code-splitted* page when detected within the viewport.
 Requires [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to be supported (see [CanIUse](https://caniuse.com/#feat=intersectionobserver)).
 
-We recommend conditionally polyfilling this feature with a service like [Polyfill.io](https://polyfill.io):
+We recommend conditionally polyfilling this feature with a service like [Polyfill](https://cdnjs.cloudflare.com/polyfill/):
 
 `nuxt.config.js`
 
@@ -259,7 +259,7 @@ We recommend conditionally polyfilling this feature with a service like [Polyfil
 export default {
   head: {
     script: [
-      { src: 'https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver', body: true }
+      { src: 'https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=IntersectionObserver', body: true }
     ]
   }
 }

--- a/fr/api/configuration-router.md
+++ b/fr/api/configuration-router.md
@@ -261,7 +261,7 @@ Configurez `<nuxt-link>` pour pré-charger la page *divisée par code* lorsqu'el
 Nécessite [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) pour être 
 pris en charge (voir [CanIUse](https://caniuse.com/#feat=intersectionobserver)) .
 
-Nous vous recommandons de polyfiller conditionnellement cette fonctionnalité avec un service comme [Polyfill.io](https://polyfill.io):
+Nous vous recommandons de polyfiller conditionnellement cette fonctionnalité avec un service comme [Polyfill](https://cdnjs.cloudflare.com/polyfill):
 
 `nuxt.config.js`
 
@@ -269,7 +269,7 @@ Nous vous recommandons de polyfiller conditionnellement cette fonctionnalité av
 export default {
   head: {
     script: [
-      { src: 'https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver', body: true }
+      { src: 'https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=IntersectionObserver', body: true }
     ]
   }
 }

--- a/ja/api/configuration-router.md
+++ b/ja/api/configuration-router.md
@@ -253,7 +253,7 @@ export default {
 viewport（ブラウザの表示領域）内にリンクが表示されたとき *コード分割された* ページを先読みする `<nuxt-link>` の設定をします。
 [IntersectionObserver](https://developer.mozilla.org/ja/docs/Web/API/Intersection_Observer_API) がサポートされている必要があります ([CanIUse](https://caniuse.com/#feat=intersectionobserver)を御覧ください）。
 
-この機能を [Polyfill.io](https://polyfill.io) のようなサービスで条件付きで埋め込むことをお勧めします:
+この機能を [Polyfill](https://cdnjs.cloudflare.com/polyfill) のようなサービスで条件付きで埋め込むことをお勧めします:
 
 `nuxt.config.js`
 
@@ -261,7 +261,7 @@ viewport（ブラウザの表示領域）内にリンクが表示されたとき
 export default {
   head: {
     script: [
-      { src: 'https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver', body: true }
+      { src: 'https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=IntersectionObserver', body: true }
     ]
   }
 }

--- a/zh/api/configuration-router.md
+++ b/zh/api/configuration-router.md
@@ -260,7 +260,7 @@ module.exports = {
 
 在视图中检测到时，配置`<nuxt-link>`用来预获取*代码分割*页面。需要支持[IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)(参阅 [CanIUse](https://caniuse.com/#feat=intersectionobserver))。
 
-我们建议使用[Polyfill.io](https://polyfill.io)等服务有条件地填充此功能：
+我们建议使用[Polyfill](https://cdnjs.cloudflare.com/polyfill)等服务有条件地填充此功能：
 
 `nuxt.config.js`
 
@@ -268,7 +268,7 @@ module.exports = {
 export default {
   head: {
     script: [
-      { src: 'https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver', body: true }
+      { src: 'https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=IntersectionObserver', body: true }
     ]
   }
 }


### PR DESCRIPTION
As announced everywhere, [Cloudflare](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet), [Fastly](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540), [GitHub](https://github.com/polyfillpolyfill/polyfill-service) and several sources. Polyfill(.)io is a malicious CDN that needs to be avoided. Instead there are alternative options like Cloudflare and Fastly which provide the same features as the previous CDN.

This PR replaces all polyfill(.)io links to cloudflare's CDN.